### PR TITLE
feat: add primitives for per-key sequential transaction sends

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Different situations call for different key management. near-kit supports severa
 | `InMemorySigner` | Scripts and bots with a hardcoded or loaded key |
 | `FileSigner` | Local development — reads from `~/.near-credentials` |
 | `EnvSigner` | CI/CD pipelines via `NEAR_ACCOUNT_ID` and `NEAR_PRIVATE_KEY` |
-| `RotatingSigner` | High-throughput apps that need multiple keys to avoid nonce conflicts |
+| `RotatingSigner` | High-throughput apps that need multiple keys to avoid nonce conflicts. Use `into_per_key_signers()` to split into per-key signers for sequential send queues |
 | `KeyringSigner` | Desktop apps using the system keychain (requires `keyring` feature) |
 
 ## Token Standards

--- a/crates/near-kit/examples/sequential_sends.rs
+++ b/crates/near-kit/examples/sequential_sends.rs
@@ -1,0 +1,149 @@
+//! Sequential Per-Key Transaction Sends
+//!
+//! Demonstrates how to build a per-key sequential send pattern using
+//! `RotatingSigner::into_per_key_signers()`. This ensures transactions
+//! from the same access key are sent one at a time, waiting for block
+//! inclusion before sending the next — preventing the send-ordering
+//! race condition where a higher nonce arrives at a validator before
+//! a lower one.
+//!
+//! Run: cargo run --example sequential_sends --features sandbox
+//!
+//! This example requires the `sandbox` feature and will start a local NEAR node.
+
+use near_kit::*;
+
+#[cfg(feature = "sandbox")]
+use near_kit::sandbox::{OwnedSandbox, SandboxConfig};
+
+#[cfg(feature = "sandbox")]
+async fn sequential_example() -> Result<(), Error> {
+    println!("Starting local sandbox...\n");
+    let sandbox: OwnedSandbox = SandboxConfig::fresh().await;
+
+    let root_near = sandbox.client();
+    let root_account = root_near.account_id().unwrap().to_string();
+
+    // Generate 3 keypairs for the bot account
+    let num_keys = 3;
+    let keypairs: Vec<KeyPair> = (0..num_keys).map(|_| KeyPair::random()).collect();
+
+    // Create a bot account with the first key
+    let bot_account = format!("bot-{}.{}", std::process::id(), root_account);
+    println!("Creating bot account: {bot_account}");
+
+    root_near
+        .transaction(&bot_account)
+        .create_account()
+        .transfer(NearToken::near(50))
+        .add_full_access_key(keypairs[0].public_key.clone())
+        .send()
+        .await?;
+
+    // Add remaining keys
+    let bot_near = Near::custom(sandbox.rpc_url())
+        .signer(InMemorySigner::from_secret_key(
+            bot_account.parse()?,
+            keypairs[0].secret_key.clone(),
+        ))
+        .build();
+
+    keypairs[1..]
+        .iter()
+        .fold(bot_near.transaction(&bot_account), |tx, kp| {
+            tx.add_full_access_key(kp.public_key.clone())
+        })
+        .send()
+        .await?;
+
+    // Create recipient
+    let recipient = format!("recipient.{root_account}");
+    root_near
+        .transaction(&recipient)
+        .create_account()
+        .transfer(NearToken::millinear(100))
+        .send()
+        .await?;
+
+    // Split RotatingSigner into per-key signers
+    let secret_keys: Vec<SecretKey> = keypairs.into_iter().map(|kp| kp.secret_key).collect();
+    let rotating = RotatingSigner::new(&bot_account, secret_keys)?;
+
+    println!(
+        "Splitting {} keys into per-key signers...",
+        rotating.key_count()
+    );
+    let per_key_signers = rotating.into_per_key_signers();
+
+    // Each key gets its own sequential queue via tokio::spawn.
+    // Within each queue, transactions wait for block inclusion before
+    // sending the next one — preventing nonce ordering issues.
+    let txs_per_key = 5;
+    println!("Sending {txs_per_key} sequential txs per key ({num_keys} keys in parallel)...\n");
+
+    let start = std::time::Instant::now();
+    let rpc_url = sandbox.rpc_url().to_string();
+
+    let handles: Vec<_> = per_key_signers
+        .into_iter()
+        .enumerate()
+        .map(|(key_idx, signer)| {
+            let rpc_url = rpc_url.clone();
+            let recipient = recipient.clone();
+            tokio::spawn(async move {
+                let near = Near::custom(&rpc_url).signer(signer).build();
+                for tx_idx in 0..txs_per_key {
+                    near.transfer(&recipient, NearToken::millinear(1))
+                        .send()
+                        .wait_until(TxExecutionStatus::Included)
+                        .await
+                        .unwrap();
+                    println!("  key[{key_idx}] tx {tx_idx} included");
+                }
+            })
+        })
+        .collect();
+
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    let duration = start.elapsed();
+    let total = num_keys * txs_per_key;
+
+    println!("\n=== Results ===");
+    println!("Total txs:  {total}");
+    println!("Duration:   {:.2?}", duration);
+    println!(
+        "Throughput: {:.1} tx/s",
+        total as f64 / duration.as_secs_f64()
+    );
+
+    // Verify balance
+    let balance = bot_near.balance(&recipient).await?;
+    println!("\nRecipient balance: {}", balance.available);
+
+    println!("\nDone.");
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    println!("Sequential Per-Key Sends Example\n");
+    println!(
+        "Demonstrates per-key sequential transaction execution using into_per_key_signers().\n"
+    );
+
+    #[cfg(feature = "sandbox")]
+    {
+        sequential_example().await?;
+    }
+
+    #[cfg(not(feature = "sandbox"))]
+    {
+        println!("This example requires the `sandbox` feature.");
+        println!("Run with: cargo run --example sequential_sends --features sandbox");
+    }
+
+    Ok(())
+}

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -702,9 +702,10 @@ impl RotatingSigner {
     /// assert_eq!(per_key.len(), 2);
     /// ```
     pub fn into_per_key_signers(self) -> Vec<InMemorySigner> {
+        let account_id = self.account_id;
         self.keys
             .into_iter()
-            .map(|sk| InMemorySigner::from_secret_key(self.account_id.clone(), sk))
+            .map(|sk| InMemorySigner::from_secret_key(account_id.clone(), sk))
             .collect()
     }
 }

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -670,6 +670,43 @@ impl RotatingSigner {
     pub fn public_keys(&self) -> Vec<PublicKey> {
         self.keys.iter().map(|sk| sk.public_key()).collect()
     }
+
+    /// Get all signing keys without advancing the rotation counter.
+    ///
+    /// Useful for building per-key data structures like sequential send queues.
+    /// Unlike [`key()`](Signer::key), calling this does not affect the rotation.
+    pub fn signing_keys(&self) -> Vec<SigningKey> {
+        self.keys
+            .iter()
+            .map(|sk| SigningKey::new(sk.clone()))
+            .collect()
+    }
+
+    /// Split into per-key [`InMemorySigner`] instances.
+    ///
+    /// Each signer uses a single key from the rotation pool, allowing
+    /// independent send ordering per key. The global nonce manager
+    /// automatically tracks nonces per `(account_id, public_key)`,
+    /// so per-key signers coordinate correctly without extra setup.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use near_kit::{RotatingSigner, SecretKey};
+    ///
+    /// let keys = vec![SecretKey::generate_ed25519(), SecretKey::generate_ed25519()];
+    /// let rotating = RotatingSigner::new("bot.testnet", keys).unwrap();
+    ///
+    /// // Create per-key signers for sequential queue workers
+    /// let per_key: Vec<_> = rotating.into_per_key_signers();
+    /// assert_eq!(per_key.len(), 2);
+    /// ```
+    pub fn into_per_key_signers(self) -> Vec<InMemorySigner> {
+        self.keys
+            .into_iter()
+            .map(|sk| InMemorySigner::from_secret_key(self.account_id.clone(), sk))
+            .collect()
+    }
 }
 
 impl std::fmt::Debug for RotatingSigner {
@@ -914,6 +951,45 @@ mod tests {
         assert!(debug_str.contains("public_key"));
         assert!(!debug_str.contains("secret_key"));
         assert!(!debug_str.contains("3D4YudUahN1nawWogh"));
+    }
+
+    #[test]
+    fn test_rotating_signer_signing_keys() {
+        let keys = vec![
+            SecretKey::generate_ed25519(),
+            SecretKey::generate_ed25519(),
+            SecretKey::generate_ed25519(),
+        ];
+        let expected_public_keys: Vec<_> = keys.iter().map(|k| k.public_key()).collect();
+
+        let signer = RotatingSigner::new("bot.testnet", keys).unwrap();
+
+        // signing_keys() should not advance the counter
+        let counter_before = signer.counter.load(Ordering::Relaxed);
+        let signing_keys = signer.signing_keys();
+        let counter_after = signer.counter.load(Ordering::Relaxed);
+        assert_eq!(counter_before, counter_after);
+
+        // Should return all keys with matching public keys
+        assert_eq!(signing_keys.len(), 3);
+        for (sk, expected_pk) in signing_keys.iter().zip(&expected_public_keys) {
+            assert_eq!(sk.public_key(), expected_pk);
+        }
+    }
+
+    #[test]
+    fn test_rotating_signer_into_per_key_signers() {
+        let keys = vec![SecretKey::generate_ed25519(), SecretKey::generate_ed25519()];
+        let expected_public_keys: Vec<_> = keys.iter().map(|k| k.public_key()).collect();
+
+        let signer = RotatingSigner::new("bot.testnet", keys).unwrap();
+        let per_key = signer.into_per_key_signers();
+
+        assert_eq!(per_key.len(), 2);
+        for (ims, expected_pk) in per_key.iter().zip(&expected_public_keys) {
+            assert_eq!(ims.account_id().as_str(), "bot.testnet");
+            assert_eq!(ims.public_key(), expected_pk);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Adds `RotatingSigner::signing_keys()` and `into_per_key_signers()` to enable building per-key sequential send queues
- Adds `sequential_sends` example demonstrating the pattern with delegate-compatible transactions
- Addresses the send-ordering race condition where concurrent txs from the same access key arrive at validators out of nonce order

## Context

NEAR processes one tx per signer per chunk. When sending concurrent txs from the same access key, nonces are assigned atomically but sends are unordered — a higher nonce can arrive before a lower one, causing rejections. Related discussion with defuse-labs on building a wallet-contract relayer that needs sequential execution guarantees.

Rather than baking a sequential mode into the library (like `near-api-rs` [PR #124](https://github.com/near/near-api-rs/pull/124)), this provides composable primitives so users can wire up their own per-key queues:

```rust
let per_key = rotating.into_per_key_signers();
for signer in per_key {
    let near = Near::custom(rpc_url).signer(signer).build();
    tokio::spawn(async move {
        for job in queue {
            near.transaction(delegate.sender_id())
                .signed_delegate_action(delegate)
                .send()
                .wait_until(TxExecutionStatus::Included)
                .await?;
        }
    });
}
```

## Test plan

- [x] `cargo test -p near-kit --lib signer::tests` — 20 tests pass including 2 new ones
- [x] `cargo build --example sequential_sends` compiles
- [x] `cargo run --example sequential_sends --features sandbox` runs successfully (15 txs, 0 failures)
- [x] Pre-commit hooks (clippy + rustfmt) pass