### PR TITLE
feat: add multi-token (MT) client implementing NEP-245

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -834,6 +834,45 @@ impl Near {
             self.max_nonce_retries,
         ))
     }
+
+    /// Get a multi token client for a NEP-245 contract.
+    ///
+    /// Accepts either a string/`AccountId` for raw addresses, or a contract
+    /// identifier that implements [`IntoContractId`].
+    ///
+    /// [`IntoContractId`]: crate::tokens::IntoContractId
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example() -> Result<(), near_kit::Error> {
+    /// let near = Near::testnet().build();
+    /// let mt = near.mt("mt-contract.near")?;
+    ///
+    /// // Get a specific token
+    /// if let Some(token) = mt.token("token-1").await? {
+    ///     println!("Token: {:?}", token);
+    /// }
+    ///
+    /// // Get balance of a specific token for an account
+    /// let balance = mt.balance_of("alice.near", "token-1").await?;
+    /// println!("Balance: {}", balance);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn mt(
+        &self,
+        contract: impl crate::tokens::IntoContractId,
+    ) -> Result<crate::tokens::MultiToken, Error> {
+        let contract_id = contract.into_contract_id(self.network)?;
+        Ok(crate::tokens::MultiToken::new(
+            self.rpc.clone(),
+            self.signer.clone(),
+            contract_id,
+            self.max_nonce_retries,
+        ))
+    }
 }
 
 impl std::fmt::Debug for Near {

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -417,9 +417,9 @@ pub use client::KeyringSigner;
 
 // Re-export token types
 pub use tokens::{
-    FtAmount, FtMetadata, FungibleToken, IntoContractId, KnownToken, NftContractMetadata, NftToken,
-    NftTokenMetadata, NonFungibleToken, StorageBalance, StorageBalanceBounds, StorageDepositCall,
-    USDC, USDT, W_NEAR,
+    FtAmount, FtMetadata, FungibleToken, IntoContractId, KnownToken, MtBaseTokenMetadata, MtToken,
+    MtTokenMetadata, MultiToken, NftContractMetadata, NftToken, NftTokenMetadata, NonFungibleToken,
+    StorageBalance, StorageBalanceBounds, StorageDepositCall, USDC, USDT, W_NEAR,
 };
 
 // Re-export proc macros

--- a/crates/near-kit/src/tokens/mod.rs
+++ b/crates/near-kit/src/tokens/mod.rs
@@ -113,10 +113,12 @@
 
 mod ft;
 mod known;
+mod mt;
 mod nft;
 mod types;
 
 pub use ft::*;
 pub use known::{IntoContractId, KnownToken, USDC, USDT, W_NEAR};
+pub use mt::*;
 pub use nft::*;
 pub use types::*;

--- a/crates/near-kit/src/tokens/mt.rs
+++ b/crates/near-kit/src/tokens/mt.rs
@@ -1,0 +1,585 @@
+//! Multi token client (NEP-245).
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::client::{CallBuilder, RpcClient, Signer, TransactionBuilder};
+use crate::error::Error;
+use crate::types::{AccountId, BlockReference, Finality, Gas, NearToken};
+
+use super::types::MtToken;
+
+// =============================================================================
+// MultiToken
+// =============================================================================
+
+/// Client for interacting with a NEP-245 Multi Token contract.
+///
+/// Create via [`Near::mt()`](crate::Near::mt).
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use near_kit::*;
+///
+/// # async fn example() -> Result<(), near_kit::Error> {
+/// let near = Near::testnet().build();
+/// let mt = near.mt("mt-contract.near")?;
+///
+/// // Get a specific token
+/// if let Some(token) = mt.token("token-1").await? {
+///     println!("Token: {:?}", token);
+/// }
+///
+/// // Get balance of a specific token for an account
+/// let balance = mt.balance_of("alice.near", "token-1").await?;
+/// println!("Balance: {}", balance);
+///
+/// // Get total supply of a specific token
+/// let supply = mt.supply("token-1").await?;
+/// println!("Supply: {}", supply);
+/// # Ok(())
+/// # }
+/// ```
+pub struct MultiToken {
+    rpc: Arc<RpcClient>,
+    signer: Option<Arc<dyn Signer>>,
+    contract_id: AccountId,
+    max_nonce_retries: u32,
+}
+
+impl MultiToken {
+    /// Create a new MultiToken client.
+    pub(crate) fn new(
+        rpc: Arc<RpcClient>,
+        signer: Option<Arc<dyn Signer>>,
+        contract_id: AccountId,
+        max_nonce_retries: u32,
+    ) -> Self {
+        Self {
+            rpc,
+            signer,
+            contract_id,
+            max_nonce_retries,
+        }
+    }
+
+    /// Get the contract ID.
+    pub fn contract_id(&self) -> &AccountId {
+        &self.contract_id
+    }
+
+    /// Create a transaction builder for this contract.
+    fn transaction(&self) -> TransactionBuilder {
+        TransactionBuilder::new(
+            self.rpc.clone(),
+            self.signer.clone(),
+            self.contract_id.clone(),
+            self.max_nonce_retries,
+        )
+    }
+
+    // =========================================================================
+    // View Methods
+    // =========================================================================
+
+    /// Get a specific token by ID (mt_token).
+    ///
+    /// Returns `None` if the token doesn't exist.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example() -> Result<(), near_kit::Error> {
+    /// let near = Near::testnet().build();
+    /// let mt = near.mt("mt-contract.near")?;
+    ///
+    /// if let Some(token) = mt.token("token-1").await? {
+    ///     println!("Token: {:?}", token);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn token(&self, token_id: impl AsRef<str>) -> Result<Option<MtToken>, Error> {
+        #[derive(Serialize)]
+        struct Args<'a> {
+            token_ids: Vec<&'a str>,
+        }
+
+        let args = serde_json::to_vec(&Args {
+            token_ids: vec![token_id.as_ref()],
+        })?;
+
+        let result = self
+            .rpc
+            .view_function(
+                &self.contract_id,
+                "mt_token",
+                &args,
+                BlockReference::Finality(Finality::Optimistic),
+            )
+            .await?;
+
+        let tokens: Vec<Option<MtToken>> = result.json().map_err(Error::from)?;
+        Ok(tokens.into_iter().next().flatten())
+    }
+
+    /// Get info for multiple tokens by ID (mt_batch_tokens).
+    ///
+    /// Returns a vector of optional tokens (None for IDs that don't exist).
+    pub async fn batch_tokens(
+        &self,
+        token_ids: &[impl AsRef<str>],
+    ) -> Result<Vec<Option<MtToken>>, Error> {
+        #[derive(Serialize)]
+        struct Args<'a> {
+            token_ids: Vec<&'a str>,
+        }
+
+        let args = serde_json::to_vec(&Args {
+            token_ids: token_ids.iter().map(|id| id.as_ref()).collect(),
+        })?;
+
+        let result = self
+            .rpc
+            .view_function(
+                &self.contract_id,
+                "mt_token",
+                &args,
+                BlockReference::Finality(Finality::Optimistic),
+            )
+            .await?;
+
+        result.json().map_err(Error::from)
+    }
+
+    /// Get the balance of a specific token for an account (mt_balance_of).
+    ///
+    /// Returns the balance as a string (u128 encoded as string per NEP-245).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example() -> Result<(), near_kit::Error> {
+    /// let near = Near::testnet().build();
+    /// let mt = near.mt("mt-contract.near")?;
+    ///
+    /// let balance = mt.balance_of("alice.near", "token-1").await?;
+    /// println!("Balance: {}", balance);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn balance_of(
+        &self,
+        account_id: impl Into<AccountId>,
+        token_id: impl AsRef<str>,
+    ) -> Result<u128, Error> {
+        let account_id: AccountId = account_id.into();
+
+        #[derive(Serialize)]
+        struct Args<'a> {
+            account_id: &'a str,
+            token_id: &'a str,
+        }
+
+        let args = serde_json::to_vec(&Args {
+            account_id: account_id.as_str(),
+            token_id: token_id.as_ref(),
+        })?;
+
+        let result = self
+            .rpc
+            .view_function(
+                &self.contract_id,
+                "mt_balance_of",
+                &args,
+                BlockReference::Finality(Finality::Optimistic),
+            )
+            .await?;
+
+        let balance_str: String = result.json().map_err(Error::from)?;
+        balance_str.parse().map_err(|_| {
+            Error::Rpc(crate::error::RpcError::InvalidResponse(format!(
+                "Invalid balance format: {}",
+                balance_str
+            )))
+        })
+    }
+
+    /// Get balances for multiple token/account pairs (mt_batch_balance_of).
+    ///
+    /// Each element in `account_ids` and `token_ids` must correspond pairwise.
+    /// Returns a vector of balances in the same order.
+    pub async fn batch_balance_of(
+        &self,
+        account_ids: &[impl AsRef<str>],
+        token_ids: &[impl AsRef<str>],
+    ) -> Result<Vec<u128>, Error> {
+        #[derive(Serialize)]
+        struct Args<'a> {
+            account_ids: Vec<&'a str>,
+            token_ids: Vec<&'a str>,
+        }
+
+        let args = serde_json::to_vec(&Args {
+            account_ids: account_ids.iter().map(|id| id.as_ref()).collect(),
+            token_ids: token_ids.iter().map(|id| id.as_ref()).collect(),
+        })?;
+
+        let result = self
+            .rpc
+            .view_function(
+                &self.contract_id,
+                "mt_batch_balance_of",
+                &args,
+                BlockReference::Finality(Finality::Optimistic),
+            )
+            .await?;
+
+        let balances: Vec<String> = result.json().map_err(Error::from)?;
+        balances
+            .into_iter()
+            .map(|s| {
+                s.parse().map_err(|_| {
+                    Error::Rpc(crate::error::RpcError::InvalidResponse(format!(
+                        "Invalid balance format: {}",
+                        s
+                    )))
+                })
+            })
+            .collect()
+    }
+
+    /// Get the total supply of a specific token (mt_supply).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example() -> Result<(), near_kit::Error> {
+    /// let near = Near::testnet().build();
+    /// let mt = near.mt("mt-contract.near")?;
+    ///
+    /// let supply = mt.supply("token-1").await?;
+    /// println!("Supply: {}", supply);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn supply(&self, token_id: impl AsRef<str>) -> Result<u128, Error> {
+        #[derive(Serialize)]
+        struct Args<'a> {
+            token_id: &'a str,
+        }
+
+        let args = serde_json::to_vec(&Args {
+            token_id: token_id.as_ref(),
+        })?;
+
+        let result = self
+            .rpc
+            .view_function(
+                &self.contract_id,
+                "mt_supply",
+                &args,
+                BlockReference::Finality(Finality::Optimistic),
+            )
+            .await?;
+
+        let supply_str: String = result.json().map_err(Error::from)?;
+        supply_str.parse().map_err(|_| {
+            Error::Rpc(crate::error::RpcError::InvalidResponse(format!(
+                "Invalid supply format: {}",
+                supply_str
+            )))
+        })
+    }
+
+    /// Get total supplies for multiple tokens (mt_batch_supply).
+    ///
+    /// Returns supplies in the same order as the provided token IDs.
+    pub async fn batch_supply(&self, token_ids: &[impl AsRef<str>]) -> Result<Vec<u128>, Error> {
+        #[derive(Serialize)]
+        struct Args<'a> {
+            token_ids: Vec<&'a str>,
+        }
+
+        let args = serde_json::to_vec(&Args {
+            token_ids: token_ids.iter().map(|id| id.as_ref()).collect(),
+        })?;
+
+        let result = self
+            .rpc
+            .view_function(
+                &self.contract_id,
+                "mt_batch_supply",
+                &args,
+                BlockReference::Finality(Finality::Optimistic),
+            )
+            .await?;
+
+        let supplies: Vec<String> = result.json().map_err(Error::from)?;
+        supplies
+            .into_iter()
+            .map(|s| {
+                s.parse().map_err(|_| {
+                    Error::Rpc(crate::error::RpcError::InvalidResponse(format!(
+                        "Invalid supply format: {}",
+                        s
+                    )))
+                })
+            })
+            .collect()
+    }
+
+    // =========================================================================
+    // Transfer Methods
+    // =========================================================================
+
+    /// Transfer tokens to a receiver (mt_transfer).
+    ///
+    /// # Security
+    ///
+    /// This automatically attaches 1 yoctoNEAR as required by NEP-245 for
+    /// security (prevents function-call access key abuse).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example() -> Result<(), near_kit::Error> {
+    /// let near = Near::testnet()
+    ///     .credentials("ed25519:...", "alice.near")?
+    ///     .build();
+    /// let mt = near.mt("mt-contract.near")?;
+    ///
+    /// mt.transfer("bob.near", "token-1", 100_u128).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn transfer(
+        &self,
+        receiver_id: impl Into<AccountId>,
+        token_id: impl AsRef<str>,
+        amount: impl Into<u128>,
+    ) -> CallBuilder {
+        #[derive(Serialize)]
+        struct TransferArgs {
+            receiver_id: String,
+            token_id: String,
+            amount: String,
+        }
+
+        self.transaction()
+            .call("mt_transfer")
+            .args(TransferArgs {
+                receiver_id: receiver_id.into().to_string(),
+                token_id: token_id.as_ref().to_string(),
+                amount: amount.into().to_string(),
+            })
+            .deposit(NearToken::yocto(1))
+            .gas(Gas::tgas(30))
+    }
+
+    /// Transfer tokens with a memo (mt_transfer).
+    ///
+    /// Same as [`transfer`](Self::transfer) but with an optional memo field.
+    pub fn transfer_with_memo(
+        &self,
+        receiver_id: impl Into<AccountId>,
+        token_id: impl AsRef<str>,
+        amount: impl Into<u128>,
+        memo: impl Into<String>,
+    ) -> CallBuilder {
+        #[derive(Serialize)]
+        struct TransferArgs {
+            receiver_id: String,
+            token_id: String,
+            amount: String,
+            memo: String,
+        }
+
+        self.transaction()
+            .call("mt_transfer")
+            .args(TransferArgs {
+                receiver_id: receiver_id.into().to_string(),
+                token_id: token_id.as_ref().to_string(),
+                amount: amount.into().to_string(),
+                memo: memo.into(),
+            })
+            .deposit(NearToken::yocto(1))
+            .gas(Gas::tgas(30))
+    }
+
+    /// Batch transfer multiple token types (mt_batch_transfer).
+    ///
+    /// Transfers multiple token types in a single transaction.
+    /// Each element in `token_ids` and `amounts` must correspond pairwise.
+    ///
+    /// # Security
+    ///
+    /// This automatically attaches 1 yoctoNEAR as required by NEP-245.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example() -> Result<(), near_kit::Error> {
+    /// let near = Near::testnet()
+    ///     .credentials("ed25519:...", "alice.near")?
+    ///     .build();
+    /// let mt = near.mt("mt-contract.near")?;
+    ///
+    /// mt.batch_transfer(
+    ///     "bob.near",
+    ///     &["token-1", "token-2"],
+    ///     &[100_u128, 200_u128],
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn batch_transfer(
+        &self,
+        receiver_id: impl Into<AccountId>,
+        token_ids: &[impl AsRef<str>],
+        amounts: &[u128],
+    ) -> CallBuilder {
+        #[derive(Serialize)]
+        struct BatchTransferArgs {
+            receiver_id: String,
+            token_ids: Vec<String>,
+            amounts: Vec<String>,
+        }
+
+        self.transaction()
+            .call("mt_batch_transfer")
+            .args(BatchTransferArgs {
+                receiver_id: receiver_id.into().to_string(),
+                token_ids: token_ids.iter().map(|id| id.as_ref().to_string()).collect(),
+                amounts: amounts.iter().map(|a| a.to_string()).collect(),
+            })
+            .deposit(NearToken::yocto(1))
+            .gas(Gas::tgas(60))
+    }
+
+    /// Transfer tokens with a callback to the receiver (mt_transfer_call).
+    ///
+    /// This calls `mt_on_transfer` on the receiver contract, allowing it to
+    /// handle the tokens. The receiver can return unused tokens, which will
+    /// be refunded to the sender.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example() -> Result<(), near_kit::Error> {
+    /// let near = Near::testnet()
+    ///     .credentials("ed25519:...", "alice.near")?
+    ///     .build();
+    /// let mt = near.mt("mt-contract.near")?;
+    ///
+    /// mt.transfer_call("defi.near", "token-1", 100_u128, r#"{"action":"deposit"}"#)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn transfer_call(
+        &self,
+        receiver_id: impl Into<AccountId>,
+        token_id: impl AsRef<str>,
+        amount: impl Into<u128>,
+        msg: impl Into<String>,
+    ) -> CallBuilder {
+        #[derive(Serialize)]
+        struct TransferCallArgs {
+            receiver_id: String,
+            token_id: String,
+            amount: String,
+            msg: String,
+        }
+
+        self.transaction()
+            .call("mt_transfer_call")
+            .args(TransferCallArgs {
+                receiver_id: receiver_id.into().to_string(),
+                token_id: token_id.as_ref().to_string(),
+                amount: amount.into().to_string(),
+                msg: msg.into(),
+            })
+            .deposit(NearToken::yocto(1))
+            .gas(Gas::tgas(100))
+    }
+
+    /// Batch transfer with a callback to the receiver (mt_batch_transfer_call).
+    ///
+    /// This calls `mt_on_transfer` on the receiver contract with multiple
+    /// token types. Each element in `token_ids` and `amounts` must correspond
+    /// pairwise.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example() -> Result<(), near_kit::Error> {
+    /// let near = Near::testnet()
+    ///     .credentials("ed25519:...", "alice.near")?
+    ///     .build();
+    /// let mt = near.mt("mt-contract.near")?;
+    ///
+    /// mt.batch_transfer_call(
+    ///     "defi.near",
+    ///     &["token-1", "token-2"],
+    ///     &[100_u128, 200_u128],
+    ///     r#"{"action":"deposit"}"#,
+    /// ).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn batch_transfer_call(
+        &self,
+        receiver_id: impl Into<AccountId>,
+        token_ids: &[impl AsRef<str>],
+        amounts: &[u128],
+        msg: impl Into<String>,
+    ) -> CallBuilder {
+        #[derive(Serialize)]
+        struct BatchTransferCallArgs {
+            receiver_id: String,
+            token_ids: Vec<String>,
+            amounts: Vec<String>,
+            msg: String,
+        }
+
+        self.transaction()
+            .call("mt_batch_transfer_call")
+            .args(BatchTransferCallArgs {
+                receiver_id: receiver_id.into().to_string(),
+                token_ids: token_ids.iter().map(|id| id.as_ref().to_string()).collect(),
+                amounts: amounts.iter().map(|a| a.to_string()).collect(),
+                msg: msg.into(),
+            })
+            .deposit(NearToken::yocto(1))
+            .gas(Gas::tgas(100))
+    }
+}
+
+impl Clone for MultiToken {
+    fn clone(&self) -> Self {
+        Self {
+            rpc: self.rpc.clone(),
+            signer: self.signer.clone(),
+            contract_id: self.contract_id.clone(),
+            max_nonce_retries: self.max_nonce_retries,
+        }
+    }
+}
+
+impl std::fmt::Debug for MultiToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MultiToken")
+            .field("contract_id", &self.contract_id)
+            .finish()
+    }
+}

--- a/crates/near-kit/src/tokens/types.rs
+++ b/crates/near-kit/src/tokens/types.rs
@@ -356,6 +356,95 @@ pub struct NftToken {
 }
 
 // =============================================================================
+// Multi Token Types (NEP-245)
+// =============================================================================
+
+/// NEP-245 Multi Token metadata for an individual token.
+///
+/// This is part of the token info returned by `mt_token` on NEP-245 contracts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MtTokenMetadata {
+    /// Token title
+    pub title: Option<String>,
+
+    /// Token description
+    pub description: Option<String>,
+
+    /// URL to media file
+    pub media: Option<String>,
+
+    /// Base64-encoded SHA-256 hash of the media content
+    pub media_hash: Option<String>,
+
+    /// Number of copies (for limited editions)
+    pub copies: Option<u64>,
+
+    /// ISO 8601 datetime when issued
+    pub issued_at: Option<String>,
+
+    /// ISO 8601 datetime when expires
+    pub expires_at: Option<String>,
+
+    /// ISO 8601 datetime when starts being valid
+    pub starts_at: Option<String>,
+
+    /// ISO 8601 datetime when last updated
+    pub updated_at: Option<String>,
+
+    /// Extra arbitrary data (JSON string)
+    pub extra: Option<String>,
+
+    /// URL to off-chain JSON metadata
+    pub reference: Option<String>,
+
+    /// Base64-encoded SHA-256 hash of the reference content
+    pub reference_hash: Option<String>,
+}
+
+/// NEP-245 Multi Token base metadata for a token type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MtBaseTokenMetadata {
+    /// Human-readable token name
+    pub name: String,
+
+    /// Unique identifier for this token type
+    pub id: String,
+
+    /// Token symbol (e.g., "SWORD", "GOLD")
+    pub symbol: Option<String>,
+
+    /// Number of decimal places for display
+    pub decimals: Option<u8>,
+
+    /// Optional icon as a data URI
+    pub icon: Option<String>,
+
+    /// Optional base URI for token metadata references
+    pub base_uri: Option<String>,
+
+    /// Optional URL to off-chain JSON metadata
+    pub reference: Option<String>,
+
+    /// Optional base64-encoded SHA-256 hash of the reference content
+    pub reference_hash: Option<String>,
+}
+
+/// NEP-245 Multi Token.
+///
+/// A single token entry within a multi-token contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MtToken {
+    /// Unique token identifier within this contract
+    pub token_id: String,
+
+    /// Current owner of the token (if applicable)
+    pub owner_id: Option<String>,
+
+    /// Optional token metadata
+    pub metadata: Option<MtTokenMetadata>,
+}
+
+// =============================================================================
 // Helper Functions
 // =============================================================================
 


### PR DESCRIPTION
## Summary

- Adds `MultiToken` client for NEP-245 Multi Token standard, following the same patterns as `FungibleToken` (NEP-141) and `NonFungibleToken` (NEP-171)
- Implements all core NEP-245 methods: `mt_transfer`, `mt_batch_transfer`, `mt_transfer_call`, `mt_batch_transfer_call`, `mt_token`, `mt_batch_tokens`, `mt_balance_of`, `mt_batch_balance_of`, `mt_supply`, `mt_batch_supply`
- Adds MT-specific types (`MtToken`, `MtTokenMetadata`, `MtBaseTokenMetadata`) and exposes `Near::mt()` entry point

Closes #63

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` passes (all existing tests still green)
- [x] Clippy and rustfmt pass (pre-commit hooks)