### PR TITLE
fix: make CallBuilder::finish() public for conditional action building

### DIFF
--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -926,7 +926,11 @@ impl CallBuilder {
     }
 
     /// Finish this call and return to the transaction builder.
-    fn finish(self) -> TransactionBuilder {
+    ///
+    /// This is useful when you need to conditionally add actions to a
+    /// transaction, since it gives back the [`TransactionBuilder`] so you can
+    /// branch on runtime state before starting the next action.
+    pub fn finish(self) -> TransactionBuilder {
         let mut builder = self.builder;
         builder.push_action(Action::function_call(
             self.method,


### PR DESCRIPTION
Closes #47

## Summary

- Makes `CallBuilder::finish()` public so callers can drop back to the `TransactionBuilder` mid-chain and conditionally add further actions.
- Adds a doc comment explaining the use case.

## Motivation

Every method on `CallBuilder` either chains another action or sends the transaction. There is no way to "pause" mid-build and branch on runtime state. Making `finish()` public enables this pattern:

```rust
let mut tx = client
    .call("contract.near", "init")
    .args_json(json!({ "owner": "alice.near" }))
    .deposit(NearToken::from_near(1))
    .finish();  // return to TransactionBuilder

if needs_upgrade {
    tx = tx.deploy(wasm_bytes);
}

if let Some(key) = access_key {
    tx = tx.add_key(key, AccessKeyPermission::FullAccess);
}

let outcome = tx.send().await?;
```

`finish()` was already called internally by every chaining method on `CallBuilder`, so this is purely a visibility change with no behavior difference for existing callers.

## Test plan

- [x] `cargo check` passes
- [x] Pre-commit hooks (clippy + rustfmt) pass