### PR TITLE
fix: align FinalExecutionStatus and ExecutionStatus with nearcore

### DIFF
--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use near_kit::sandbox::{ROOT_ACCOUNT, SandboxConfig};
 use near_kit::*;
 use near_kit::{
-    AccessKeyPermissionView, ActionView, FinalExecutionStatus, MerkleDirection, ReceiptContent,
+    AccessKeyPermissionView, ActionView, MerkleDirection, ReceiptContent, TxExecutionStatus,
 };
 
 /// Counter for generating unique subaccount names
@@ -267,14 +267,13 @@ async fn test_final_execution_outcome_full_fields() {
     assert!(
         matches!(
             outcome.final_execution_status,
-            FinalExecutionStatus::Final | FinalExecutionStatus::Executed
+            TxExecutionStatus::Final | TxExecutionStatus::Executed
         ),
         "Should have final execution status, got {:?}",
         outcome.final_execution_status
     );
     assert!(outcome.is_success(), "Transaction should succeed");
     assert!(!outcome.is_pending(), "Transaction should not be pending");
-    assert!(outcome.status.is_some(), "Status should be present");
     assert!(
         outcome.transaction.is_some(),
         "Transaction should be present"


### PR DESCRIPTION
## Summary

- **`FinalExecutionStatus`** was incorrectly modeled as wait-level variants (`None`, `Included`, `ExecutedOptimistic`, etc.), duplicating `TxExecutionStatus`. Changed to match nearcore's actual `FinalExecutionStatus`: `NotStarted`, `Started`, `Failure(TxExecutionError)`, `SuccessValue(String)`
- **`FinalExecutionOutcome.final_execution_status`** now correctly uses `TxExecutionStatus` (the wait level)
- **`FinalExecutionOutcome.status`** now uses `FinalExecutionStatus` directly instead of `Option<ExecutionStatus>`
- Removed `Pending` variant from `ExecutionStatus` (per-receipt type doesn't have it in nearcore)

### Breaking changes

| Before | After |
|--------|-------|
| `FinalExecutionStatus::Final` | `TxExecutionStatus::Final` |
| `outcome.status: Option<ExecutionStatus>` | `outcome.status: FinalExecutionStatus` |
| `ExecutionStatus::Pending` | Removed (use `FinalExecutionStatus::Started`) |

## Test plan

- [x] All 332 unit tests pass
- [x] Clippy clean
- [ ] Sandbox integration tests (CI)