### PR TITLE
feat: add missing fields and new type variants

### DIFF
--- a/crates/near-kit/src/types/block_reference.rs
+++ b/crates/near-kit/src/types/block_reference.rs
@@ -4,6 +4,16 @@ use serde::{Deserialize, Serialize};
 
 use super::CryptoHash;
 
+/// Sync checkpoint for block references.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncCheckpoint {
+    /// Genesis block.
+    Genesis,
+    /// Earliest available block.
+    EarliestAvailable,
+}
+
 /// Reference to a specific block for RPC queries.
 ///
 /// Every NEAR RPC query operates on state at a specific block.
@@ -15,6 +25,8 @@ pub enum BlockReference {
     Height(u64),
     /// Query at specific block hash.
     Hash(CryptoHash),
+    /// Query at a sync checkpoint (genesis or earliest available).
+    SyncCheckpoint(SyncCheckpoint),
 }
 
 impl Default for BlockReference {
@@ -49,6 +61,16 @@ impl BlockReference {
         Self::Hash(hash)
     }
 
+    /// Query at genesis block.
+    pub fn genesis() -> Self {
+        Self::SyncCheckpoint(SyncCheckpoint::Genesis)
+    }
+
+    /// Query at earliest available block.
+    pub fn earliest_available() -> Self {
+        Self::SyncCheckpoint(SyncCheckpoint::EarliestAvailable)
+    }
+
     /// Convert to JSON for RPC requests.
     pub fn to_rpc_params(&self) -> serde_json::Value {
         match self {
@@ -60,6 +82,13 @@ impl BlockReference {
             }
             BlockReference::Hash(h) => {
                 serde_json::json!({ "block_id": h.to_string() })
+            }
+            BlockReference::SyncCheckpoint(cp) => {
+                let cp_str = match cp {
+                    SyncCheckpoint::Genesis => "genesis",
+                    SyncCheckpoint::EarliestAvailable => "earliest_available",
+                };
+                serde_json::json!({ "sync_checkpoint": cp_str })
             }
         }
     }

--- a/crates/near-kit/src/types/block_reference.rs
+++ b/crates/near-kit/src/types/block_reference.rs
@@ -330,4 +330,39 @@ mod tests {
         assert_eq!(f1, f2);
         assert_eq!(f1, f3);
     }
+
+    #[test]
+    fn test_sync_checkpoint_constructors() {
+        let genesis = BlockReference::genesis();
+        assert!(matches!(
+            genesis,
+            BlockReference::SyncCheckpoint(SyncCheckpoint::Genesis)
+        ));
+
+        let earliest = BlockReference::earliest_available();
+        assert!(matches!(
+            earliest,
+            BlockReference::SyncCheckpoint(SyncCheckpoint::EarliestAvailable)
+        ));
+    }
+
+    #[test]
+    fn test_sync_checkpoint_rpc_params() {
+        let genesis = BlockReference::genesis();
+        let params = genesis.to_rpc_params();
+        assert_eq!(params["sync_checkpoint"], "genesis");
+
+        let earliest = BlockReference::earliest_available();
+        let params = earliest.to_rpc_params();
+        assert_eq!(params["sync_checkpoint"], "earliest_available");
+    }
+
+    #[test]
+    fn test_sync_checkpoint_serde_roundtrip() {
+        for cp in [SyncCheckpoint::Genesis, SyncCheckpoint::EarliestAvailable] {
+            let json = serde_json::to_string(&cp).unwrap();
+            let parsed: SyncCheckpoint = serde_json::from_str(&json).unwrap();
+            assert_eq!(cp, parsed);
+        }
+    }
 }

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -66,7 +66,7 @@ pub use action::{
     GlobalContractIdentifier, NonDelegateAction, SignedDelegateAction, StakeAction, TransferAction,
     TransferToGasKeyAction, UseGlobalContractAction, WithdrawFromGasKeyAction,
 };
-pub use block_reference::{BlockReference, Finality, TxExecutionStatus};
+pub use block_reference::{BlockReference, Finality, SyncCheckpoint, TxExecutionStatus};
 pub use error::{
     ActionError, ActionErrorKind, ActionsValidationError, CompilationError,
     DepositCostFailureReason, FunctionCallError, HostError, InvalidAccessKeyError, InvalidTxError,
@@ -82,8 +82,8 @@ pub use network::Network;
 pub use rpc::{
     AccessKeyDetails, AccessKeyInfoView, AccessKeyListView, AccessKeyPermissionView, AccessKeyView,
     AccountBalance, AccountView, ActionReceiptData, ActionView, BlockHeaderView, BlockView,
-    ChunkHeaderView, DataReceiptData, DataReceiverView, ExecutionMetadata, ExecutionOutcome,
-    ExecutionOutcomeWithId, ExecutionStatus, FinalExecutionOutcome,
+    ChunkHeaderView, CongestionInfoView, DataReceiptData, DataReceiverView, ExecutionMetadata,
+    ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus, FinalExecutionOutcome,
     FinalExecutionOutcomeWithReceipts, FinalExecutionStatus, GasPrice, GasProfileEntry,
     MerkleDirection, MerklePathItem, NodeVersion, Receipt, ReceiptContent, STORAGE_AMOUNT_PER_BYTE,
     SlashedValidator, StatusResponse, SyncInfo, TransactionView, ValidatorInfo, ValidatorStakeView,

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -296,10 +296,10 @@ pub struct BlockHeaderView {
     pub signature: String,
     /// Latest protocol version.
     pub latest_protocol_version: u32,
-    /// Rent paid (deprecated, always 0).
+    /// Rent paid (deprecated; when present, always 0).
     #[serde(default)]
     pub rent_paid: Option<NearToken>,
-    /// Validator reward (deprecated, always 0).
+    /// Validator reward (deprecated; when present, always 0).
     #[serde(default)]
     pub validator_reward: Option<NearToken>,
     /// Chunk endorsements (optional).
@@ -405,7 +405,7 @@ pub struct ChunkHeaderView {
     /// Bandwidth requests (optional, added in later protocol versions).
     #[serde(default)]
     pub bandwidth_requests: Option<serde_json::Value>,
-    /// Rent paid (deprecated, always 0).
+    /// Rent paid (deprecated; when present, always 0).
     #[serde(default)]
     pub rent_paid: Option<NearToken>,
     /// Proposed split (optional).

--- a/crates/near-kit/tests/integration/debug_rpc_responses.rs
+++ b/crates/near-kit/tests/integration/debug_rpc_responses.rs
@@ -297,6 +297,9 @@ async fn debug_transaction_receipts() {
                 println!("    Data ID: {}", data_receipt.data_id);
                 println!("    Data: {:?}", data_receipt.data);
             }
+            ReceiptContent::GlobalContractDistribution { .. } => {
+                println!("    Type: GLOBAL_CONTRACT_DISTRIBUTION");
+            }
         }
     }
 

--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -449,6 +449,9 @@ async fn test_tx_status_with_receipts() {
                 println!("  Type: Data receipt");
                 println!("  Data ID: {}", data_receipt.data_id);
             }
+            ReceiptContent::GlobalContractDistribution { .. } => {
+                println!("  Type: Global contract distribution");
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds missing fields to `BlockHeaderView`, `ChunkHeaderView`, `AccountView`, `TransactionView` from recent nearcore protocol versions
- Adds `CongestionInfoView` struct for shard congestion data
- Adds `SyncCheckpoint` enum and `BlockReference::SyncCheckpoint` variant
- Adds `ReceiptContent::GlobalContractDistribution` variant
- All new fields use `#[serde(default)]` for backward compatibility

Stacked on #32. Part of #27 (sections 5+6).

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` — 313 passed, 0 failed
- [x] `cargo clippy --all-targets` clean
- [x] Integration tests updated for new enum variants