### PR TITLE
feat: remove lifetime from typed contract client macro

### DIFF
--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -426,14 +426,14 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
         }
 
         // Generated client struct
-        #vis struct #client_name<'a> {
-            near: &'a near_kit::Near,
+        #vis struct #client_name {
+            near: near_kit::Near,
             contract_id: near_kit::AccountId,
         }
 
-        impl<'a> #client_name<'a> {
+        impl #client_name {
             /// Create a new contract client.
-            pub fn new(near: &'a near_kit::Near, contract_id: near_kit::AccountId) -> Self {
+            pub fn new(near: near_kit::Near, contract_id: near_kit::AccountId) -> Self {
                 Self { near, contract_id }
             }
 
@@ -442,19 +442,27 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
                 &self.contract_id
             }
 
+            /// Return a new client that uses the given signer for transactions.
+            pub fn with_signer(&self, signer: impl near_kit::Signer + 'static) -> Self {
+                Self {
+                    near: self.near.with_signer(signer),
+                    contract_id: self.contract_id.clone(),
+                }
+            }
+
             #(#client_methods)*
         }
 
         // Implement ContractClient trait for construction via near.contract::<T>()
-        impl<'a> near_kit::contract::ContractClient<'a> for #client_name<'a> {
-            fn new(near: &'a near_kit::Near, contract_id: near_kit::AccountId) -> Self {
+        impl near_kit::contract::ContractClient for #client_name {
+            fn new(near: near_kit::Near, contract_id: near_kit::AccountId) -> Self {
                 Self { near, contract_id }
             }
         }
 
         // Implement Contract marker trait
         impl near_kit::Contract for dyn #trait_name {
-            type Client<'a> = #client_name<'a>;
+            type Client = #client_name;
         }
     };
 

--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -456,7 +456,7 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
         // Implement ContractClient trait for construction via near.contract::<T>()
         impl near_kit::contract::ContractClient for #client_name {
             fn new(near: near_kit::Near, contract_id: near_kit::AccountId) -> Self {
-                Self { near, contract_id }
+                #client_name::new(near, contract_id)
             }
         }
 

--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -456,7 +456,7 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
         // Implement ContractClient trait for construction via near.contract::<T>()
         impl near_kit::contract::ContractClient for #client_name {
             fn new(near: near_kit::Near, contract_id: near_kit::AccountId) -> Self {
-                #client_name::new(near, contract_id)
+                Self::new(near, contract_id)
             }
         }
 

--- a/crates/near-kit-macros/tests/compile-pass/borsh_contract.rs
+++ b/crates/near-kit-macros/tests/compile-pass/borsh_contract.rs
@@ -18,7 +18,7 @@ pub trait BorshContract {
 fn main() {
     // Verify the generated client can be constructed
     let near = Near::testnet().build();
-    let client = BorshContractClient::new(&near, "contract.testnet".parse().unwrap());
+    let client = BorshContractClient::new(near.clone(), "contract.testnet".parse().unwrap());
 
     // Verify methods exist and have correct return types
     // Borsh view methods should return ViewCallBorsh, not ViewCall

--- a/crates/near-kit-macros/tests/compile-pass/json_contract.rs
+++ b/crates/near-kit-macros/tests/compile-pass/json_contract.rs
@@ -26,7 +26,7 @@ pub trait JsonGuestbook {
 fn main() {
     // Verify the generated client can be constructed
     let near = Near::testnet().build();
-    let client = JsonGuestbookClient::new(&near, "guestbook.testnet".parse().unwrap());
+    let client = JsonGuestbookClient::new(near.clone(), "guestbook.testnet".parse().unwrap());
 
     // Verify methods exist and have correct return types
     let _view: ViewCall<Vec<Message>> = client.get_messages();

--- a/crates/near-kit-macros/tests/compile-pass/json_contract.rs
+++ b/crates/near-kit-macros/tests/compile-pass/json_contract.rs
@@ -34,4 +34,12 @@ fn main() {
     let _call: CallBuilder = client.add_message(AddMessageArgs {
         text: "hello".to_string(),
     });
+
+    // Verify with_signer returns a new client with the same type
+    let signer = InMemorySigner::new(
+        "bob.testnet",
+        "ed25519:3D4YudUahN1nawWogh8pAKSj92sUNMdbZGjn7kERKzYoTy8tnFQuwoGUC51DowKqorvkr2pytJSnwuSbsNVfqygr",
+    )
+    .unwrap();
+    let _client2: JsonGuestbookClient = client.with_signer(signer);
 }

--- a/crates/near-kit-macros/tests/compile-pass/mixed_format_contract.rs
+++ b/crates/near-kit-macros/tests/compile-pass/mixed_format_contract.rs
@@ -49,7 +49,7 @@ fn main() {
 
     // Test MixedContract (JSON default)
     {
-        let client = MixedContractClient::new(&near, "contract.testnet".parse().unwrap());
+        let client = MixedContractClient::new(near.clone(), "contract.testnet".parse().unwrap());
 
         // JSON methods return ViewCall
         let _: ViewCall<u64> = client.get_json_value();
@@ -63,7 +63,7 @@ fn main() {
     // Test MixedContractBorshDefault (Borsh default)
     {
         let client =
-            MixedContractBorshDefaultClient::new(&near, "contract.testnet".parse().unwrap());
+            MixedContractBorshDefaultClient::new(near.clone(), "contract.testnet".parse().unwrap());
 
         // Borsh methods return ViewCallBorsh
         let _: ViewCallBorsh<u64> = client.get_borsh_value();

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -744,9 +744,9 @@ impl Near {
     pub fn contract<T: crate::Contract + ?Sized>(
         &self,
         contract_id: impl Into<AccountId>,
-    ) -> T::Client<'_> {
+    ) -> T::Client {
         let contract_id = contract_id.into();
-        T::Client::new(self, contract_id)
+        T::Client::new(self.clone(), contract_id)
     }
 
     // ========================================================================

--- a/crates/near-kit/src/contract.rs
+++ b/crates/near-kit/src/contract.rs
@@ -104,19 +104,19 @@ use crate::types::AccountId;
 ///
 /// ```ignore
 /// impl Contract for dyn MyContract {
-///     type Client<'a> = MyContractClient<'a>;
+///     type Client = MyContractClient;
 /// }
 /// ```
 pub trait Contract {
     /// The generated client type for this contract interface.
-    type Client<'a>: ContractClient<'a>;
+    type Client: ContractClient;
 }
 
 /// Trait for contract client constructors.
 ///
 /// This trait is implemented by the generated client structs to enable
 /// construction via [`Near::contract`](crate::Near::contract).
-pub trait ContractClient<'a>: Sized {
+pub trait ContractClient: Sized {
     /// Create a new contract client.
-    fn new(near: &'a Near, contract_id: AccountId) -> Self;
+    fn new(near: Near, contract_id: AccountId) -> Self;
 }


### PR DESCRIPTION
## Summary
- Remove the `'a` lifetime parameter from generated contract client structs so they own `Near` instead of borrowing `&'a Near`. Since `Near` is cheap to clone (all fields are Arc-wrapped or Copy), this eliminates lifetime annotations without meaningful cost.
- Add a `with_signer()` method on generated clients for conveniently swapping signers.
- Update `ContractClient` trait, `Contract` trait, and `Near::contract()` to match the owned pattern.

## Changes
- `crates/near-kit/src/contract.rs`: Remove lifetime from `ContractClient` and `Contract::Client`
- `crates/near-kit-macros/src/lib.rs`: Generated struct owns `Near`, add `with_signer()` method
- `crates/near-kit/src/client/near.rs`: `contract()` passes `self.clone()` instead of `&self`
- Compile-pass tests updated to use `near.clone()` for direct client construction

Closes #62