### PR TITLE
feat: add gas key types

### DIFF
--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -1145,6 +1145,42 @@ mod tests {
     }
 
     #[test]
+    fn test_access_key_permission_discriminants() {
+        let fc = AccessKeyPermission::FunctionCall(FunctionCallPermission {
+            allowance: None,
+            receiver_id: "test.near".parse().unwrap(),
+            method_names: vec![],
+        });
+        let bytes = borsh::to_vec(&fc).unwrap();
+        assert_eq!(bytes[0], 0, "FunctionCall should have discriminant 0");
+
+        let fa = AccessKeyPermission::FullAccess;
+        let bytes = borsh::to_vec(&fa).unwrap();
+        assert_eq!(bytes[0], 1, "FullAccess should have discriminant 1");
+
+        let gkfc = AccessKeyPermission::GasKeyFunctionCall(
+            GasKeyInfo {
+                balance: NearToken::from_near(1),
+                num_nonces: 5,
+            },
+            FunctionCallPermission {
+                allowance: None,
+                receiver_id: "test.near".parse().unwrap(),
+                method_names: vec![],
+            },
+        );
+        let bytes = borsh::to_vec(&gkfc).unwrap();
+        assert_eq!(bytes[0], 2, "GasKeyFunctionCall should have discriminant 2");
+
+        let gkfa = AccessKeyPermission::GasKeyFullAccess(GasKeyInfo {
+            balance: NearToken::from_near(1),
+            num_nonces: 5,
+        });
+        let bytes = borsh::to_vec(&gkfa).unwrap();
+        assert_eq!(bytes[0], 3, "GasKeyFullAccess should have discriminant 3");
+    }
+
+    #[test]
     fn test_derive_account_id_different_data() {
         // Different data should produce different account IDs
         let mut data = BTreeMap::new();

--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -874,7 +874,8 @@ mod tests {
         // Verify action discriminants match NEAR protocol specification
         // 0 = CreateAccount, 1 = DeployContract, 2 = FunctionCall, 3 = Transfer,
         // 4 = Stake, 5 = AddKey, 6 = DeleteKey, 7 = DeleteAccount, 8 = Delegate,
-        // 9 = DeployGlobalContract, 10 = UseGlobalContract, 11 = DeterministicStateInit
+        // 9 = DeployGlobalContract, 10 = UseGlobalContract, 11 = DeterministicStateInit,
+        // 12 = TransferToGasKey, 13 = WithdrawFromGasKey
 
         let create_account = Action::create_account();
         let bytes = borsh::to_vec(&create_account).unwrap();

--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -17,16 +17,34 @@ use super::{AccountId, CryptoHash, Gas, NearToken, PublicKey, Signature};
 /// regular transaction signatures.
 pub const DELEGATE_ACTION_PREFIX: u32 = 1_073_742_190;
 
+/// Gas key information.
+///
+/// Gas keys are access keys with a prepaid balance to pay for gas costs.
+#[derive(
+    Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
+)]
+pub struct GasKeyInfo {
+    /// Prepaid gas balance in yoctoNEAR.
+    pub balance: NearToken,
+    /// Number of nonces allocated for this gas key.
+    pub num_nonces: u16,
+}
+
 /// Access key permission.
 ///
 /// IMPORTANT: Variant order matters for Borsh serialization!
-/// NEAR Protocol defines: 0 = FunctionCall, 1 = FullAccess
+/// NEAR Protocol defines: 0 = FunctionCall, 1 = FullAccess,
+/// 2 = GasKeyFunctionCall, 3 = GasKeyFullAccess
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub enum AccessKeyPermission {
     /// Function call access with restrictions. (discriminant = 0)
     FunctionCall(FunctionCallPermission),
     /// Full access to the account. (discriminant = 1)
     FullAccess,
+    /// Gas key with function call access. (discriminant = 2)
+    GasKeyFunctionCall(GasKeyInfo, FunctionCallPermission),
+    /// Gas key with full access. (discriminant = 3)
+    GasKeyFullAccess(GasKeyInfo),
 }
 
 impl AccessKeyPermission {
@@ -97,7 +115,8 @@ impl AccessKey {
 /// The discriminants match NEAR Protocol specification:
 /// 0 = CreateAccount, 1 = DeployContract, 2 = FunctionCall, 3 = Transfer,
 /// 4 = Stake, 5 = AddKey, 6 = DeleteKey, 7 = DeleteAccount, 8 = Delegate,
-/// 9 = DeployGlobalContract, 10 = UseGlobalContract, 11 = DeterministicStateInit
+/// 9 = DeployGlobalContract, 10 = UseGlobalContract, 11 = DeterministicStateInit,
+/// 12 = TransferToGasKey, 13 = WithdrawFromGasKey
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub enum Action {
     /// Create a new account. (discriminant = 0)
@@ -124,6 +143,10 @@ pub enum Action {
     UseGlobalContract(UseGlobalContractAction),
     /// NEP-616: Deploy with deterministically derived account ID. (discriminant = 11)
     DeterministicStateInit(DeterministicStateInitAction),
+    /// Transfer NEAR to a gas key. (discriminant = 12)
+    TransferToGasKey(TransferToGasKeyAction),
+    /// Withdraw NEAR from a gas key. (discriminant = 13)
+    WithdrawFromGasKey(WithdrawFromGasKeyAction),
 }
 
 /// Create a new account.
@@ -331,6 +354,24 @@ impl DeterministicStateInitAction {
     }
 }
 
+/// Transfer NEAR to a gas key.
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct TransferToGasKeyAction {
+    /// Public key of the gas key to fund.
+    pub public_key: PublicKey,
+    /// Amount of NEAR to transfer.
+    pub deposit: NearToken,
+}
+
+/// Withdraw NEAR from a gas key.
+#[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct WithdrawFromGasKeyAction {
+    /// Public key of the gas key to withdraw from.
+    pub public_key: PublicKey,
+    /// Amount of NEAR to withdraw.
+    pub amount: NearToken,
+}
+
 /// Delegate action for meta-transactions.
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct DelegateAction {
@@ -536,6 +577,19 @@ impl Action {
             }),
             deposit,
         })
+    }
+
+    /// Transfer NEAR to a gas key.
+    pub fn transfer_to_gas_key(public_key: PublicKey, deposit: NearToken) -> Self {
+        Self::TransferToGasKey(TransferToGasKeyAction {
+            public_key,
+            deposit,
+        })
+    }
+
+    /// Withdraw NEAR from a gas key.
+    pub fn withdraw_from_gas_key(public_key: PublicKey, amount: NearToken) -> Self {
+        Self::WithdrawFromGasKey(WithdrawFromGasKeyAction { public_key, amount })
     }
 }
 
@@ -858,6 +912,22 @@ mod tests {
         assert_eq!(
             bytes[0], 11,
             "DeterministicStateInit should have discriminant 11"
+        );
+
+        // TransferToGasKey (discriminant = 12)
+        let pk: PublicKey = "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp"
+            .parse()
+            .unwrap();
+        let transfer_gas = Action::transfer_to_gas_key(pk.clone(), NearToken::from_near(1));
+        let bytes = borsh::to_vec(&transfer_gas).unwrap();
+        assert_eq!(bytes[0], 12, "TransferToGasKey should have discriminant 12");
+
+        // WithdrawFromGasKey (discriminant = 13)
+        let withdraw_gas = Action::withdraw_from_gas_key(pk, NearToken::from_near(1));
+        let bytes = borsh::to_vec(&withdraw_gas).unwrap();
+        assert_eq!(
+            bytes[0], 13,
+            "WithdrawFromGasKey should have discriminant 13"
         );
     }
 

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -62,8 +62,9 @@ pub use action::{
     DELEGATE_ACTION_PREFIX, DecodeError as DelegateDecodeError, DelegateAction,
     DeleteAccountAction, DeleteKeyAction, DeployContractAction, DeployGlobalContractAction,
     DeterministicAccountStateInit, DeterministicAccountStateInitV1, DeterministicStateInitAction,
-    FunctionCallAction, FunctionCallPermission, GlobalContractDeployMode, GlobalContractIdentifier,
-    NonDelegateAction, SignedDelegateAction, StakeAction, TransferAction, UseGlobalContractAction,
+    FunctionCallAction, FunctionCallPermission, GasKeyInfo, GlobalContractDeployMode,
+    GlobalContractIdentifier, NonDelegateAction, SignedDelegateAction, StakeAction, TransferAction,
+    TransferToGasKeyAction, UseGlobalContractAction, WithdrawFromGasKeyAction,
 };
 pub use block_reference::{BlockReference, Finality, TxExecutionStatus};
 pub use error::{

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -160,6 +160,26 @@ pub enum AccessKeyPermissionView {
         /// Methods that can be called (empty = all).
         method_names: Vec<String>,
     },
+    /// Gas key with function call access.
+    GasKeyFunctionCall {
+        /// Gas key balance.
+        balance: NearToken,
+        /// Number of nonces.
+        num_nonces: u16,
+        /// Maximum amount this key can spend.
+        allowance: Option<NearToken>,
+        /// Contract that can be called.
+        receiver_id: String,
+        /// Methods that can be called (empty = all).
+        method_names: Vec<String>,
+    },
+    /// Gas key with full access.
+    GasKeyFullAccess {
+        /// Gas key balance.
+        balance: NearToken,
+        /// Number of nonces.
+        num_nonces: u16,
+    },
 }
 
 /// Access key list from view_access_key_list RPC.
@@ -551,6 +571,14 @@ pub enum ActionView {
     #[serde(rename = "DeterministicStateInit")]
     DeterministicStateInit {
         deposit: NearToken,
+    },
+    TransferToGasKey {
+        public_key: String,
+        deposit: NearToken,
+    },
+    WithdrawFromGasKey {
+        public_key: String,
+        amount: NearToken,
     },
 }
 

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -1088,4 +1088,61 @@ mod tests {
         let decoded: Result<u64, _> = result.borsh();
         assert!(decoded.is_err());
     }
+
+    #[test]
+    fn test_gas_key_function_call_deserialization() {
+        let json = serde_json::json!({
+            "GasKeyFunctionCall": {
+                "balance": "1000000000000000000000000",
+                "num_nonces": 5,
+                "allowance": "500000000000000000000000",
+                "receiver_id": "app.near",
+                "method_names": ["call_method"]
+            }
+        });
+        let perm: AccessKeyPermissionView = serde_json::from_value(json).unwrap();
+        assert!(matches!(
+            perm,
+            AccessKeyPermissionView::GasKeyFunctionCall { .. }
+        ));
+    }
+
+    #[test]
+    fn test_gas_key_full_access_deserialization() {
+        let json = serde_json::json!({
+            "GasKeyFullAccess": {
+                "balance": "1000000000000000000000000",
+                "num_nonces": 10
+            }
+        });
+        let perm: AccessKeyPermissionView = serde_json::from_value(json).unwrap();
+        assert!(matches!(
+            perm,
+            AccessKeyPermissionView::GasKeyFullAccess { .. }
+        ));
+    }
+
+    #[test]
+    fn test_transfer_to_gas_key_action_view_deserialization() {
+        let json = serde_json::json!({
+            "TransferToGasKey": {
+                "public_key": "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp",
+                "deposit": "1000000000000000000000000"
+            }
+        });
+        let action: ActionView = serde_json::from_value(json).unwrap();
+        assert!(matches!(action, ActionView::TransferToGasKey { .. }));
+    }
+
+    #[test]
+    fn test_withdraw_from_gas_key_action_view_deserialization() {
+        let json = serde_json::json!({
+            "WithdrawFromGasKey": {
+                "public_key": "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp",
+                "amount": "500000000000000000000000"
+            }
+        });
+        let action: ActionView = serde_json::from_value(json).unwrap();
+        assert!(matches!(action, ActionView::WithdrawFromGasKey { .. }));
+    }
 }

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -169,7 +169,7 @@ pub enum AccessKeyPermissionView {
         /// Maximum amount this key can spend.
         allowance: Option<NearToken>,
         /// Contract that can be called.
-        receiver_id: String,
+        receiver_id: AccountId,
         /// Methods that can be called (empty = all).
         method_names: Vec<String>,
     },

--- a/crates/near-kit/tests/integration/debug_rpc_responses.rs
+++ b/crates/near-kit/tests/integration/debug_rpc_responses.rs
@@ -359,6 +359,12 @@ async fn debug_access_key_details() {
                 println!("      Allowance: {:?}", allowance);
                 println!("      Method names: {:?}", method_names);
             }
+            near_kit::AccessKeyPermissionView::GasKeyFunctionCall { balance, .. } => {
+                println!("    Permission: GasKeyFunctionCall (balance: {})", balance);
+            }
+            near_kit::AccessKeyPermissionView::GasKeyFullAccess { balance, .. } => {
+                println!("    Permission: GasKeyFullAccess (balance: {})", balance);
+            }
         }
     }
 

--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -219,6 +219,12 @@ async fn test_access_key_list_view() {
                 println!("    Allowance: {:?}", allowance);
                 println!("    Methods: {:?}", method_names);
             }
+            AccessKeyPermissionView::GasKeyFunctionCall { balance, .. } => {
+                println!("  Permission: GasKeyFunctionCall (balance: {})", balance);
+            }
+            AccessKeyPermissionView::GasKeyFullAccess { balance, .. } => {
+                println!("  Permission: GasKeyFullAccess (balance: {})", balance);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `TransferToGasKey` (discriminant 12) and `WithdrawFromGasKey` (discriminant 13) to `Action` enum with borsh structs
- Adds `GasKeyFunctionCall` and `GasKeyFullAccess` variants to both `AccessKeyPermission` (borsh) and `AccessKeyPermissionView` (RPC)
- Adds `GasKeyInfo` struct for gas key balance and nonce tracking
- Updates integration tests for new enum variants

Part of #27 (sections 2+3)

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] `cargo clippy` clean
- [x] Borsh discriminant test covers new variants