### PR TITLE
Replace impl AsRef<str> with impl TryInto<AccountId> for account ID params

### DIFF
--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -277,10 +277,10 @@ fn generate_view_method(method: &MethodInfo, contract_format: SerializationForma
         };
 
         quote! {
-            pub fn #method_name(&self, #arg_name: #arg_type) -> #view_return_type {
-                self.near.view::<#return_type>(&self.contract_id, #method_name_str)
+            pub fn #method_name(&self, #arg_name: #arg_type) -> Result<#view_return_type, near_kit::Error> {
+                Ok(self.near.view::<#return_type>(&self.contract_id, #method_name_str)?
                     #args_method
-                    #borsh_suffix
+                    #borsh_suffix)
             }
         }
     } else {
@@ -288,17 +288,17 @@ fn generate_view_method(method: &MethodInfo, contract_format: SerializationForma
         match format {
             SerializationFormat::Json => {
                 quote! {
-                    pub fn #method_name(&self) -> #view_return_type {
-                        self.near.view::<#return_type>(&self.contract_id, #method_name_str)
-                            .args(serde_json::json!({}))
+                    pub fn #method_name(&self) -> Result<#view_return_type, near_kit::Error> {
+                        Ok(self.near.view::<#return_type>(&self.contract_id, #method_name_str)?
+                            .args(serde_json::json!({})))
                     }
                 }
             }
             SerializationFormat::Borsh => {
                 quote! {
-                    pub fn #method_name(&self) -> #view_return_type {
-                        self.near.view::<#return_type>(&self.contract_id, #method_name_str)
-                            .borsh()
+                    pub fn #method_name(&self) -> Result<#view_return_type, near_kit::Error> {
+                        Ok(self.near.view::<#return_type>(&self.contract_id, #method_name_str)?
+                            .borsh())
                     }
                 }
             }
@@ -322,9 +322,9 @@ fn generate_call_method(method: &MethodInfo, contract_format: SerializationForma
         };
 
         quote! {
-            pub fn #method_name(&self, #arg_name: #arg_type) -> near_kit::CallBuilder {
-                self.near.call(&self.contract_id, #method_name_str)
-                    #args_method
+            pub fn #method_name(&self, #arg_name: #arg_type) -> Result<near_kit::CallBuilder, near_kit::Error> {
+                Ok(self.near.call(&self.contract_id, #method_name_str)?
+                    #args_method)
             }
         }
     } else {
@@ -332,16 +332,16 @@ fn generate_call_method(method: &MethodInfo, contract_format: SerializationForma
         match format {
             SerializationFormat::Json => {
                 quote! {
-                    pub fn #method_name(&self) -> near_kit::CallBuilder {
-                        self.near.call(&self.contract_id, #method_name_str)
-                            .args(serde_json::json!({}))
+                    pub fn #method_name(&self) -> Result<near_kit::CallBuilder, near_kit::Error> {
+                        Ok(self.near.call(&self.contract_id, #method_name_str)?
+                            .args(serde_json::json!({})))
                     }
                 }
             }
             SerializationFormat::Borsh => {
                 quote! {
-                    pub fn #method_name(&self) -> near_kit::CallBuilder {
-                        self.near.call(&self.contract_id, #method_name_str)
+                    pub fn #method_name(&self) -> Result<near_kit::CallBuilder, near_kit::Error> {
+                        Ok(self.near.call(&self.contract_id, #method_name_str)?)
                     }
                 }
             }

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -307,9 +307,12 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn balance(&self, account_id: impl AsRef<str>) -> BalanceQuery {
-        let account_id = AccountId::parse_lenient(account_id);
-        BalanceQuery::new(self.rpc.clone(), account_id)
+    pub fn balance(
+        &self,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<BalanceQuery, Error> {
+        let account_id = account_id.try_into().map_err(Into::into)?;
+        Ok(BalanceQuery::new(self.rpc.clone(), account_id))
     }
 
     /// Get full account information.
@@ -325,9 +328,12 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn account(&self, account_id: impl AsRef<str>) -> AccountQuery {
-        let account_id = AccountId::parse_lenient(account_id);
-        AccountQuery::new(self.rpc.clone(), account_id)
+    pub fn account(
+        &self,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<AccountQuery, Error> {
+        let account_id = account_id.try_into().map_err(Into::into)?;
+        Ok(AccountQuery::new(self.rpc.clone(), account_id))
     }
 
     /// Check if an account exists.
@@ -344,9 +350,12 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn account_exists(&self, account_id: impl AsRef<str>) -> AccountExistsQuery {
-        let account_id = AccountId::parse_lenient(account_id);
-        AccountExistsQuery::new(self.rpc.clone(), account_id)
+    pub fn account_exists(
+        &self,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<AccountExistsQuery, Error> {
+        let account_id = account_id.try_into().map_err(Into::into)?;
+        Ok(AccountExistsQuery::new(self.rpc.clone(), account_id))
     }
 
     /// Call a view function on a contract.
@@ -371,9 +380,17 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn view<T>(&self, contract_id: impl AsRef<str>, method: &str) -> ViewCall<T> {
-        let contract_id = AccountId::parse_lenient(contract_id);
-        ViewCall::new(self.rpc.clone(), contract_id, method.to_string())
+    pub fn view<T>(
+        &self,
+        contract_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+        method: &str,
+    ) -> Result<ViewCall<T>, Error> {
+        let contract_id = contract_id.try_into().map_err(Into::into)?;
+        Ok(ViewCall::new(
+            self.rpc.clone(),
+            contract_id,
+            method.to_string(),
+        ))
     }
 
     /// Get all access keys for an account.
@@ -391,9 +408,12 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn access_keys(&self, account_id: impl AsRef<str>) -> AccessKeysQuery {
-        let account_id = AccountId::parse_lenient(account_id);
-        AccessKeysQuery::new(self.rpc.clone(), account_id)
+    pub fn access_keys(
+        &self,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<AccessKeysQuery, Error> {
+        let account_id = account_id.try_into().map_err(Into::into)?;
+        Ok(AccessKeysQuery::new(self.rpc.clone(), account_id))
     }
 
     // ========================================================================
@@ -472,10 +492,10 @@ impl Near {
     /// ```
     pub fn transfer(
         &self,
-        receiver: impl AsRef<str>,
+        receiver: impl TryInto<AccountId, Error = impl Into<Error>>,
         amount: impl IntoNearToken,
-    ) -> TransactionBuilder {
-        self.transaction(receiver).transfer(amount)
+    ) -> Result<TransactionBuilder, Error> {
+        Ok(self.transaction(receiver)?.transfer(amount))
     }
 
     /// Call a function on a contract.
@@ -504,8 +524,12 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn call(&self, contract_id: impl AsRef<str>, method: &str) -> CallBuilder {
-        self.transaction(contract_id).call(method)
+    pub fn call(
+        &self,
+        contract_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+        method: &str,
+    ) -> Result<CallBuilder, Error> {
+        Ok(self.transaction(contract_id)?.call(method))
     }
 
     /// Deploy a contract.
@@ -526,28 +550,30 @@ impl Near {
     /// ```
     pub fn deploy(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         code: impl Into<Vec<u8>>,
-    ) -> TransactionBuilder {
-        self.transaction(account_id).deploy(code)
+    ) -> Result<TransactionBuilder, Error> {
+        Ok(self.transaction(account_id)?.deploy(code))
     }
 
     /// Add a full access key to an account.
     pub fn add_full_access_key(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         public_key: PublicKey,
-    ) -> TransactionBuilder {
-        self.transaction(account_id).add_full_access_key(public_key)
+    ) -> Result<TransactionBuilder, Error> {
+        Ok(self
+            .transaction(account_id)?
+            .add_full_access_key(public_key))
     }
 
     /// Delete an access key from an account.
     pub fn delete_key(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         public_key: PublicKey,
-    ) -> TransactionBuilder {
-        self.transaction(account_id).delete_key(public_key)
+    ) -> Result<TransactionBuilder, Error> {
+        Ok(self.transaction(account_id)?.delete_key(public_key))
     }
 
     // ========================================================================
@@ -588,14 +614,17 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn transaction(&self, receiver_id: impl AsRef<str>) -> TransactionBuilder {
-        let receiver_id = AccountId::parse_lenient(receiver_id);
-        TransactionBuilder::new(
+    pub fn transaction(
+        &self,
+        receiver_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<TransactionBuilder, Error> {
+        let receiver_id = receiver_id.try_into().map_err(Into::into)?;
+        Ok(TransactionBuilder::new(
             self.rpc.clone(),
             self.signer.clone(),
             receiver_id,
             self.max_nonce_retries,
-        )
+        ))
     }
 
     /// Send a pre-signed transaction.
@@ -661,36 +690,33 @@ impl Near {
     /// Call a view function with arguments (convenience method).
     pub async fn view_with_args<T: DeserializeOwned + Send + 'static, A: serde::Serialize>(
         &self,
-        contract_id: impl AsRef<str>,
+        contract_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         method: &str,
         args: &A,
     ) -> Result<T, Error> {
-        let contract_id = AccountId::parse_lenient(contract_id);
-        ViewCall::new(self.rpc.clone(), contract_id, method.to_string())
-            .args(args)
-            .await
+        self.view(contract_id, method)?.args(args).await
     }
 
     /// Call a function with arguments (convenience method).
     pub async fn call_with_args<A: serde::Serialize>(
         &self,
-        contract_id: impl AsRef<str>,
+        contract_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         method: &str,
         args: &A,
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        self.call(contract_id, method).args(args).await
+        self.call(contract_id, method)?.args(args).await
     }
 
     /// Call a function with full options (convenience method).
     pub async fn call_with_options<A: serde::Serialize>(
         &self,
-        contract_id: impl AsRef<str>,
+        contract_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         method: &str,
         args: &A,
         gas: Gas,
         deposit: NearToken,
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        self.call(contract_id, method)
+        self.call(contract_id, method)?
             .args(args)
             .gas(gas)
             .deposit(deposit)
@@ -743,10 +769,10 @@ impl Near {
     /// ```
     pub fn contract<T: crate::Contract + ?Sized>(
         &self,
-        contract_id: impl AsRef<str>,
-    ) -> T::Client<'_> {
-        let contract_id = AccountId::parse_lenient(contract_id);
-        T::Client::new(self, contract_id)
+        contract_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<T::Client<'_>, Error> {
+        let contract_id = contract_id.try_into().map_err(Into::into)?;
+        Ok(T::Client::new(self, contract_id))
     }
 
     // ========================================================================
@@ -911,7 +937,7 @@ impl NearBuilder {
     pub fn credentials(
         mut self,
         private_key: impl AsRef<str>,
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
     ) -> Result<Self, Error> {
         let signer = InMemorySigner::new(account_id, private_key)?;
         self.signer = Some(Arc::new(signer));

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -274,10 +274,10 @@ impl InMemorySigner {
     ///
     /// Returns an error if the account ID or secret key cannot be parsed.
     pub fn new(
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<crate::error::Error>>,
         secret_key: impl AsRef<str>,
     ) -> Result<Self, crate::error::Error> {
-        let account_id: AccountId = account_id.as_ref().parse()?;
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
         let secret_key: SecretKey = secret_key.as_ref().parse()?;
         let public_key = secret_key.public_key();
 
@@ -318,10 +318,10 @@ impl InMemorySigner {
     /// ).unwrap();
     /// ```
     pub fn from_seed_phrase(
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<crate::error::Error>>,
         phrase: impl AsRef<str>,
     ) -> Result<Self, crate::error::Error> {
-        let account_id: AccountId = account_id.as_ref().parse()?;
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
         let secret_key = SecretKey::from_seed_phrase(phrase)?;
         Ok(Self::from_secret_key(account_id, secret_key))
     }
@@ -346,11 +346,11 @@ impl InMemorySigner {
     /// ).unwrap();
     /// ```
     pub fn from_seed_phrase_with_path(
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<crate::error::Error>>,
         phrase: impl AsRef<str>,
         hd_path: impl AsRef<str>,
     ) -> Result<Self, crate::error::Error> {
-        let account_id: AccountId = account_id.as_ref().parse()?;
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
         let secret_key = SecretKey::from_seed_phrase_with_path(phrase, hd_path)?;
         Ok(Self::from_secret_key(account_id, secret_key))
     }
@@ -426,15 +426,16 @@ impl FileSigner {
     /// - The file cannot be parsed
     pub fn new(
         network: impl AsRef<str>,
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<crate::error::Error>>,
     ) -> Result<Self, crate::error::Error> {
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
         let home = dirs::home_dir().ok_or_else(|| {
             crate::error::Error::Config("Could not determine home directory".to_string())
         })?;
         let path = home
             .join(".near-credentials")
             .join(network.as_ref())
-            .join(format!("{}.json", account_id.as_ref()));
+            .join(format!("{}.json", account_id.as_str()));
 
         Self::from_file(&path, account_id)
     }
@@ -447,7 +448,7 @@ impl FileSigner {
     /// * `account_id` - The NEAR account ID
     pub fn from_file(
         path: impl AsRef<Path>,
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<crate::error::Error>>,
     ) -> Result<Self, crate::error::Error> {
         let content = std::fs::read_to_string(path.as_ref()).map_err(|e| {
             crate::error::Error::Config(format!(
@@ -465,6 +466,7 @@ impl FileSigner {
             ))
         })?;
 
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
         let inner = InMemorySigner::new(account_id, &cred.private_key)?;
         Ok(Self { inner })
     }
@@ -658,7 +660,7 @@ impl RotatingSigner {
     /// - The account ID cannot be parsed
     /// - The keys vector is empty
     pub fn new(
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<crate::error::Error>>,
         keys: Vec<SecretKey>,
     ) -> Result<Self, crate::error::Error> {
         if keys.is_empty() {
@@ -667,7 +669,7 @@ impl RotatingSigner {
             ));
         }
 
-        let account_id: AccountId = account_id.as_ref().parse()?;
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
 
         Ok(Self {
             account_id,
@@ -727,7 +729,7 @@ impl RotatingSigner {
     /// * `account_id` - The NEAR account ID
     /// * `keys` - Slice of secret keys in string format (e.g., "ed25519:...")
     pub fn from_key_strings(
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<crate::error::Error>>,
         keys: &[impl AsRef<str>],
     ) -> Result<Self, crate::error::Error> {
         let parsed_keys: Result<Vec<SecretKey>, _> =

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -272,18 +272,18 @@ impl TransactionBuilder {
     pub fn add_function_call_key(
         mut self,
         public_key: PublicKey,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         method_names: Vec<String>,
         allowance: Option<NearToken>,
-    ) -> Self {
-        let receiver_id = AccountId::parse_lenient(receiver_id);
+    ) -> Result<Self, Error> {
+        let receiver_id = receiver_id.try_into().map_err(Into::into)?;
         self.actions.push(Action::add_function_call_key(
             public_key,
             receiver_id,
             method_names,
             allowance,
         ));
-        self
+        Ok(self)
     }
 
     /// Delete an access key from the account.
@@ -293,10 +293,13 @@ impl TransactionBuilder {
     }
 
     /// Delete the account and transfer remaining balance to beneficiary.
-    pub fn delete_account(mut self, beneficiary_id: impl AsRef<str>) -> Self {
-        let beneficiary_id = AccountId::parse_lenient(beneficiary_id);
+    pub fn delete_account(
+        mut self,
+        beneficiary_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<Self, Error> {
+        let beneficiary_id = beneficiary_id.try_into().map_err(Into::into)?;
         self.actions.push(Action::delete_account(beneficiary_id));
-        self
+        Ok(self)
     }
 
     /// Add a stake action.
@@ -535,10 +538,13 @@ impl TransactionBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn deploy_from_publisher(mut self, publisher_id: impl AsRef<str>) -> Self {
-        let publisher_id = AccountId::parse_lenient(publisher_id);
+    pub fn deploy_from_publisher(
+        mut self,
+        publisher_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<Self, Error> {
+        let publisher_id = publisher_id.try_into().map_err(Into::into)?;
         self.actions.push(Action::deploy_from_account(publisher_id));
-        self
+        Ok(self)
     }
 
     /// Create a NEP-616 deterministic state init action with code hash reference.
@@ -612,11 +618,11 @@ impl TransactionBuilder {
     /// Panics if the deposit amount string cannot be parsed.
     pub fn state_init_by_publisher(
         mut self,
-        publisher_id: impl AsRef<str>,
+        publisher_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         data: BTreeMap<Vec<u8>, Vec<u8>>,
         deposit: impl IntoNearToken,
-    ) -> Self {
-        let publisher_id = AccountId::parse_lenient(publisher_id);
+    ) -> Result<Self, Error> {
+        let publisher_id = publisher_id.try_into().map_err(Into::into)?;
         let deposit = deposit
             .into_near_token()
             .expect("invalid deposit amount - use NearToken::from_str() for user input");
@@ -632,7 +638,7 @@ impl TransactionBuilder {
 
         self.actions
             .push(Action::state_init_by_account(publisher_id, data, deposit));
-        self
+        Ok(self)
     }
 
     // ========================================================================
@@ -970,10 +976,10 @@ impl CallBuilder {
     pub fn add_function_call_key(
         self,
         public_key: PublicKey,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         method_names: Vec<String>,
         allowance: Option<NearToken>,
-    ) -> TransactionBuilder {
+    ) -> Result<TransactionBuilder, Error> {
         self.finish()
             .add_function_call_key(public_key, receiver_id, method_names, allowance)
     }
@@ -984,7 +990,10 @@ impl CallBuilder {
     }
 
     /// Delete the account.
-    pub fn delete_account(self, beneficiary_id: impl AsRef<str>) -> TransactionBuilder {
+    pub fn delete_account(
+        self,
+        beneficiary_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<TransactionBuilder, Error> {
         self.finish().delete_account(beneficiary_id)
     }
 
@@ -1004,7 +1013,10 @@ impl CallBuilder {
     }
 
     /// Deploy a contract from the global registry by publisher account.
-    pub fn deploy_from_publisher(self, publisher_id: impl AsRef<str>) -> TransactionBuilder {
+    pub fn deploy_from_publisher(
+        self,
+        publisher_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<TransactionBuilder, Error> {
         self.finish().deploy_from_publisher(publisher_id)
     }
 
@@ -1021,10 +1033,10 @@ impl CallBuilder {
     /// Create a NEP-616 deterministic state init action with publisher account reference.
     pub fn state_init_by_publisher(
         self,
-        publisher_id: impl AsRef<str>,
+        publisher_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         data: BTreeMap<Vec<u8>, Vec<u8>>,
         deposit: impl IntoNearToken,
-    ) -> TransactionBuilder {
+    ) -> Result<TransactionBuilder, Error> {
         self.finish()
             .state_init_by_publisher(publisher_id, data, deposit)
     }

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -454,6 +454,12 @@ pub enum Error {
     TokenNotAvailable { token: String, network: String },
 }
 
+impl From<std::convert::Infallible> for Error {
+    fn from(e: std::convert::Infallible) -> Self {
+        match e {}
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -133,7 +133,11 @@ impl FungibleToken {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn balance_of(&self, account_id: impl AsRef<str>) -> Result<FtAmount, Error> {
+    pub async fn balance_of(
+        &self,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<FtAmount, Error> {
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
         let metadata = self.metadata().await?;
 
         #[derive(Serialize)]
@@ -142,7 +146,7 @@ impl FungibleToken {
         }
 
         let args = serde_json::to_vec(&Args {
-            account_id: account_id.as_ref(),
+            account_id: account_id.as_str(),
         })?;
 
         let result = self
@@ -201,7 +205,10 @@ impl FungibleToken {
     ///
     /// An account must be registered (via `storage_deposit`) before it can
     /// receive tokens.
-    pub async fn is_registered(&self, account_id: impl AsRef<str>) -> Result<bool, Error> {
+    pub async fn is_registered(
+        &self,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<bool, Error> {
         let balance = self.storage_balance_of(account_id).await?;
         Ok(balance.is_some())
     }
@@ -211,15 +218,17 @@ impl FungibleToken {
     /// Returns `None` if the account is not registered.
     pub async fn storage_balance_of(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
     ) -> Result<Option<StorageBalance>, Error> {
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
+
         #[derive(Serialize)]
         struct Args<'a> {
             account_id: &'a str,
         }
 
         let args = serde_json::to_vec(&Args {
-            account_id: account_id.as_ref(),
+            account_id: account_id.as_str(),
         })?;
 
         let result = self
@@ -255,14 +264,18 @@ impl FungibleToken {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn storage_deposit(&self, account_id: impl AsRef<str>) -> StorageDepositCall {
-        StorageDepositCall::new(
+    pub fn storage_deposit(
+        &self,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<StorageDepositCall, Error> {
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
+        Ok(StorageDepositCall::new(
             self.rpc.clone(),
             self.signer.clone(),
             self.contract_id.clone(),
-            Some(account_id.as_ref().to_string()),
+            Some(account_id.to_string()),
             self.storage_bounds.clone(),
-        )
+        ))
     }
 
     // =========================================================================
@@ -298,21 +311,28 @@ impl FungibleToken {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn transfer(&self, receiver_id: impl AsRef<str>, amount: impl Into<u128>) -> CallBuilder {
+    pub fn transfer(
+        &self,
+        receiver_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+        amount: impl Into<u128>,
+    ) -> Result<CallBuilder, Error> {
+        let receiver_id: AccountId = receiver_id.try_into().map_err(Into::into)?;
+
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
             amount: String,
         }
 
-        self.transaction()
+        Ok(self
+            .transaction()
             .call("ft_transfer")
             .args(TransferArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.to_string(),
                 amount: amount.into().to_string(),
             })
             .deposit(NearToken::yocto(1))
-            .gas(Gas::tgas(30))
+            .gas(Gas::tgas(30)))
     }
 
     /// Transfer tokens with a memo (ft_transfer).
@@ -320,10 +340,12 @@ impl FungibleToken {
     /// Same as [`transfer`](Self::transfer) but with an optional memo field.
     pub fn transfer_with_memo(
         &self,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         amount: impl Into<u128>,
         memo: impl Into<String>,
-    ) -> CallBuilder {
+    ) -> Result<CallBuilder, Error> {
+        let receiver_id: AccountId = receiver_id.try_into().map_err(Into::into)?;
+
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -331,15 +353,16 @@ impl FungibleToken {
             memo: String,
         }
 
-        self.transaction()
+        Ok(self
+            .transaction()
             .call("ft_transfer")
             .args(TransferArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.to_string(),
                 amount: amount.into().to_string(),
                 memo: memo.into(),
             })
             .deposit(NearToken::yocto(1))
-            .gas(Gas::tgas(30))
+            .gas(Gas::tgas(30)))
     }
 
     /// Transfer tokens with a callback to the receiver (ft_transfer_call).
@@ -367,10 +390,12 @@ impl FungibleToken {
     /// ```
     pub fn transfer_call(
         &self,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         amount: impl Into<u128>,
         msg: impl Into<String>,
-    ) -> CallBuilder {
+    ) -> Result<CallBuilder, Error> {
+        let receiver_id: AccountId = receiver_id.try_into().map_err(Into::into)?;
+
         #[derive(Serialize)]
         struct TransferCallArgs {
             receiver_id: String,
@@ -378,15 +403,16 @@ impl FungibleToken {
             msg: String,
         }
 
-        self.transaction()
+        Ok(self
+            .transaction()
             .call("ft_transfer_call")
             .args(TransferCallArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.to_string(),
                 amount: amount.into().to_string(),
                 msg: msg.into(),
             })
             .deposit(NearToken::yocto(1))
-            .gas(Gas::tgas(100))
+            .gas(Gas::tgas(100)))
     }
 }
 

--- a/crates/near-kit/src/tokens/nft.rs
+++ b/crates/near-kit/src/tokens/nft.rs
@@ -180,10 +180,12 @@ impl NonFungibleToken {
     /// ```
     pub async fn tokens_for_owner(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         from_index: Option<u64>,
         limit: Option<u64>,
     ) -> Result<Vec<NftToken>, Error> {
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
+
         #[derive(Serialize)]
         struct Args<'a> {
             account_id: &'a str,
@@ -194,7 +196,7 @@ impl NonFungibleToken {
         }
 
         let args = serde_json::to_vec(&Args {
-            account_id: account_id.as_ref(),
+            account_id: account_id.as_str(),
             from_index: from_index.map(|i| i.to_string()),
             limit,
         })?;
@@ -235,14 +237,19 @@ impl NonFungibleToken {
     }
 
     /// Get token supply for an owner (nft_supply_for_owner).
-    pub async fn supply_for_owner(&self, account_id: impl AsRef<str>) -> Result<u64, Error> {
+    pub async fn supply_for_owner(
+        &self,
+        account_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+    ) -> Result<u64, Error> {
+        let account_id: AccountId = account_id.try_into().map_err(Into::into)?;
+
         #[derive(Serialize)]
         struct Args<'a> {
             account_id: &'a str,
         }
 
         let args = serde_json::to_vec(&Args {
-            account_id: account_id.as_ref(),
+            account_id: account_id.as_str(),
         })?;
 
         let result = self
@@ -290,21 +297,28 @@ impl NonFungibleToken {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn transfer(&self, receiver_id: impl AsRef<str>, token_id: impl AsRef<str>) -> CallBuilder {
+    pub fn transfer(
+        &self,
+        receiver_id: impl TryInto<AccountId, Error = impl Into<Error>>,
+        token_id: impl AsRef<str>,
+    ) -> Result<CallBuilder, Error> {
+        let receiver_id: AccountId = receiver_id.try_into().map_err(Into::into)?;
+
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
             token_id: String,
         }
 
-        self.transaction()
+        Ok(self
+            .transaction()
             .call("nft_transfer")
             .args(TransferArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.to_string(),
                 token_id: token_id.as_ref().to_string(),
             })
             .deposit(NearToken::yocto(1))
-            .gas(Gas::tgas(30))
+            .gas(Gas::tgas(30)))
     }
 
     /// Transfer an NFT with a memo (nft_transfer).
@@ -312,10 +326,12 @@ impl NonFungibleToken {
     /// Same as [`transfer`](Self::transfer) but with an optional memo field.
     pub fn transfer_with_memo(
         &self,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         token_id: impl AsRef<str>,
         memo: impl Into<String>,
-    ) -> CallBuilder {
+    ) -> Result<CallBuilder, Error> {
+        let receiver_id: AccountId = receiver_id.try_into().map_err(Into::into)?;
+
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -323,24 +339,27 @@ impl NonFungibleToken {
             memo: String,
         }
 
-        self.transaction()
+        Ok(self
+            .transaction()
             .call("nft_transfer")
             .args(TransferArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.to_string(),
                 token_id: token_id.as_ref().to_string(),
                 memo: memo.into(),
             })
             .deposit(NearToken::yocto(1))
-            .gas(Gas::tgas(30))
+            .gas(Gas::tgas(30)))
     }
 
     /// Transfer an NFT with approval ID (for approved transfers).
     pub fn transfer_with_approval(
         &self,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         token_id: impl AsRef<str>,
         approval_id: u64,
-    ) -> CallBuilder {
+    ) -> Result<CallBuilder, Error> {
+        let receiver_id: AccountId = receiver_id.try_into().map_err(Into::into)?;
+
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -348,15 +367,16 @@ impl NonFungibleToken {
             approval_id: u64,
         }
 
-        self.transaction()
+        Ok(self
+            .transaction()
             .call("nft_transfer")
             .args(TransferArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.to_string(),
                 token_id: token_id.as_ref().to_string(),
                 approval_id,
             })
             .deposit(NearToken::yocto(1))
-            .gas(Gas::tgas(30))
+            .gas(Gas::tgas(30)))
     }
 
     /// Transfer an NFT with a callback to the receiver (nft_transfer_call).
@@ -380,10 +400,12 @@ impl NonFungibleToken {
     /// ```
     pub fn transfer_call(
         &self,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl TryInto<AccountId, Error = impl Into<Error>>,
         token_id: impl AsRef<str>,
         msg: impl Into<String>,
-    ) -> CallBuilder {
+    ) -> Result<CallBuilder, Error> {
+        let receiver_id: AccountId = receiver_id.try_into().map_err(Into::into)?;
+
         #[derive(Serialize)]
         struct TransferCallArgs {
             receiver_id: String,
@@ -391,15 +413,16 @@ impl NonFungibleToken {
             msg: String,
         }
 
-        self.transaction()
+        Ok(self
+            .transaction()
             .call("nft_transfer_call")
             .args(TransferCallArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.to_string(),
                 token_id: token_id.as_ref().to_string(),
                 msg: msg.into(),
             })
             .deposit(NearToken::yocto(1))
-            .gas(Gas::tgas(100))
+            .gas(Gas::tgas(100)))
     }
 }
 

--- a/crates/near-kit/src/types/account.rs
+++ b/crates/near-kit/src/types/account.rs
@@ -198,6 +198,20 @@ impl TryFrom<String> for AccountId {
     }
 }
 
+impl TryFrom<&String> for AccountId {
+    type Error = ParseAccountIdError;
+
+    fn try_from(s: &String) -> Result<Self, Self::Error> {
+        Self::new(s.as_str())
+    }
+}
+
+impl From<&AccountId> for AccountId {
+    fn from(id: &AccountId) -> Self {
+        id.clone()
+    }
+}
+
 impl Display for AccountId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)


### PR DESCRIPTION
## Summary

- Migrates all public API methods from `impl AsRef<str>` to `impl TryInto<AccountId, Error = impl Into<Error>>` for account ID parameters
- Validates account IDs at the API boundary instead of silently accepting invalid IDs via `parse_lenient`
- Updates the `#[near_kit::contract]` proc macro so generated view/call methods return `Result`
- Adds `TryFrom<&String>`, `From<&AccountId>` for `AccountId`, and `From<Infallible>` for `Error` to support all conversion paths

**BREAKING CHANGE**: Methods that previously returned builders directly now return `Result<Builder, Error>`. Existing code using `&str` and `String` will continue to compile, but call sites that chain methods need `?` or `.unwrap()` after the newly fallible calls.

## Test plan

- [x] `cargo check` passes (library + default-feature tests)
- [x] All 361 unit tests pass (`cargo test --lib`)
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] Integration tests (sandbox) need updating for new Result-returning API — tracked separately

Closes #47