### PR TITLE
feat: add global contract and NEP-616 deterministic account actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ thiserror = "2"
 tracing = "0.1"
 
 # Optional: Sandbox integration
-near-sandbox = { path = "../near-sandbox-rs", features = ["global_install"], optional = true }
+near-sandbox = { path = "/home/ricky/near-sandbox-rs", features = ["global_install"], optional = true }
 
 [features]
 default = []
@@ -49,7 +49,7 @@ sandbox = ["near-sandbox"]
 
 [dev-dependencies]
 tokio-test = "0.4"
-near-sandbox = { path = "../near-sandbox-rs", features = ["global_install"] }
+near-sandbox = { path = "/home/ricky/near-sandbox-rs", features = ["global_install"] }
 tempfile = "3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 

--- a/src/client/transaction.rs
+++ b/src/client/transaction.rs
@@ -34,7 +34,7 @@ use std::sync::{Arc, OnceLock};
 
 use crate::error::{Error, RpcError};
 use crate::types::{
-    AccountId, Action, BlockReference, FinalExecutionOutcome, Finality, Gas, IntoGas,
+    AccountId, Action, BlockReference, CryptoHash, FinalExecutionOutcome, Finality, Gas, IntoGas,
     IntoNearToken, NearToken, PublicKey, Transaction, TxExecutionStatus,
 };
 
@@ -235,6 +235,155 @@ impl TransactionBuilder {
     }
 
     // ========================================================================
+    // Global Contract Actions
+    // ========================================================================
+
+    /// Publish a contract to the global registry.
+    ///
+    /// Global contracts are deployed once and can be referenced by multiple accounts,
+    /// saving storage costs. Two modes are available:
+    ///
+    /// - `by_hash = false` (default): Contract is identified by the signer's account ID.
+    ///   The signer can update the contract later, and all users will automatically
+    ///   use the updated version.
+    ///
+    /// - `by_hash = true`: Contract is identified by its code hash. This creates
+    ///   an immutable contract that cannot be updated.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::prelude::*;
+    /// # async fn example(near: Near) -> Result<(), near_kit::Error> {
+    /// let wasm_code = std::fs::read("contract.wasm")?;
+    ///
+    /// // Publish updatable contract (identified by your account)
+    /// near.transaction("alice.testnet")
+    ///     .publish_contract(wasm_code.clone(), false)
+    ///     .send()
+    ///     .await?;
+    ///
+    /// // Publish immutable contract (identified by its hash)
+    /// near.transaction("alice.testnet")
+    ///     .publish_contract(wasm_code, true)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn publish_contract(mut self, code: impl Into<Vec<u8>>, by_hash: bool) -> Self {
+        self.actions
+            .push(Action::publish_contract(code.into(), by_hash));
+        self
+    }
+
+    /// Deploy a contract from the global registry by code hash.
+    ///
+    /// References a previously published immutable contract.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::prelude::*;
+    /// # async fn example(near: Near, code_hash: CryptoHash) -> Result<(), near_kit::Error> {
+    /// near.transaction("alice.testnet")
+    ///     .deploy_from_hash(code_hash)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn deploy_from_hash(mut self, code_hash: CryptoHash) -> Self {
+        self.actions.push(Action::deploy_from_hash(code_hash));
+        self
+    }
+
+    /// Deploy a contract from the global registry by publisher account.
+    ///
+    /// References a contract published by the given account.
+    /// The contract can be updated by the publisher.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::prelude::*;
+    /// # async fn example(near: Near) -> Result<(), near_kit::Error> {
+    /// near.transaction("alice.testnet")
+    ///     .deploy_from_publisher("contract-publisher.near")
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn deploy_from_publisher(mut self, publisher_id: impl AsRef<str>) -> Self {
+        let publisher_id: AccountId = publisher_id
+            .as_ref()
+            .parse()
+            .unwrap_or_else(|_| AccountId::new_unchecked(publisher_id.as_ref()));
+        self.actions.push(Action::deploy_from_account(publisher_id));
+        self
+    }
+
+    /// Create a NEP-616 deterministic state init action with code hash reference.
+    ///
+    /// The account ID is derived from the state init data:
+    /// `"0s" + hex(keccak256(borsh(state_init))[12..32])`
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::prelude::*;
+    /// # async fn example(near: Near, code_hash: CryptoHash) -> Result<(), near_kit::Error> {
+    /// near.transaction("alice.testnet")
+    ///     .state_init_by_hash(code_hash, vec![], "1 NEAR")
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn state_init_by_hash(
+        mut self,
+        code_hash: CryptoHash,
+        data: Vec<(Vec<u8>, Vec<u8>)>,
+        deposit: impl IntoNearToken,
+    ) -> Self {
+        let deposit = deposit.into_near_token().unwrap_or(NearToken::ZERO);
+        self.actions
+            .push(Action::state_init_by_hash(code_hash, data, deposit));
+        self
+    }
+
+    /// Create a NEP-616 deterministic state init action with publisher account reference.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::prelude::*;
+    /// # async fn example(near: Near) -> Result<(), near_kit::Error> {
+    /// near.transaction("alice.testnet")
+    ///     .state_init_by_publisher("contract-publisher.near", vec![], "1 NEAR")
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn state_init_by_publisher(
+        mut self,
+        publisher_id: impl AsRef<str>,
+        data: Vec<(Vec<u8>, Vec<u8>)>,
+        deposit: impl IntoNearToken,
+    ) -> Self {
+        let publisher_id: AccountId = publisher_id
+            .as_ref()
+            .parse()
+            .unwrap_or_else(|_| AccountId::new_unchecked(publisher_id.as_ref()));
+        let deposit = deposit.into_near_token().unwrap_or(NearToken::ZERO);
+        self.actions
+            .push(Action::state_init_by_account(publisher_id, data, deposit));
+        self
+    }
+
+    // ========================================================================
     // Configuration methods
     // ========================================================================
 
@@ -394,6 +543,42 @@ impl CallBuilder {
     /// Add a stake action.
     pub fn stake(self, amount: impl IntoNearToken, public_key: PublicKey) -> TransactionBuilder {
         self.finish().stake(amount, public_key)
+    }
+
+    /// Publish a contract to the global registry.
+    pub fn publish_contract(self, code: impl Into<Vec<u8>>, by_hash: bool) -> TransactionBuilder {
+        self.finish().publish_contract(code, by_hash)
+    }
+
+    /// Deploy a contract from the global registry by code hash.
+    pub fn deploy_from_hash(self, code_hash: CryptoHash) -> TransactionBuilder {
+        self.finish().deploy_from_hash(code_hash)
+    }
+
+    /// Deploy a contract from the global registry by publisher account.
+    pub fn deploy_from_publisher(self, publisher_id: impl AsRef<str>) -> TransactionBuilder {
+        self.finish().deploy_from_publisher(publisher_id)
+    }
+
+    /// Create a NEP-616 deterministic state init action with code hash reference.
+    pub fn state_init_by_hash(
+        self,
+        code_hash: CryptoHash,
+        data: Vec<(Vec<u8>, Vec<u8>)>,
+        deposit: impl IntoNearToken,
+    ) -> TransactionBuilder {
+        self.finish().state_init_by_hash(code_hash, data, deposit)
+    }
+
+    /// Create a NEP-616 deterministic state init action with publisher account reference.
+    pub fn state_init_by_publisher(
+        self,
+        publisher_id: impl AsRef<str>,
+        data: Vec<(Vec<u8>, Vec<u8>)>,
+        deposit: impl IntoNearToken,
+    ) -> TransactionBuilder {
+        self.finish()
+            .state_init_by_publisher(publisher_id, data, deposit)
     }
 
     /// Override the signer.

--- a/src/client/transaction.rs
+++ b/src/client/transaction.rs
@@ -28,6 +28,7 @@
 //! # }
 //! ```
 
+use std::collections::BTreeMap;
 use std::future::{Future, IntoFuture};
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
@@ -541,7 +542,7 @@ impl TransactionBuilder {
     /// # use near_kit::prelude::*;
     /// # async fn example(near: Near, code_hash: CryptoHash) -> Result<(), near_kit::Error> {
     /// near.transaction("alice.testnet")
-    ///     .state_init_by_hash(code_hash, vec![], "1 NEAR")
+    ///     .state_init_by_hash(code_hash, Default::default(), "1 NEAR")
     ///     .send()
     ///     .await?;
     /// # Ok(())
@@ -550,7 +551,7 @@ impl TransactionBuilder {
     pub fn state_init_by_hash(
         mut self,
         code_hash: CryptoHash,
-        data: Vec<(Vec<u8>, Vec<u8>)>,
+        data: BTreeMap<Vec<u8>, Vec<u8>>,
         deposit: impl IntoNearToken,
     ) -> Self {
         let deposit = deposit.into_near_token().unwrap_or(NearToken::ZERO);
@@ -567,7 +568,7 @@ impl TransactionBuilder {
     /// # use near_kit::prelude::*;
     /// # async fn example(near: Near) -> Result<(), near_kit::Error> {
     /// near.transaction("alice.testnet")
-    ///     .state_init_by_publisher("contract-publisher.near", vec![], "1 NEAR")
+    ///     .state_init_by_publisher("contract-publisher.near", Default::default(), "1 NEAR")
     ///     .send()
     ///     .await?;
     /// # Ok(())
@@ -576,7 +577,7 @@ impl TransactionBuilder {
     pub fn state_init_by_publisher(
         mut self,
         publisher_id: impl AsRef<str>,
-        data: Vec<(Vec<u8>, Vec<u8>)>,
+        data: BTreeMap<Vec<u8>, Vec<u8>>,
         deposit: impl IntoNearToken,
     ) -> Self {
         let publisher_id: AccountId = publisher_id
@@ -770,7 +771,7 @@ impl CallBuilder {
     pub fn state_init_by_hash(
         self,
         code_hash: CryptoHash,
-        data: Vec<(Vec<u8>, Vec<u8>)>,
+        data: BTreeMap<Vec<u8>, Vec<u8>>,
         deposit: impl IntoNearToken,
     ) -> TransactionBuilder {
         self.finish().state_init_by_hash(code_hash, data, deposit)
@@ -780,7 +781,7 @@ impl CallBuilder {
     pub fn state_init_by_publisher(
         self,
         publisher_id: impl AsRef<str>,
-        data: Vec<(Vec<u8>, Vec<u8>)>,
+        data: BTreeMap<Vec<u8>, Vec<u8>>,
         deposit: impl IntoNearToken,
     ) -> TransactionBuilder {
         self.finish()

--- a/src/types/action.rs
+++ b/src/types/action.rs
@@ -1,5 +1,7 @@
 //! Transaction action types.
 
+use std::collections::BTreeMap;
+
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
@@ -260,7 +262,7 @@ pub struct DeterministicAccountStateInitV1 {
     pub code: GlobalContractIdentifier,
     /// Initial key-value pairs to populate in the contract's storage.
     /// Keys and values are Borsh-serialized bytes.
-    pub data: Vec<(Vec<u8>, Vec<u8>)>,
+    pub data: BTreeMap<Vec<u8>, Vec<u8>>,
 }
 
 /// Deploy a contract with a deterministically derived account ID (NEP-616).
@@ -478,7 +480,7 @@ impl Action {
     /// Create a NEP-616 deterministic state init action with code hash reference.
     pub fn state_init_by_hash(
         code_hash: CryptoHash,
-        data: Vec<(Vec<u8>, Vec<u8>)>,
+        data: BTreeMap<Vec<u8>, Vec<u8>>,
         deposit: NearToken,
     ) -> Self {
         Self::DeterministicStateInit(DeterministicStateInitAction {
@@ -493,7 +495,7 @@ impl Action {
     /// Create a NEP-616 deterministic state init action with account reference.
     pub fn state_init_by_account(
         account_id: AccountId,
-        data: Vec<(Vec<u8>, Vec<u8>)>,
+        data: BTreeMap<Vec<u8>, Vec<u8>>,
         deposit: NearToken,
     ) -> Self {
         Self::DeterministicStateInit(DeterministicStateInitAction {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -15,8 +15,10 @@ mod units;
 pub use account::AccountId;
 pub use action::{
     AccessKey, AccessKeyPermission, Action, AddKeyAction, CreateAccountAction, DelegateAction,
-    DeleteAccountAction, DeleteKeyAction, DeployContractAction, FunctionCallAction,
-    FunctionCallPermission, NonDelegateAction, SignedDelegateAction, StakeAction, TransferAction,
+    DeleteAccountAction, DeleteKeyAction, DeployContractAction, DeployGlobalContractAction,
+    DeterministicAccountStateInit, DeterministicAccountStateInitV1, DeterministicStateInitAction,
+    FunctionCallAction, FunctionCallPermission, GlobalContractDeployMode, GlobalContractIdentifier,
+    NonDelegateAction, SignedDelegateAction, StakeAction, TransferAction, UseGlobalContractAction,
 };
 pub use block_reference::{BlockReference, Finality, TxExecutionStatus};
 pub use hash::CryptoHash;


### PR DESCRIPTION
## Summary

- Add support for 3 new NEAR Protocol action types (discriminants 9-11)
- Implement TransactionBuilder and CallBuilder methods for ergonomic API
- Matches TypeScript library patterns from `near-kit`

## New Action Types

| Action | Discriminant | Description |
|--------|-------------|-------------|
| `DeployGlobalContract` | 9 | Publish contract to global registry |
| `UseGlobalContract` | 10 | Deploy from global registry (by hash or account) |
| `DeterministicStateInit` | 11 | NEP-616 deterministic account creation |

## New API Methods

```rust
// Publish to global registry
near.transaction("alice.near")
    .publish_contract(wasm_code, false)  // by_hash = false for updatable
    .send().await?;

// Deploy from registry
near.transaction("bob.near")
    .deploy_from_hash(code_hash)
    .send().await?;

near.transaction("bob.near")
    .deploy_from_publisher("alice.near")
    .send().await?;

// NEP-616 deterministic accounts
near.transaction("alice.near")
    .state_init_by_hash(code_hash, vec![], "1 NEAR")
    .send().await?;
```

## Supporting Types Added

- `GlobalContractIdentifier` - `CodeHash(CryptoHash)` or `AccountId(AccountId)`
- `GlobalContractDeployMode` - `CodeHash` or `AccountId`
- `DeterministicAccountStateInit` / `DeterministicAccountStateInitV1`

## Testing

- All 40 unit tests pass
- `cargo clippy --lib -- -D warnings` passes