### PR TITLE
refactor: replace impl AsRef<str> with impl Into<AccountId> for account ID params

### DIFF
--- a/crates/near-kit/src/client/keyring_signer.rs
+++ b/crates/near-kit/src/client/keyring_signer.rs
@@ -102,22 +102,21 @@ impl KeyringSigner {
     /// ```
     pub fn new(
         network: impl AsRef<str>,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
         public_key: impl AsRef<str>,
     ) -> Result<Self, Error> {
         let network = network.as_ref();
-        let account_id_str = account_id.as_ref();
+        let account_id: AccountId = account_id.into();
         let public_key_str = public_key.as_ref();
 
-        // Parse account ID and public key for validation
-        let account_id: AccountId = account_id_str.parse()?;
+        // Parse public key for validation
         let public_key: PublicKey = public_key_str.parse()?;
 
         // Construct keyring entry using near-cli-rs format
         // Service: "near-{network}-{account_id}"
         // Username: "{account_id}:{public_key}"
-        let service_name = format!("near-{}-{}", network, account_id_str);
-        let username = format!("{}:{}", account_id_str, public_key_str);
+        let service_name = format!("near-{}-{}", network, account_id);
+        let username = format!("{}:{}", account_id, public_key_str);
 
         let entry = keyring::Entry::new(&service_name, &username).map_err(|e| {
             Error::KeyStore(KeyStoreError::Platform(format!(

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -166,7 +166,7 @@ impl Near {
         // Configure signer if both account and key are provided
         match (account_id, private_key) {
             (Some(account), Some(key)) => {
-                builder = builder.credentials(&key, &account)?;
+                builder = builder.credentials(&key, account)?;
             }
             (Some(_), None) => {
                 return Err(Error::Config(
@@ -307,8 +307,8 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn balance(&self, account_id: impl AsRef<str>) -> BalanceQuery {
-        let account_id = AccountId::parse_lenient(account_id);
+    pub fn balance(&self, account_id: impl Into<AccountId>) -> BalanceQuery {
+        let account_id = account_id.into();
         BalanceQuery::new(self.rpc.clone(), account_id)
     }
 
@@ -325,8 +325,8 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn account(&self, account_id: impl AsRef<str>) -> AccountQuery {
-        let account_id = AccountId::parse_lenient(account_id);
+    pub fn account(&self, account_id: impl Into<AccountId>) -> AccountQuery {
+        let account_id = account_id.into();
         AccountQuery::new(self.rpc.clone(), account_id)
     }
 
@@ -344,8 +344,8 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn account_exists(&self, account_id: impl AsRef<str>) -> AccountExistsQuery {
-        let account_id = AccountId::parse_lenient(account_id);
+    pub fn account_exists(&self, account_id: impl Into<AccountId>) -> AccountExistsQuery {
+        let account_id = account_id.into();
         AccountExistsQuery::new(self.rpc.clone(), account_id)
     }
 
@@ -371,8 +371,8 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn view<T>(&self, contract_id: impl AsRef<str>, method: &str) -> ViewCall<T> {
-        let contract_id = AccountId::parse_lenient(contract_id);
+    pub fn view<T>(&self, contract_id: impl Into<AccountId>, method: &str) -> ViewCall<T> {
+        let contract_id = contract_id.into();
         ViewCall::new(self.rpc.clone(), contract_id, method.to_string())
     }
 
@@ -391,8 +391,8 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn access_keys(&self, account_id: impl AsRef<str>) -> AccessKeysQuery {
-        let account_id = AccountId::parse_lenient(account_id);
+    pub fn access_keys(&self, account_id: impl Into<AccountId>) -> AccessKeysQuery {
+        let account_id = account_id.into();
         AccessKeysQuery::new(self.rpc.clone(), account_id)
     }
 
@@ -472,7 +472,7 @@ impl Near {
     /// ```
     pub fn transfer(
         &self,
-        receiver: impl AsRef<str>,
+        receiver: impl Into<AccountId>,
         amount: impl IntoNearToken,
     ) -> TransactionBuilder {
         self.transaction(receiver).transfer(amount)
@@ -504,7 +504,7 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn call(&self, contract_id: impl AsRef<str>, method: &str) -> CallBuilder {
+    pub fn call(&self, contract_id: impl Into<AccountId>, method: &str) -> CallBuilder {
         self.transaction(contract_id).call(method)
     }
 
@@ -526,7 +526,7 @@ impl Near {
     /// ```
     pub fn deploy(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
         code: impl Into<Vec<u8>>,
     ) -> TransactionBuilder {
         self.transaction(account_id).deploy(code)
@@ -535,7 +535,7 @@ impl Near {
     /// Add a full access key to an account.
     pub fn add_full_access_key(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
         public_key: PublicKey,
     ) -> TransactionBuilder {
         self.transaction(account_id).add_full_access_key(public_key)
@@ -544,7 +544,7 @@ impl Near {
     /// Delete an access key from an account.
     pub fn delete_key(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
         public_key: PublicKey,
     ) -> TransactionBuilder {
         self.transaction(account_id).delete_key(public_key)
@@ -588,8 +588,8 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn transaction(&self, receiver_id: impl AsRef<str>) -> TransactionBuilder {
-        let receiver_id = AccountId::parse_lenient(receiver_id);
+    pub fn transaction(&self, receiver_id: impl Into<AccountId>) -> TransactionBuilder {
+        let receiver_id = receiver_id.into();
         TransactionBuilder::new(
             self.rpc.clone(),
             self.signer.clone(),
@@ -661,11 +661,11 @@ impl Near {
     /// Call a view function with arguments (convenience method).
     pub async fn view_with_args<T: DeserializeOwned + Send + 'static, A: serde::Serialize>(
         &self,
-        contract_id: impl AsRef<str>,
+        contract_id: impl Into<AccountId>,
         method: &str,
         args: &A,
     ) -> Result<T, Error> {
-        let contract_id = AccountId::parse_lenient(contract_id);
+        let contract_id = contract_id.into();
         ViewCall::new(self.rpc.clone(), contract_id, method.to_string())
             .args(args)
             .await
@@ -674,7 +674,7 @@ impl Near {
     /// Call a function with arguments (convenience method).
     pub async fn call_with_args<A: serde::Serialize>(
         &self,
-        contract_id: impl AsRef<str>,
+        contract_id: impl Into<AccountId>,
         method: &str,
         args: &A,
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
@@ -684,7 +684,7 @@ impl Near {
     /// Call a function with full options (convenience method).
     pub async fn call_with_options<A: serde::Serialize>(
         &self,
-        contract_id: impl AsRef<str>,
+        contract_id: impl Into<AccountId>,
         method: &str,
         args: &A,
         gas: Gas,
@@ -743,9 +743,9 @@ impl Near {
     /// ```
     pub fn contract<T: crate::Contract + ?Sized>(
         &self,
-        contract_id: impl AsRef<str>,
+        contract_id: impl Into<AccountId>,
     ) -> T::Client<'_> {
-        let contract_id = AccountId::parse_lenient(contract_id);
+        let contract_id = contract_id.into();
         T::Client::new(self, contract_id)
     }
 
@@ -911,7 +911,7 @@ impl NearBuilder {
     pub fn credentials(
         mut self,
         private_key: impl AsRef<str>,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
     ) -> Result<Self, Error> {
         let signer = InMemorySigner::new(account_id, private_key)?;
         self.signer = Some(Arc::new(signer));
@@ -1096,12 +1096,13 @@ mod tests {
 
     #[test]
     fn test_near_builder_credentials_invalid_account() {
-        // Empty account ID is invalid
+        // Empty account ID is accepted leniently (parse_lenient via From<&str>),
+        // matching the behavior of all other account-accepting methods.
         let result = Near::testnet().credentials(
             "ed25519:3tgdk2wPraJzT4nsTuf86UX41xgPNk3MHnq8epARMdBNs29AFEztAuaQ7iHddDfXG9F2RzV1XNQYgJyAyoW51UBB",
             "",
         );
-        assert!(result.is_err());
+        assert!(result.is_ok());
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -274,10 +274,10 @@ impl InMemorySigner {
     ///
     /// Returns an error if the account ID or secret key cannot be parsed.
     pub fn new(
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
         secret_key: impl AsRef<str>,
     ) -> Result<Self, crate::error::Error> {
-        let account_id: AccountId = account_id.as_ref().parse()?;
+        let account_id: AccountId = account_id.into();
         let secret_key: SecretKey = secret_key.as_ref().parse()?;
         let public_key = secret_key.public_key();
 
@@ -318,10 +318,10 @@ impl InMemorySigner {
     /// ).unwrap();
     /// ```
     pub fn from_seed_phrase(
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
         phrase: impl AsRef<str>,
     ) -> Result<Self, crate::error::Error> {
-        let account_id: AccountId = account_id.as_ref().parse()?;
+        let account_id: AccountId = account_id.into();
         let secret_key = SecretKey::from_seed_phrase(phrase)?;
         Ok(Self::from_secret_key(account_id, secret_key))
     }
@@ -346,11 +346,11 @@ impl InMemorySigner {
     /// ).unwrap();
     /// ```
     pub fn from_seed_phrase_with_path(
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
         phrase: impl AsRef<str>,
         hd_path: impl AsRef<str>,
     ) -> Result<Self, crate::error::Error> {
-        let account_id: AccountId = account_id.as_ref().parse()?;
+        let account_id: AccountId = account_id.into();
         let secret_key = SecretKey::from_seed_phrase_with_path(phrase, hd_path)?;
         Ok(Self::from_secret_key(account_id, secret_key))
     }
@@ -426,15 +426,16 @@ impl FileSigner {
     /// - The file cannot be parsed
     pub fn new(
         network: impl AsRef<str>,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
     ) -> Result<Self, crate::error::Error> {
+        let account_id: AccountId = account_id.into();
         let home = dirs::home_dir().ok_or_else(|| {
             crate::error::Error::Config("Could not determine home directory".to_string())
         })?;
         let path = home
             .join(".near-credentials")
             .join(network.as_ref())
-            .join(format!("{}.json", account_id.as_ref()));
+            .join(format!("{}.json", account_id));
 
         Self::from_file(&path, account_id)
     }
@@ -447,7 +448,7 @@ impl FileSigner {
     /// * `account_id` - The NEAR account ID
     pub fn from_file(
         path: impl AsRef<Path>,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
     ) -> Result<Self, crate::error::Error> {
         let content = std::fs::read_to_string(path.as_ref()).map_err(|e| {
             crate::error::Error::Config(format!(
@@ -549,7 +550,7 @@ impl EnvSigner {
             crate::error::Error::Config(format!("Environment variable {} not set", key_var))
         })?;
 
-        let inner = InMemorySigner::new(&account_id, &private_key)?;
+        let inner = InMemorySigner::new(account_id, &private_key)?;
         Ok(Self { inner })
     }
 
@@ -658,7 +659,7 @@ impl RotatingSigner {
     /// - The account ID cannot be parsed
     /// - The keys vector is empty
     pub fn new(
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
         keys: Vec<SecretKey>,
     ) -> Result<Self, crate::error::Error> {
         if keys.is_empty() {
@@ -667,7 +668,7 @@ impl RotatingSigner {
             ));
         }
 
-        let account_id: AccountId = account_id.as_ref().parse()?;
+        let account_id: AccountId = account_id.into();
 
         Ok(Self {
             account_id,
@@ -727,7 +728,7 @@ impl RotatingSigner {
     /// * `account_id` - The NEAR account ID
     /// * `keys` - Slice of secret keys in string format (e.g., "ed25519:...")
     pub fn from_key_strings(
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
         keys: &[impl AsRef<str>],
     ) -> Result<Self, crate::error::Error> {
         let parsed_keys: Result<Vec<SecretKey>, _> =

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -272,11 +272,11 @@ impl TransactionBuilder {
     pub fn add_function_call_key(
         mut self,
         public_key: PublicKey,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl Into<AccountId>,
         method_names: Vec<String>,
         allowance: Option<NearToken>,
     ) -> Self {
-        let receiver_id = AccountId::parse_lenient(receiver_id);
+        let receiver_id = receiver_id.into();
         self.actions.push(Action::add_function_call_key(
             public_key,
             receiver_id,
@@ -293,8 +293,8 @@ impl TransactionBuilder {
     }
 
     /// Delete the account and transfer remaining balance to beneficiary.
-    pub fn delete_account(mut self, beneficiary_id: impl AsRef<str>) -> Self {
-        let beneficiary_id = AccountId::parse_lenient(beneficiary_id);
+    pub fn delete_account(mut self, beneficiary_id: impl Into<AccountId>) -> Self {
+        let beneficiary_id = beneficiary_id.into();
         self.actions.push(Action::delete_account(beneficiary_id));
         self
     }
@@ -535,8 +535,8 @@ impl TransactionBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn deploy_from_publisher(mut self, publisher_id: impl AsRef<str>) -> Self {
-        let publisher_id = AccountId::parse_lenient(publisher_id);
+    pub fn deploy_from_publisher(mut self, publisher_id: impl Into<AccountId>) -> Self {
+        let publisher_id = publisher_id.into();
         self.actions.push(Action::deploy_from_account(publisher_id));
         self
     }
@@ -601,11 +601,11 @@ impl TransactionBuilder {
     /// Panics if the deposit amount string cannot be parsed.
     pub fn state_init_by_publisher(
         self,
-        publisher_id: impl AsRef<str>,
+        publisher_id: impl Into<AccountId>,
         data: BTreeMap<Vec<u8>, Vec<u8>>,
         deposit: impl IntoNearToken,
     ) -> Self {
-        let publisher_id = AccountId::parse_lenient(publisher_id);
+        let publisher_id = publisher_id.into();
         let state_init = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
             code: GlobalContractIdentifier::AccountId(publisher_id),
             data,
@@ -976,7 +976,7 @@ impl CallBuilder {
     pub fn add_function_call_key(
         self,
         public_key: PublicKey,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl Into<AccountId>,
         method_names: Vec<String>,
         allowance: Option<NearToken>,
     ) -> TransactionBuilder {
@@ -990,7 +990,7 @@ impl CallBuilder {
     }
 
     /// Delete the account.
-    pub fn delete_account(self, beneficiary_id: impl AsRef<str>) -> TransactionBuilder {
+    pub fn delete_account(self, beneficiary_id: impl Into<AccountId>) -> TransactionBuilder {
         self.finish().delete_account(beneficiary_id)
     }
 
@@ -1010,7 +1010,7 @@ impl CallBuilder {
     }
 
     /// Deploy a contract from the global registry by publisher account.
-    pub fn deploy_from_publisher(self, publisher_id: impl AsRef<str>) -> TransactionBuilder {
+    pub fn deploy_from_publisher(self, publisher_id: impl Into<AccountId>) -> TransactionBuilder {
         self.finish().deploy_from_publisher(publisher_id)
     }
 
@@ -1027,7 +1027,7 @@ impl CallBuilder {
     /// Create a NEP-616 deterministic state init action with publisher account reference.
     pub fn state_init_by_publisher(
         self,
-        publisher_id: impl AsRef<str>,
+        publisher_id: impl Into<AccountId>,
         data: BTreeMap<Vec<u8>, Vec<u8>>,
         deposit: impl IntoNearToken,
     ) -> TransactionBuilder {

--- a/crates/near-kit/src/sandbox.rs
+++ b/crates/near-kit/src/sandbox.rs
@@ -171,11 +171,11 @@ impl SharedSandbox {
     /// ```
     pub async fn set_balance(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<crate::AccountId>,
         balance: crate::NearToken,
     ) -> Result<(), crate::Error> {
         let near = self.client();
-        let account_id = crate::AccountId::parse_lenient(account_id);
+        let account_id: crate::AccountId = account_id.into();
 
         // Fetch raw account data from RPC - this includes all fields the sandbox expects
         let mut account_response: serde_json::Value = near
@@ -297,11 +297,11 @@ impl OwnedSandbox {
     /// ```
     pub async fn set_balance(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<crate::AccountId>,
         balance: crate::NearToken,
     ) -> Result<(), crate::Error> {
         let near = self.client();
-        let account_id = crate::AccountId::parse_lenient(account_id);
+        let account_id: crate::AccountId = account_id.into();
 
         // Fetch raw account data from RPC - this includes all fields the sandbox expects
         let mut account_response: serde_json::Value = near

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -133,7 +133,8 @@ impl FungibleToken {
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn balance_of(&self, account_id: impl AsRef<str>) -> Result<FtAmount, Error> {
+    pub async fn balance_of(&self, account_id: impl Into<AccountId>) -> Result<FtAmount, Error> {
+        let account_id: AccountId = account_id.into();
         let metadata = self.metadata().await?;
 
         #[derive(Serialize)]
@@ -142,7 +143,7 @@ impl FungibleToken {
         }
 
         let args = serde_json::to_vec(&Args {
-            account_id: account_id.as_ref(),
+            account_id: account_id.as_str(),
         })?;
 
         let result = self
@@ -201,7 +202,7 @@ impl FungibleToken {
     ///
     /// An account must be registered (via `storage_deposit`) before it can
     /// receive tokens.
-    pub async fn is_registered(&self, account_id: impl AsRef<str>) -> Result<bool, Error> {
+    pub async fn is_registered(&self, account_id: impl Into<AccountId>) -> Result<bool, Error> {
         let balance = self.storage_balance_of(account_id).await?;
         Ok(balance.is_some())
     }
@@ -211,15 +212,17 @@ impl FungibleToken {
     /// Returns `None` if the account is not registered.
     pub async fn storage_balance_of(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
     ) -> Result<Option<StorageBalance>, Error> {
+        let account_id: AccountId = account_id.into();
+
         #[derive(Serialize)]
         struct Args<'a> {
             account_id: &'a str,
         }
 
         let args = serde_json::to_vec(&Args {
-            account_id: account_id.as_ref(),
+            account_id: account_id.as_str(),
         })?;
 
         let result = self
@@ -255,12 +258,13 @@ impl FungibleToken {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn storage_deposit(&self, account_id: impl AsRef<str>) -> StorageDepositCall {
+    pub fn storage_deposit(&self, account_id: impl Into<AccountId>) -> StorageDepositCall {
+        let account_id: AccountId = account_id.into();
         StorageDepositCall::new(
             self.rpc.clone(),
             self.signer.clone(),
             self.contract_id.clone(),
-            Some(account_id.as_ref().to_string()),
+            Some(account_id.to_string()),
             self.storage_bounds.clone(),
         )
     }
@@ -298,7 +302,13 @@ impl FungibleToken {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn transfer(&self, receiver_id: impl AsRef<str>, amount: impl Into<u128>) -> CallBuilder {
+    pub fn transfer(
+        &self,
+        receiver_id: impl Into<AccountId>,
+        amount: impl Into<u128>,
+    ) -> CallBuilder {
+        let receiver_id: AccountId = receiver_id.into();
+
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -308,7 +318,7 @@ impl FungibleToken {
         self.transaction()
             .call("ft_transfer")
             .args(TransferArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.to_string(),
                 amount: amount.into().to_string(),
             })
             .deposit(NearToken::yocto(1))
@@ -320,10 +330,12 @@ impl FungibleToken {
     /// Same as [`transfer`](Self::transfer) but with an optional memo field.
     pub fn transfer_with_memo(
         &self,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl Into<AccountId>,
         amount: impl Into<u128>,
         memo: impl Into<String>,
     ) -> CallBuilder {
+        let receiver_id: AccountId = receiver_id.into();
+
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -334,7 +346,7 @@ impl FungibleToken {
         self.transaction()
             .call("ft_transfer")
             .args(TransferArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.to_string(),
                 amount: amount.into().to_string(),
                 memo: memo.into(),
             })
@@ -367,10 +379,12 @@ impl FungibleToken {
     /// ```
     pub fn transfer_call(
         &self,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl Into<AccountId>,
         amount: impl Into<u128>,
         msg: impl Into<String>,
     ) -> CallBuilder {
+        let receiver_id: AccountId = receiver_id.into();
+
         #[derive(Serialize)]
         struct TransferCallArgs {
             receiver_id: String,
@@ -381,7 +395,7 @@ impl FungibleToken {
         self.transaction()
             .call("ft_transfer_call")
             .args(TransferCallArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.to_string(),
                 amount: amount.into().to_string(),
                 msg: msg.into(),
             })

--- a/crates/near-kit/src/tokens/nft.rs
+++ b/crates/near-kit/src/tokens/nft.rs
@@ -180,10 +180,12 @@ impl NonFungibleToken {
     /// ```
     pub async fn tokens_for_owner(
         &self,
-        account_id: impl AsRef<str>,
+        account_id: impl Into<AccountId>,
         from_index: Option<u64>,
         limit: Option<u64>,
     ) -> Result<Vec<NftToken>, Error> {
+        let account_id: AccountId = account_id.into();
+
         #[derive(Serialize)]
         struct Args<'a> {
             account_id: &'a str,
@@ -194,7 +196,7 @@ impl NonFungibleToken {
         }
 
         let args = serde_json::to_vec(&Args {
-            account_id: account_id.as_ref(),
+            account_id: account_id.as_str(),
             from_index: from_index.map(|i| i.to_string()),
             limit,
         })?;
@@ -235,14 +237,16 @@ impl NonFungibleToken {
     }
 
     /// Get token supply for an owner (nft_supply_for_owner).
-    pub async fn supply_for_owner(&self, account_id: impl AsRef<str>) -> Result<u64, Error> {
+    pub async fn supply_for_owner(&self, account_id: impl Into<AccountId>) -> Result<u64, Error> {
+        let account_id: AccountId = account_id.into();
+
         #[derive(Serialize)]
         struct Args<'a> {
             account_id: &'a str,
         }
 
         let args = serde_json::to_vec(&Args {
-            account_id: account_id.as_ref(),
+            account_id: account_id.as_str(),
         })?;
 
         let result = self
@@ -290,7 +294,11 @@ impl NonFungibleToken {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn transfer(&self, receiver_id: impl AsRef<str>, token_id: impl AsRef<str>) -> CallBuilder {
+    pub fn transfer(
+        &self,
+        receiver_id: impl Into<AccountId>,
+        token_id: impl AsRef<str>,
+    ) -> CallBuilder {
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -300,7 +308,7 @@ impl NonFungibleToken {
         self.transaction()
             .call("nft_transfer")
             .args(TransferArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.into().to_string(),
                 token_id: token_id.as_ref().to_string(),
             })
             .deposit(NearToken::yocto(1))
@@ -312,7 +320,7 @@ impl NonFungibleToken {
     /// Same as [`transfer`](Self::transfer) but with an optional memo field.
     pub fn transfer_with_memo(
         &self,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl Into<AccountId>,
         token_id: impl AsRef<str>,
         memo: impl Into<String>,
     ) -> CallBuilder {
@@ -326,7 +334,7 @@ impl NonFungibleToken {
         self.transaction()
             .call("nft_transfer")
             .args(TransferArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.into().to_string(),
                 token_id: token_id.as_ref().to_string(),
                 memo: memo.into(),
             })
@@ -337,7 +345,7 @@ impl NonFungibleToken {
     /// Transfer an NFT with approval ID (for approved transfers).
     pub fn transfer_with_approval(
         &self,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl Into<AccountId>,
         token_id: impl AsRef<str>,
         approval_id: u64,
     ) -> CallBuilder {
@@ -351,7 +359,7 @@ impl NonFungibleToken {
         self.transaction()
             .call("nft_transfer")
             .args(TransferArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.into().to_string(),
                 token_id: token_id.as_ref().to_string(),
                 approval_id,
             })
@@ -380,7 +388,7 @@ impl NonFungibleToken {
     /// ```
     pub fn transfer_call(
         &self,
-        receiver_id: impl AsRef<str>,
+        receiver_id: impl Into<AccountId>,
         token_id: impl AsRef<str>,
         msg: impl Into<String>,
     ) -> CallBuilder {
@@ -394,7 +402,7 @@ impl NonFungibleToken {
         self.transaction()
             .call("nft_transfer_call")
             .args(TransferCallArgs {
-                receiver_id: receiver_id.as_ref().to_string(),
+                receiver_id: receiver_id.into().to_string(),
                 token_id: token_id.as_ref().to_string(),
                 msg: msg.into(),
             })

--- a/crates/near-kit/src/types/account.rs
+++ b/crates/near-kit/src/types/account.rs
@@ -182,19 +182,27 @@ impl FromStr for AccountId {
     }
 }
 
-impl TryFrom<&str> for AccountId {
-    type Error = ParseAccountIdError;
-
-    fn try_from(s: &str) -> Result<Self, Self::Error> {
-        Self::new(s)
+impl From<&str> for AccountId {
+    fn from(s: &str) -> Self {
+        Self::parse_lenient(s)
     }
 }
 
-impl TryFrom<String> for AccountId {
-    type Error = ParseAccountIdError;
+impl From<String> for AccountId {
+    fn from(s: String) -> Self {
+        Self::parse_lenient(s)
+    }
+}
 
-    fn try_from(s: String) -> Result<Self, Self::Error> {
-        Self::new(s)
+impl From<&AccountId> for AccountId {
+    fn from(id: &AccountId) -> Self {
+        id.clone()
+    }
+}
+
+impl From<&String> for AccountId {
+    fn from(s: &String) -> Self {
+        Self::parse_lenient(s.as_str())
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `From<&str>`, `From<String>`, `From<&AccountId>`, and `From<&String>` impls for `AccountId` (all using `parse_lenient`), enabling `impl Into<AccountId>` as the bound for account ID parameters
- Replace `impl AsRef<str>` with `impl Into<AccountId>` across all public API methods that accept account IDs: `Near`, `NearBuilder`, `TransactionBuilder`, `CallBuilder`, `InMemorySigner`, `FileSigner`, `KeyringSigner`, `RotatingSigner`, `FungibleToken`, `NonFungibleToken`, and sandbox helpers
- Remove now-conflicting `TryFrom<&str>` and `TryFrom<String>` impls (the blanket `TryFrom` from `Into` covers these)

## Test plan

- [x] `cargo check --all-features --all-targets` passes
- [x] `cargo clippy --all-features --all-targets` passes
- [x] `cargo test --all-features` passes (364 unit tests + 119 doc tests)
- [x] All existing call sites compile unchanged (`&str`, `String`, `&String`, `AccountId`, `&AccountId` all work)

Closes #47