### PR TITLE
feat: configurable max_nonce_retries and network-scoped nonce cache

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -924,16 +924,22 @@ impl NearBuilder {
         self
     }
 
-    /// Set the maximum number of nonce retries on `InvalidNonce` errors.
+    /// Set the maximum number of transaction send attempts on `InvalidNonce` errors.
     ///
     /// When a transaction fails with `InvalidNonce`, the client automatically
     /// retries with the corrected nonce from the error response. This controls
-    /// how many times that retry is attempted before giving up.
+    /// the total number of send attempts (including the initial one) before
+    /// giving up. A value of `1` means no retries (only the initial attempt).
     ///
     /// Defaults to `3`. For high-contention relayer scenarios, consider setting
     /// this higher (e.g., `u32::MAX`) and wrapping sends in `tokio::timeout`.
-    pub fn max_nonce_retries(mut self, retries: u32) -> Self {
-        self.max_nonce_retries = retries;
+    ///
+    /// # Panics
+    ///
+    /// Panics if `attempts` is `0`.
+    pub fn max_nonce_retries(mut self, attempts: u32) -> Self {
+        assert!(attempts > 0, "max_nonce_retries must be at least 1");
+        self.max_nonce_retries = attempts;
         self
     }
 

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -95,6 +95,7 @@ pub struct Near {
     rpc: Arc<RpcClient>,
     signer: Option<Arc<dyn Signer>>,
     network: Network,
+    max_nonce_retries: u32,
 }
 
 impl Near {
@@ -218,6 +219,7 @@ impl Near {
             rpc: Arc::new(RpcClient::new(network.rpc_url())),
             signer: Some(Arc::new(signer)),
             network: Network::Sandbox,
+            max_nonce_retries: 3,
         }
     }
 
@@ -269,6 +271,7 @@ impl Near {
             rpc: self.rpc.clone(),
             signer: Some(Arc::new(signer)),
             network: self.network,
+            max_nonce_retries: self.max_nonce_retries,
         }
     }
 
@@ -587,7 +590,12 @@ impl Near {
     /// ```
     pub fn transaction(&self, receiver_id: impl AsRef<str>) -> TransactionBuilder {
         let receiver_id = AccountId::parse_lenient(receiver_id);
-        TransactionBuilder::new(self.rpc.clone(), self.signer.clone(), receiver_id)
+        TransactionBuilder::new(
+            self.rpc.clone(),
+            self.signer.clone(),
+            receiver_id,
+            self.max_nonce_retries,
+        )
     }
 
     /// Send a pre-signed transaction.
@@ -785,6 +793,7 @@ impl Near {
             self.rpc.clone(),
             self.signer.clone(),
             contract_id,
+            self.max_nonce_retries,
         ))
     }
 
@@ -822,6 +831,7 @@ impl Near {
             self.rpc.clone(),
             self.signer.clone(),
             contract_id,
+            self.max_nonce_retries,
         ))
     }
 }
@@ -862,6 +872,7 @@ pub struct NearBuilder {
     signer: Option<Arc<dyn Signer>>,
     retry_config: RetryConfig,
     network: Network,
+    max_nonce_retries: u32,
 }
 
 impl NearBuilder {
@@ -872,6 +883,7 @@ impl NearBuilder {
             signer: None,
             retry_config: RetryConfig::default(),
             network,
+            max_nonce_retries: 3,
         }
     }
 
@@ -912,6 +924,19 @@ impl NearBuilder {
         self
     }
 
+    /// Set the maximum number of nonce retries on `InvalidNonce` errors.
+    ///
+    /// When a transaction fails with `InvalidNonce`, the client automatically
+    /// retries with the corrected nonce from the error response. This controls
+    /// how many times that retry is attempted before giving up.
+    ///
+    /// Defaults to `3`. For high-contention relayer scenarios, consider setting
+    /// this higher (e.g., `u32::MAX`) and wrapping sends in `tokio::timeout`.
+    pub fn max_nonce_retries(mut self, retries: u32) -> Self {
+        self.max_nonce_retries = retries;
+        self
+    }
+
     /// Build the client.
     pub fn build(self) -> Near {
         Near {
@@ -921,6 +946,7 @@ impl NearBuilder {
             )),
             signer: self.signer,
             network: self.network,
+            max_nonce_retries: self.max_nonce_retries,
         }
     }
 }

--- a/crates/near-kit/src/client/nonce_manager.rs
+++ b/crates/near-kit/src/client/nonce_manager.rs
@@ -48,6 +48,7 @@ impl NonceManager {
     /// Next nonce to use for transaction
     pub async fn get_next_nonce<F, Fut>(
         &self,
+        network: &str,
         account_id: &str,
         public_key: &str,
         fetch_from_blockchain: F,
@@ -56,7 +57,7 @@ impl NonceManager {
         F: FnOnce() -> Fut,
         Fut: Future<Output = Result<u64, crate::Error>>,
     {
-        let key = format!("{}:{}", account_id, public_key);
+        let key = format!("{}:{}:{}", network, account_id, public_key);
 
         // Fast path: check if we already have a cached nonce
         {
@@ -91,8 +92,8 @@ impl NonceManager {
     /// Call this when an InvalidNonceError occurs to force a fresh fetch
     /// from the blockchain on the next transaction.
     #[allow(dead_code)]
-    pub fn invalidate(&self, account_id: &str, public_key: &str) {
-        let key = format!("{}:{}", account_id, public_key);
+    pub fn invalidate(&self, network: &str, account_id: &str, public_key: &str) {
+        let key = format!("{}:{}:{}", network, account_id, public_key);
         let mut nonces = self.nonces.lock().unwrap();
         nonces.remove(&key);
     }
@@ -114,11 +115,12 @@ impl NonceManager {
     /// The next nonce to use (current_nonce + 1)
     pub fn update_and_get_next(
         &self,
+        network: &str,
         account_id: &str,
         public_key: &str,
         current_nonce: u64,
     ) -> u64 {
-        let key = format!("{}:{}", account_id, public_key);
+        let key = format!("{}:{}:{}", network, account_id, public_key);
         let next_nonce = current_nonce + 1;
 
         let mut nonces = self.nonces.lock().unwrap();
@@ -151,14 +153,16 @@ mod tests {
 
         // First call should fetch from blockchain
         let nonce1 = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async { Ok(10) })
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
+                Ok(10)
+            })
             .await
             .unwrap();
         assert_eq!(nonce1, 11); // blockchain nonce + 1
 
         // Second call should use cached value
         let nonce2 = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async {
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
                 panic!("Should not fetch again!")
             })
             .await
@@ -167,7 +171,7 @@ mod tests {
 
         // Third call
         let nonce3 = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async {
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
                 panic!("Should not fetch again!")
             })
             .await
@@ -181,17 +185,21 @@ mod tests {
 
         // Fetch initial nonce
         let nonce1 = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async { Ok(10) })
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
+                Ok(10)
+            })
             .await
             .unwrap();
         assert_eq!(nonce1, 11);
 
         // Invalidate
-        manager.invalidate("alice.testnet", "ed25519:abc");
+        manager.invalidate("testnet", "alice.testnet", "ed25519:abc");
 
         // Next call should fetch again
         let nonce2 = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async { Ok(15) })
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
+                Ok(15)
+            })
             .await
             .unwrap();
         assert_eq!(nonce2, 16); // Fresh fetch
@@ -202,20 +210,22 @@ mod tests {
         let manager = NonceManager::new();
 
         let nonce_alice = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async { Ok(10) })
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
+                Ok(10)
+            })
             .await
             .unwrap();
         assert_eq!(nonce_alice, 11);
 
         let nonce_bob = manager
-            .get_next_nonce("bob.testnet", "ed25519:xyz", || async { Ok(20) })
+            .get_next_nonce("testnet", "bob.testnet", "ed25519:xyz", || async { Ok(20) })
             .await
             .unwrap();
         assert_eq!(nonce_bob, 21);
 
         // Alice's nonce should still increment
         let nonce_alice2 = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async {
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
                 panic!("Should not fetch!")
             })
             .await
@@ -224,25 +234,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_nonce_manager_different_networks() {
+        let manager = NonceManager::new();
+
+        // Same account+key on testnet
+        let nonce_testnet = manager
+            .get_next_nonce("testnet", "alice.near", "ed25519:abc", || async { Ok(10) })
+            .await
+            .unwrap();
+        assert_eq!(nonce_testnet, 11);
+
+        // Same account+key on mainnet should fetch separately
+        let nonce_mainnet = manager
+            .get_next_nonce("mainnet", "alice.near", "ed25519:abc", || async { Ok(50) })
+            .await
+            .unwrap();
+        assert_eq!(nonce_mainnet, 51);
+
+        // Testnet should still increment from its own cache
+        let nonce_testnet2 = manager
+            .get_next_nonce("testnet", "alice.near", "ed25519:abc", || async {
+                panic!("Should not fetch!")
+            })
+            .await
+            .unwrap();
+        assert_eq!(nonce_testnet2, 12);
+    }
+
+    #[tokio::test]
     async fn test_nonce_manager_update_and_get_next() {
         let manager = NonceManager::new();
 
         // First call - no entry exists
-        let nonce1 = manager.update_and_get_next("alice.testnet", "ed25519:abc", 100);
+        let nonce1 = manager.update_and_get_next("testnet", "alice.testnet", "ed25519:abc", 100);
         assert_eq!(nonce1, 101); // current_nonce + 1
 
         // Second call - entry exists, should increment
-        let nonce2 = manager.update_and_get_next("alice.testnet", "ed25519:abc", 100);
+        let nonce2 = manager.update_and_get_next("testnet", "alice.testnet", "ed25519:abc", 100);
         // Should use cached value (102) since it's higher than 101
         assert_eq!(nonce2, 102);
 
         // Third call with higher ak_nonce - should update cache
-        let nonce3 = manager.update_and_get_next("alice.testnet", "ed25519:abc", 110);
+        let nonce3 = manager.update_and_get_next("testnet", "alice.testnet", "ed25519:abc", 110);
         assert_eq!(nonce3, 111); // New current_nonce + 1
 
         // Fourth call - should use updated cache
         let nonce4 = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async {
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
                 panic!("Should not fetch!")
             })
             .await
@@ -256,24 +294,26 @@ mod tests {
 
         // Setup: get some nonces to advance the cache
         let _ = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async { Ok(100) })
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
+                Ok(100)
+            })
             .await
             .unwrap(); // Returns 101, cache has 102
         let _ = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async {
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
                 panic!("no fetch")
             })
             .await
             .unwrap(); // Returns 102, cache has 103
         let _ = manager
-            .get_next_nonce("alice.testnet", "ed25519:abc", || async {
+            .get_next_nonce("testnet", "alice.testnet", "ed25519:abc", || async {
                 panic!("no fetch")
             })
             .await
             .unwrap(); // Returns 103, cache has 104
 
         // Now update with a LOWER ak_nonce - should use cached value
-        let nonce = manager.update_and_get_next("alice.testnet", "ed25519:abc", 100);
+        let nonce = manager.update_and_get_next("testnet", "alice.testnet", "ed25519:abc", 100);
         // Cache had 104, which is higher than 101, so use cached
         assert_eq!(nonce, 104);
     }

--- a/crates/near-kit/src/client/nonce_manager.rs
+++ b/crates/near-kit/src/client/nonce_manager.rs
@@ -33,12 +33,15 @@ impl NonceManager {
         }
     }
 
-    /// Get the next nonce for an account and public key.
+    /// Get the next nonce for an account and public key on a specific network.
     ///
     /// Fetches from blockchain on first call, then increments atomically.
+    /// Nonces are cached per `(network, account_id, public_key)` tuple so the
+    /// same signer used against different RPC endpoints won't share state.
     ///
     /// # Arguments
     ///
+    /// * `network` - Network identifier (typically the RPC URL) used to scope the cache
     /// * `account_id` - Account ID to get nonce for
     /// * `public_key` - Public key string (e.g., "ed25519:...")
     /// * `fetch_from_blockchain` - Callback to fetch current nonce from blockchain
@@ -87,10 +90,11 @@ impl NonceManager {
         Ok(next_nonce)
     }
 
-    /// Invalidate cached nonce for an account and public key.
+    /// Invalidate cached nonce for an account and public key on a specific network.
     ///
     /// Call this when an InvalidNonceError occurs to force a fresh fetch
-    /// from the blockchain on the next transaction.
+    /// from the blockchain on the next transaction. The `network` parameter
+    /// must match the value used when the nonce was originally cached.
     #[allow(dead_code)]
     pub fn invalidate(&self, network: &str, account_id: &str, public_key: &str) {
         let key = format!("{}:{}:{}", network, account_id, public_key);
@@ -98,7 +102,7 @@ impl NonceManager {
         nonces.remove(&key);
     }
 
-    /// Update the cached nonce to a known value.
+    /// Update the cached nonce to a known value on a specific network.
     ///
     /// Use this when you receive an InvalidNonce error with `ak_nonce` -
     /// instead of invalidating and refetching, directly set the nonce
@@ -106,6 +110,7 @@ impl NonceManager {
     ///
     /// # Arguments
     ///
+    /// * `network` - Network identifier (typically the RPC URL) used to scope the cache
     /// * `account_id` - Account ID
     /// * `public_key` - Public key string (e.g., "ed25519:...")
     /// * `current_nonce` - The current nonce on chain (ak_nonce from error)

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -168,6 +168,7 @@ impl TransactionBuilder {
         rpc: Arc<RpcClient>,
         signer: Option<Arc<dyn Signer>>,
         receiver_id: AccountId,
+        max_nonce_retries: u32,
     ) -> Self {
         Self {
             rpc,
@@ -176,7 +177,7 @@ impl TransactionBuilder {
             actions: Vec::new(),
             signer_override: None,
             wait_until: TxExecutionStatus::ExecutedOptimistic,
-            max_nonce_retries: 3,
+            max_nonce_retries,
         }
     }
 
@@ -650,19 +651,6 @@ impl TransactionBuilder {
         self
     }
 
-    /// Set the maximum number of nonce retries on `InvalidNonce` errors.
-    ///
-    /// When a transaction fails with `InvalidNonce`, the builder automatically
-    /// retries with the corrected nonce from the error response. This controls
-    /// how many times that retry is attempted before giving up.
-    ///
-    /// Defaults to `3`. For high-contention relayer scenarios, consider setting
-    /// this higher (e.g., `u32::MAX`) and wrapping in `tokio::timeout` instead.
-    pub fn max_nonce_retries(mut self, retries: u32) -> Self {
-        self.max_nonce_retries = retries;
-        self
-    }
-
     // ========================================================================
     // Execution
     // ========================================================================
@@ -1051,13 +1039,6 @@ impl CallBuilder {
         self.finish().wait_until(status)
     }
 
-    /// Set the maximum number of nonce retries on `InvalidNonce` errors.
-    ///
-    /// See [`TransactionBuilder::max_nonce_retries`] for details.
-    pub fn max_nonce_retries(self, retries: u32) -> TransactionBuilder {
-        self.finish().max_nonce_retries(retries)
-    }
-
     /// Build and sign a delegate action for meta-transactions (NEP-366).
     ///
     /// This finishes the current function call and then creates a delegate action.
@@ -1111,14 +1092,6 @@ impl TransactionSend {
     /// Set the execution wait level.
     pub fn wait_until(mut self, status: TxExecutionStatus) -> Self {
         self.builder.wait_until = status;
-        self
-    }
-
-    /// Set the maximum number of nonce retries on `InvalidNonce` errors.
-    ///
-    /// See [`TransactionBuilder::max_nonce_retries`] for details.
-    pub fn max_nonce_retries(mut self, retries: u32) -> Self {
-        self.builder.max_nonce_retries = retries;
         self
     }
 }

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -160,6 +160,7 @@ pub struct TransactionBuilder {
     actions: Vec<Action>,
     signer_override: Option<Arc<dyn Signer>>,
     wait_until: TxExecutionStatus,
+    max_nonce_retries: u32,
 }
 
 impl TransactionBuilder {
@@ -175,6 +176,7 @@ impl TransactionBuilder {
             actions: Vec::new(),
             signer_override: None,
             wait_until: TxExecutionStatus::ExecutedOptimistic,
+            max_nonce_retries: 3,
         }
     }
 
@@ -648,6 +650,19 @@ impl TransactionBuilder {
         self
     }
 
+    /// Set the maximum number of nonce retries on `InvalidNonce` errors.
+    ///
+    /// When a transaction fails with `InvalidNonce`, the builder automatically
+    /// retries with the corrected nonce from the error response. This controls
+    /// how many times that retry is attempted before giving up.
+    ///
+    /// Defaults to `3`. For high-contention relayer scenarios, consider setting
+    /// this higher (e.g., `u32::MAX`) and wrapping in `tokio::timeout` instead.
+    pub fn max_nonce_retries(mut self, retries: u32) -> Self {
+        self.max_nonce_retries = retries;
+        self
+    }
+
     // ========================================================================
     // Execution
     // ========================================================================
@@ -697,11 +712,12 @@ impl TransactionBuilder {
 
         // Get nonce for the key
         let rpc = self.rpc.clone();
+        let network = rpc.url().to_string();
         let signer_id_clone = signer_id.clone();
         let public_key_clone = public_key.clone();
 
         let nonce = nonce_manager()
-            .get_next_nonce(signer_id.as_ref(), &public_key_str, || async {
+            .get_next_nonce(&network, signer_id.as_ref(), &public_key_str, || async {
                 let access_key = rpc
                     .view_access_key(
                         &signer_id_clone,
@@ -1035,6 +1051,13 @@ impl CallBuilder {
         self.finish().wait_until(status)
     }
 
+    /// Set the maximum number of nonce retries on `InvalidNonce` errors.
+    ///
+    /// See [`TransactionBuilder::max_nonce_retries`] for details.
+    pub fn max_nonce_retries(self, retries: u32) -> TransactionBuilder {
+        self.finish().max_nonce_retries(retries)
+    }
+
     /// Build and sign a delegate action for meta-transactions (NEP-366).
     ///
     /// This finishes the current function call and then creates a delegate action.
@@ -1090,6 +1113,14 @@ impl TransactionSend {
         self.builder.wait_until = status;
         self
     }
+
+    /// Set the maximum number of nonce retries on `InvalidNonce` errors.
+    ///
+    /// See [`TransactionBuilder::max_nonce_retries`] for details.
+    pub fn max_nonce_retries(mut self, retries: u32) -> Self {
+        self.builder.max_nonce_retries = retries;
+        self
+    }
 }
 
 impl IntoFuture for TransactionSend {
@@ -1115,11 +1146,12 @@ impl IntoFuture for TransactionSend {
             let signer_id = signer.account_id().clone();
 
             // Retry loop for InvalidNonceError
-            const MAX_NONCE_RETRIES: u32 = 3;
+            let max_nonce_retries = builder.max_nonce_retries;
+            let network = builder.rpc.url().to_string();
             let mut last_error: Option<Error> = None;
             let mut last_ak_nonce: Option<u64> = None;
 
-            for attempt in 0..MAX_NONCE_RETRIES {
+            for attempt in 0..max_nonce_retries {
                 // Get a signing key atomically for this attempt
                 let key = signer.key();
                 let public_key = key.public_key().clone();
@@ -1133,13 +1165,14 @@ impl IntoFuture for TransactionSend {
                 let nonce = if let Some(ak_nonce) = last_ak_nonce.take() {
                     // Use the ak_nonce from the error directly - avoids refetching
                     nonce_manager().update_and_get_next(
+                        &network,
                         signer_id.as_ref(),
                         &public_key_str,
                         ak_nonce,
                     )
                 } else {
                     nonce_manager()
-                        .get_next_nonce(signer_id.as_ref(), &public_key_str, || async {
+                        .get_next_nonce(&network, signer_id.as_ref(), &public_key_str, || async {
                             let access_key = rpc
                                 .view_access_key(
                                     &signer_id_clone,
@@ -1197,7 +1230,7 @@ impl IntoFuture for TransactionSend {
                         return Ok(outcome);
                     }
                     Err(RpcError::InvalidNonce { tx_nonce, ak_nonce })
-                        if attempt < MAX_NONCE_RETRIES - 1 =>
+                        if attempt < max_nonce_retries - 1 =>
                     {
                         // Store ak_nonce for next iteration to avoid refetching
                         last_ak_nonce = Some(ak_nonce);

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -54,6 +54,7 @@ pub struct FungibleToken {
     contract_id: AccountId,
     metadata: OnceCell<FtMetadata>,
     storage_bounds: OnceCell<StorageBalanceBounds>,
+    max_nonce_retries: u32,
 }
 
 impl FungibleToken {
@@ -62,6 +63,7 @@ impl FungibleToken {
         rpc: Arc<RpcClient>,
         signer: Option<Arc<dyn Signer>>,
         contract_id: AccountId,
+        max_nonce_retries: u32,
     ) -> Self {
         Self {
             rpc,
@@ -69,6 +71,7 @@ impl FungibleToken {
             contract_id,
             metadata: OnceCell::new(),
             storage_bounds: OnceCell::new(),
+            max_nonce_retries,
         }
     }
 
@@ -83,6 +86,7 @@ impl FungibleToken {
             self.rpc.clone(),
             self.signer.clone(),
             self.contract_id.clone(),
+            self.max_nonce_retries,
         )
     }
 
@@ -394,6 +398,7 @@ impl Clone for FungibleToken {
             contract_id: self.contract_id.clone(),
             metadata: OnceCell::new(),
             storage_bounds: OnceCell::new(),
+            max_nonce_retries: self.max_nonce_retries,
         }
     }
 }

--- a/crates/near-kit/src/tokens/nft.rs
+++ b/crates/near-kit/src/tokens/nft.rs
@@ -51,6 +51,7 @@ pub struct NonFungibleToken {
     signer: Option<Arc<dyn Signer>>,
     contract_id: AccountId,
     metadata: OnceCell<NftContractMetadata>,
+    max_nonce_retries: u32,
 }
 
 impl NonFungibleToken {
@@ -59,12 +60,14 @@ impl NonFungibleToken {
         rpc: Arc<RpcClient>,
         signer: Option<Arc<dyn Signer>>,
         contract_id: AccountId,
+        max_nonce_retries: u32,
     ) -> Self {
         Self {
             rpc,
             signer,
             contract_id,
             metadata: OnceCell::new(),
+            max_nonce_retries,
         }
     }
 
@@ -79,6 +82,7 @@ impl NonFungibleToken {
             self.rpc.clone(),
             self.signer.clone(),
             self.contract_id.clone(),
+            self.max_nonce_retries,
         )
     }
 
@@ -406,6 +410,7 @@ impl Clone for NonFungibleToken {
             signer: self.signer.clone(),
             contract_id: self.contract_id.clone(),
             metadata: OnceCell::new(),
+            max_nonce_retries: self.max_nonce_retries,
         }
     }
 }


### PR DESCRIPTION
## Summary

Based on feedback from the Defuse relayer team ([Slack thread](https://nearone.slack.com/archives/C0A64SAMDNG/p1773338797364559?thread_ts=1772251935.612039&cid=C0A64SAMDNG)):

- **Configurable `max_nonce_retries`**: adds `.max_nonce_retries(n)` on `NearBuilder` to control how many times `InvalidNonce` errors are retried. Defaults to 3 (unchanged behavior). High-contention relayer callers can set `u32::MAX` and wrap in `tokio::timeout` instead of counting attempts. Panics if set to 0.

- **Network-scoped nonce cache**: the global nonce cache now keys by `(rpc_url, account_id, public_key)` instead of just `(account_id, public_key)`, preventing cross-network nonce contamination when the same signer is used against multiple networks in the same process.

## Usage

```rust
// Relayer-style: retry indefinitely, rely on external timeout
let near = Near::mainnet()
    .credentials("ed25519:...", "relayer.near")?
    .max_nonce_retries(u32::MAX)
    .build();

// All transactions from this client will retry on InvalidNonce
near.transaction("receiver.near")
    .transfer(NearToken::near(1))
    .send()
    .await?;
```

## Test plan

- [x] All 361 existing unit tests pass
- [x] New `test_nonce_manager_different_networks` test verifies network isolation
- [x] Pre-commit hooks (clippy + rustfmt) pass