### PR TITLE
feat: replace String/Value fields with proper types

### DIFF
--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -82,11 +82,12 @@ pub use network::Network;
 pub use rpc::{
     AccessKeyDetails, AccessKeyInfoView, AccessKeyListView, AccessKeyPermissionView, AccessKeyView,
     AccountBalance, AccountView, ActionReceiptData, ActionView, BlockHeaderView, BlockView,
-    ChunkHeaderView, DataReceiptData, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId,
-    ExecutionStatus, FinalExecutionOutcome, FinalExecutionOutcomeWithReceipts,
-    FinalExecutionStatus, GasPrice, GasProfileEntry, MerkleDirection, MerklePathItem, NodeVersion,
-    Receipt, ReceiptContent, STORAGE_AMOUNT_PER_BYTE, StatusResponse, SyncInfo, TransactionView,
-    ValidatorInfo, ValidatorProposal, ViewFunctionResult,
+    ChunkHeaderView, DataReceiptData, DataReceiverView, ExecutionMetadata, ExecutionOutcome,
+    ExecutionOutcomeWithId, ExecutionStatus, FinalExecutionOutcome,
+    FinalExecutionOutcomeWithReceipts, FinalExecutionStatus, GasPrice, GasProfileEntry,
+    MerkleDirection, MerklePathItem, NodeVersion, Receipt, ReceiptContent, STORAGE_AMOUNT_PER_BYTE,
+    SlashedValidator, StatusResponse, SyncInfo, TransactionView, ValidatorInfo, ValidatorStakeView,
+    ValidatorStakeViewV1, ViewFunctionResult,
 };
 pub use transaction::{SignedTransaction, Transaction};
 pub use units::{Gas, IntoGas, IntoNearToken, NearToken};

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -307,7 +307,6 @@ pub struct ValidatorStakeViewV1 {
     /// Public key.
     pub public_key: PublicKey,
     /// Stake amount.
-    #[serde(alias = "stake")]
     pub stake: NearToken,
 }
 

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -891,7 +891,7 @@ pub struct StatusResponse {
     pub validator_account_id: Option<AccountId>,
     /// Validator public key (if validating).
     #[serde(default)]
-    pub validator_public_key: Option<String>,
+    pub validator_public_key: Option<PublicKey>,
     /// List of current validators.
     #[serde(default)]
     pub validators: Vec<ValidatorInfo>,

--- a/crates/near-kit/tests/integration/error_handling_integration.rs
+++ b/crates/near-kit/tests/integration/error_handling_integration.rs
@@ -623,7 +623,10 @@ async fn test_block_query_returns_valid_data() {
 
     let block = near.rpc().block(BlockReference::final_()).await.unwrap();
 
-    assert!(!block.author.is_empty(), "Block author should exist");
+    assert!(
+        !block.author.as_str().is_empty(),
+        "Block author should exist"
+    );
     assert!(!block.header.hash.is_zero(), "Block hash should exist");
     assert!(block.header.latest_protocol_version > 0);
 

--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -35,7 +35,10 @@ async fn test_block_view_full_fields() {
     let block = near.rpc().block(BlockReference::final_()).await.unwrap();
 
     // Verify BlockView fields
-    assert!(!block.author.is_empty(), "Block should have an author");
+    assert!(
+        !block.author.as_str().is_empty(),
+        "Block should have an author"
+    );
 
     // Verify BlockHeaderView fields - note that genesis block may have height 0
     let header = &block.header;
@@ -44,8 +47,14 @@ async fn test_block_view_full_fields() {
         !header.timestamp_nanosec.is_empty(),
         "Timestamp nanosec should exist"
     );
-    assert!(!header.gas_price.is_empty(), "Gas price should exist");
-    assert!(!header.total_supply.is_empty(), "Total supply should exist");
+    assert!(
+        header.gas_price.as_yoctonear() > 0,
+        "Gas price should exist"
+    );
+    assert!(
+        header.total_supply.as_yoctonear() > 0,
+        "Total supply should exist"
+    );
     assert!(!header.signature.is_empty(), "Signature should exist");
     assert!(
         header.latest_protocol_version > 0,
@@ -455,10 +464,16 @@ async fn test_gas_price() {
 
     let gas_price = near.rpc().gas_price(None).await.unwrap();
 
-    assert!(!gas_price.gas_price.is_empty(), "Gas price should exist");
+    assert!(
+        gas_price.gas_price.as_yoctonear() > 0,
+        "Gas price should exist"
+    );
     assert!(gas_price.as_u128() > 0, "Gas price should be positive");
 
-    println!("Current gas price: {} yoctoNEAR", gas_price.gas_price);
+    println!(
+        "Current gas price: {} yoctoNEAR",
+        gas_price.gas_price.as_yoctonear()
+    );
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Replaces ~25 loosely-typed `String` and `serde_json::Value` fields across RPC types with proper `AccountId`, `PublicKey`, `NearToken`, `CryptoHash` types
- Adds `ValidatorStakeView` (versioned), `SlashedValidator`, `DataReceiverView` helper types
- Updates integration test assertions to use typed APIs

Stacked on #31. Part of #27 (section 4).

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — 313 passed, 0 failed
- [x] `cargo clippy --all-targets` clean
- [x] Integration tests updated for new types