### PR TITLE
feat: add Near::with_signer for multi-account usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ For CI/CD, configure via environment variables:
 let near = Near::from_env()?;
 ```
 
+## Multiple Accounts
+
+Transport and signing are separate concerns. Set up the connection once, then derive clients for different accounts with `with_signer`. They share the same RPC connection, so there's no overhead:
+
+```rust
+let near = Near::testnet().build(); // read-only, shared connection
+
+let alice = near.with_signer(InMemorySigner::new("alice.testnet", "ed25519:...")?);
+let bob = near.with_signer(InMemorySigner::new("bob.testnet", "ed25519:...")?);
+
+alice.transfer("carol.testnet", NearToken::near(1)).await?;
+bob.transfer("carol.testnet", NearToken::near(2)).await?;
+```
+
+For single-account scripts, the `credentials` builder is still the simplest path. Use `with_signer` when you need to manage multiple accounts or want explicit separation between connection setup and signing.
+
 Need to pass arguments or attach a deposit? Chain the builders:
 
 ```rust

--- a/crates/near-kit/examples/quickstart.rs
+++ b/crates/near-kit/examples/quickstart.rs
@@ -166,6 +166,29 @@ async fn typed_contract_example(near: &Near) -> Result<(), Error> {
 }
 
 // ============================================================================
+// 6. Multiple accounts (shared connection, different signers)
+// ============================================================================
+
+async fn multi_account_example(near: &Near) -> Result<(), Error> {
+    println!("\n=== Multi-Account Example ===\n");
+
+    // Derive a second signing context from the same connection.
+    // In a real app, this would be a different account's key.
+    let account_id = near.account_id().unwrap();
+    let second = near.with_signer(InMemorySigner::new(
+        account_id.as_str(),
+        std::env::var("NEAR_PRIVATE_KEY").unwrap(),
+    )?);
+
+    // Both clients share the same RPC connection (no extra overhead)
+    println!("Original signer: {}", near.account_id().unwrap());
+    println!("Derived signer: {}", second.account_id().unwrap());
+    println!("Same RPC endpoint: {}", near.rpc_url() == second.rpc_url());
+
+    Ok(())
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
@@ -196,6 +219,7 @@ async fn main() -> Result<(), Error> {
             transaction_example(&near, &new_account).await?;
 
             typed_contract_example(&near).await?;
+            multi_account_example(&near).await?;
         }
         _ => {
             println!("\n---");

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -392,7 +392,7 @@ impl RpcError {
 pub enum Error {
     // ─── Configuration ───
     #[error(
-        "No signer configured. Call .signer() on NearBuilder or .sign_with() on the operation."
+        "No signer configured. Use .credentials()/.signer() on NearBuilder, .with_signer() on the client, or .sign_with() on the transaction."
     )]
     NoSigner,
 
@@ -964,7 +964,7 @@ mod tests {
     fn test_error_no_signer_display() {
         assert_eq!(
             Error::NoSigner.to_string(),
-            "No signer configured. Call .signer() on NearBuilder or .sign_with() on the operation."
+            "No signer configured. Use .credentials()/.signer() on NearBuilder, .with_signer() on the client, or .sign_with() on the transaction."
         );
     }
 

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -307,6 +307,32 @@
 //! # }
 //! ```
 //!
+//! ### Multiple Accounts
+//!
+//! For production apps that manage multiple accounts, use [`Near::with_signer`] to
+//! derive clients that share the same RPC connection but sign as different accounts:
+//!
+//! ```rust,no_run
+//! use near_kit::*;
+//!
+//! # fn example() -> Result<(), Error> {
+//! let near = Near::testnet().build();
+//!
+//! let alice = near.with_signer(InMemorySigner::new("alice.testnet", "ed25519:...")?);
+//! let bob = near.with_signer(InMemorySigner::new("bob.testnet", "ed25519:...")?);
+//!
+//! // Both share the same connection, no overhead
+//! // alice.transfer("carol.testnet", NearToken::near(1)).await?;
+//! // bob.transfer("carol.testnet", NearToken::near(2)).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Use [`with_signer`](Near::with_signer) for multi-account management and
+//! [`RotatingSigner`] for high-throughput single-account usage (multiple keys to
+//! avoid nonce collisions). For one-off overrides on a single transaction, use
+//! [`.sign_with()`](TransactionBuilder::sign_with) on the transaction builder.
+//!
 //! ## Sandbox Testing
 //!
 //! Enable the `sandbox` feature for local testing with [`near-sandbox`](https://crates.io/crates/near-sandbox):


### PR DESCRIPTION
## Summary
- Adds `Near::with_signer()` method that creates a new client sharing the same RPC connection but using a different signer, making the transport/signing separation explicit at the API level
- Adds multi-account documentation to README, crate-level rustdoc, `Near` struct docs, and the quickstart example
- Updates the `NoSigner` error message to mention `with_signer()` as an option

## Context

Got feedback that the API surface looks like it couples transport and account identity (similar to early near-api-js). The architecture already separates these concerns internally, but the public API didn't make that obvious. `with_signer()` fixes that at the API level, and the doc updates make the pattern discoverable.

## Test plan
- [x] All 313 existing tests pass
- [x] New unit tests for `with_signer` (single account derivation, multi-account, shared transport)
- [x] Clippy and rustfmt clean
- [x] Doc tests compile