### PR TITLE
feat: add tracing instrumentation to near-kit

### DIFF
--- a/crates/near-kit/src/client/nonce_manager.rs
+++ b/crates/near-kit/src/client/nonce_manager.rs
@@ -61,18 +61,26 @@ impl NonceManager {
         Fut: Future<Output = Result<u64, crate::Error>>,
     {
         let key = format!("{}:{}:{}", network, account_id, public_key);
+        let span = tracing::debug_span!("nonce", account_id = account_id, public_key = public_key);
+        let _enter = span.enter();
 
         // Fast path: check if we already have a cached nonce
         {
             let nonces = self.nonces.lock().unwrap();
             if let Some(atomic) = nonces.get(&key) {
                 // Atomically increment and return the previous value
-                return Ok(atomic.fetch_add(1, Ordering::SeqCst));
+                let nonce = atomic.fetch_add(1, Ordering::SeqCst);
+                tracing::debug!(nonce = nonce, "Nonce from cache");
+                return Ok(nonce);
             }
         }
 
         // Slow path: need to fetch from blockchain
+        tracing::debug!("Fetching nonce from RPC");
+        // Drop the span guard before the async call
+        drop(_enter);
         let blockchain_nonce = fetch_from_blockchain().await?;
+        let _enter = span.enter();
         let next_nonce = blockchain_nonce + 1;
 
         // Store the nonce (next_nonce + 1 for future calls)
@@ -81,12 +89,15 @@ impl NonceManager {
             // Check again in case another task beat us to it
             if let Some(atomic) = nonces.get(&key) {
                 // Someone else already inserted, use theirs
-                return Ok(atomic.fetch_add(1, Ordering::SeqCst));
+                let nonce = atomic.fetch_add(1, Ordering::SeqCst);
+                tracing::debug!(nonce = nonce, "Nonce from cache (race)");
+                return Ok(nonce);
             }
             // Insert with value = next_nonce + 1 (what the NEXT caller should get)
             nonces.insert(key, AtomicU64::new(next_nonce + 1));
         }
 
+        tracing::debug!(nonce = next_nonce, "Nonce acquired from RPC");
         Ok(next_nonce)
     }
 
@@ -127,6 +138,11 @@ impl NonceManager {
     ) -> u64 {
         let key = format!("{}:{}:{}", network, account_id, public_key);
         let next_nonce = current_nonce + 1;
+        tracing::debug!(
+            account_id = account_id,
+            nonce = next_nonce,
+            "Nonce updated from error"
+        );
 
         let mut nonces = self.nonces.lock().unwrap();
         if let Some(atomic) = nonces.get(&key) {

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -155,8 +155,6 @@ impl RpcClient {
     ) -> Result<R, RpcError> {
         let total_attempts = self.retry_config.max_retries + 1;
 
-        tracing::debug!(rpc.method = method, rpc.url = %self.url, "RPC request");
-
         for attempt in 0..total_attempts {
             let request_id = self.request_id.fetch_add(1, Ordering::Relaxed);
 
@@ -168,10 +166,7 @@ impl RpcClient {
             };
 
             match self.try_call::<R>(&request).await {
-                Ok(result) => {
-                    tracing::debug!(rpc.method = method, "RPC request succeeded");
-                    return Ok(result);
-                }
+                Ok(result) => return Ok(result),
                 Err(e) if e.is_retryable() && attempt < total_attempts - 1 => {
                     let delay = std::cmp::min(
                         self.retry_config.initial_delay_ms * 2u64.pow(attempt),
@@ -418,6 +413,7 @@ impl RpcClient {
         account_id: &AccountId,
         block: BlockReference,
     ) -> Result<AccountView, RpcError> {
+        tracing::debug!(account_id = %account_id, "view_account");
         let mut params = serde_json::json!({
             "request_type": "view_account",
             "account_id": account_id.to_string(),
@@ -434,6 +430,7 @@ impl RpcClient {
         public_key: &PublicKey,
         block: BlockReference,
     ) -> Result<AccessKeyView, RpcError> {
+        tracing::debug!(account_id = %account_id, public_key = %public_key, "view_access_key");
         let mut params = serde_json::json!({
             "request_type": "view_access_key",
             "account_id": account_id.to_string(),
@@ -450,6 +447,7 @@ impl RpcClient {
         account_id: &AccountId,
         block: BlockReference,
     ) -> Result<AccessKeyListView, RpcError> {
+        tracing::debug!(account_id = %account_id, "view_access_key_list");
         let mut params = serde_json::json!({
             "request_type": "view_access_key_list",
             "account_id": account_id.to_string(),
@@ -467,6 +465,7 @@ impl RpcClient {
         args: &[u8],
         block: BlockReference,
     ) -> Result<ViewFunctionResult, RpcError> {
+        tracing::debug!(contract_id = %account_id, method = method_name, "view_function");
         let mut params = serde_json::json!({
             "request_type": "call_function",
             "account_id": account_id.to_string(),
@@ -508,17 +507,20 @@ impl RpcClient {
 
     /// Get block information.
     pub async fn block(&self, block: BlockReference) -> Result<BlockView, RpcError> {
+        tracing::debug!("block");
         let params = block.to_rpc_params();
         self.call("block", params).await
     }
 
     /// Get node status.
     pub async fn status(&self) -> Result<StatusResponse, RpcError> {
+        tracing::debug!("status");
         self.call("status", serde_json::json!([])).await
     }
 
     /// Get current gas price.
     pub async fn gas_price(&self, block_hash: Option<&CryptoHash>) -> Result<GasPrice, RpcError> {
+        tracing::debug!("gas_price");
         let params = match block_hash {
             Some(hash) => serde_json::json!([hash.to_string()]),
             None => serde_json::json!([serde_json::Value::Null]),
@@ -546,7 +548,6 @@ impl RpcClient {
         });
         let mut response: SendTxResponse = self.call("send_tx", params).await?;
         response.transaction_hash = tx_hash;
-        tracing::info!(tx_hash = %response.transaction_hash, "Transaction sent successfully");
         Ok(response)
     }
 
@@ -559,6 +560,7 @@ impl RpcClient {
         sender_id: &AccountId,
         wait_until: TxExecutionStatus,
     ) -> Result<SendTxWithReceiptsResponse, RpcError> {
+        tracing::debug!(tx_hash = %tx_hash, sender = %sender_id, "tx_status");
         let params = serde_json::json!({
             "tx_hash": tx_hash.to_string(),
             "sender_account_id": sender_id.to_string(),

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -155,6 +155,8 @@ impl RpcClient {
     ) -> Result<R, RpcError> {
         let total_attempts = self.retry_config.max_retries + 1;
 
+        tracing::debug!(rpc.method = method, rpc.url = %self.url, "RPC request");
+
         for attempt in 0..total_attempts {
             let request_id = self.request_id.fetch_add(1, Ordering::Relaxed);
 
@@ -166,19 +168,38 @@ impl RpcClient {
             };
 
             match self.try_call::<R>(&request).await {
-                Ok(result) => return Ok(result),
+                Ok(result) => {
+                    tracing::debug!(rpc.method = method, "RPC request succeeded");
+                    return Ok(result);
+                }
                 Err(e) if e.is_retryable() && attempt < total_attempts - 1 => {
                     let delay = std::cmp::min(
                         self.retry_config.initial_delay_ms * 2u64.pow(attempt),
                         self.retry_config.max_delay_ms,
                     );
+                    tracing::warn!(
+                        rpc.method = method,
+                        attempt = attempt + 1,
+                        max_attempts = total_attempts,
+                        delay_ms = delay,
+                        error = %e,
+                        "RPC request failed, retrying"
+                    );
                     tokio::time::sleep(Duration::from_millis(delay)).await;
                     continue;
                 }
-                Err(e) => return Err(e),
+                Err(e) => {
+                    tracing::error!(rpc.method = method, error = %e, "RPC request failed");
+                    return Err(e);
+                }
             }
         }
 
+        tracing::error!(
+            rpc.method = method,
+            attempts = total_attempts,
+            "RPC request timed out after all retries"
+        );
         Err(RpcError::Timeout(total_attempts))
     }
 
@@ -397,6 +418,7 @@ impl RpcClient {
     // ========================================================================
 
     /// View account information.
+    #[tracing::instrument(skip(self, block), fields(account_id = %account_id))]
     pub async fn view_account(
         &self,
         account_id: &AccountId,
@@ -412,6 +434,7 @@ impl RpcClient {
     }
 
     /// View access key information.
+    #[tracing::instrument(skip(self, block), fields(account_id = %account_id, public_key = %public_key))]
     pub async fn view_access_key(
         &self,
         account_id: &AccountId,
@@ -429,6 +452,7 @@ impl RpcClient {
     }
 
     /// View all access keys for an account.
+    #[tracing::instrument(skip(self, block), fields(account_id = %account_id))]
     pub async fn view_access_key_list(
         &self,
         account_id: &AccountId,
@@ -444,6 +468,7 @@ impl RpcClient {
     }
 
     /// Call a view function on a contract.
+    #[tracing::instrument(skip(self, args, block), fields(contract_id = %account_id, method = method_name))]
     pub async fn view_function(
         &self,
         account_id: &AccountId,
@@ -517,12 +542,20 @@ impl RpcClient {
         wait_until: TxExecutionStatus,
     ) -> Result<SendTxResponse, RpcError> {
         let tx_hash = signed_tx.get_hash();
+        tracing::info!(
+            tx_hash = %tx_hash,
+            sender = %signed_tx.transaction.signer_id,
+            receiver = %signed_tx.transaction.receiver_id,
+            wait_until = ?wait_until,
+            "Sending transaction"
+        );
         let params = serde_json::json!({
             "signed_tx_base64": signed_tx.to_base64(),
             "wait_until": wait_until.as_str(),
         });
         let mut response: SendTxResponse = self.call("send_tx", params).await?;
         response.transaction_hash = tx_hash;
+        tracing::info!(tx_hash = %response.transaction_hash, "Transaction sent successfully");
         Ok(response)
     }
 

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -195,12 +195,7 @@ impl RpcClient {
             }
         }
 
-        tracing::error!(
-            rpc.method = method,
-            attempts = total_attempts,
-            "RPC request timed out after all retries"
-        );
-        Err(RpcError::Timeout(total_attempts))
+        unreachable!("all loop iterations return")
     }
 
     /// Single attempt to make an RPC call.
@@ -418,7 +413,6 @@ impl RpcClient {
     // ========================================================================
 
     /// View account information.
-    #[tracing::instrument(skip(self, block), fields(account_id = %account_id))]
     pub async fn view_account(
         &self,
         account_id: &AccountId,
@@ -434,7 +428,6 @@ impl RpcClient {
     }
 
     /// View access key information.
-    #[tracing::instrument(skip(self, block), fields(account_id = %account_id, public_key = %public_key))]
     pub async fn view_access_key(
         &self,
         account_id: &AccountId,
@@ -452,7 +445,6 @@ impl RpcClient {
     }
 
     /// View all access keys for an account.
-    #[tracing::instrument(skip(self, block), fields(account_id = %account_id))]
     pub async fn view_access_key_list(
         &self,
         account_id: &AccountId,
@@ -468,7 +460,6 @@ impl RpcClient {
     }
 
     /// Call a view function on a contract.
-    #[tracing::instrument(skip(self, args, block), fields(contract_id = %account_id, method = method_name))]
     pub async fn view_function(
         &self,
         account_id: &AccountId,

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -725,6 +725,14 @@ impl TransactionBuilder {
             .ok_or(Error::NoSigner)?;
 
         let signer_id = signer.account_id().clone();
+        let action_count = self.actions.len();
+
+        tracing::info!(
+            sender = %signer_id,
+            receiver = %self.receiver_id,
+            action_count = action_count,
+            "Signing transaction"
+        );
 
         // Get a signing key atomically. For RotatingSigner, this claims the next
         // key in rotation. The key contains both the public key and signing capability.
@@ -769,6 +777,13 @@ impl TransactionBuilder {
 
         // Sign with the key
         let signature = key.sign(tx.get_hash().as_bytes()).await?;
+        let tx_hash = tx.get_hash();
+
+        tracing::info!(
+            tx_hash = %tx_hash,
+            nonce = nonce,
+            "Transaction signed"
+        );
 
         Ok(SignedTransaction {
             transaction: tx,
@@ -1166,6 +1181,13 @@ impl IntoFuture for TransactionSend {
 
             let signer_id = signer.account_id().clone();
 
+            tracing::info!(
+                sender = %signer_id,
+                receiver = %builder.receiver_id,
+                action_count = builder.actions.len(),
+                "Sending transaction"
+            );
+
             // Retry loop for InvalidNonceError
             let max_nonce_retries = builder.max_nonce_retries;
             let network = builder.rpc.url().to_string();
@@ -1253,13 +1275,22 @@ impl IntoFuture for TransactionSend {
                     Err(RpcError::InvalidNonce { tx_nonce, ak_nonce })
                         if attempt < max_nonce_retries - 1 =>
                     {
+                        tracing::warn!(
+                            tx_nonce = tx_nonce,
+                            ak_nonce = ak_nonce,
+                            attempt = attempt + 1,
+                            "Invalid nonce, retrying"
+                        );
                         // Store ak_nonce for next iteration to avoid refetching
                         last_ak_nonce = Some(ak_nonce);
                         last_error =
                             Some(Error::Rpc(RpcError::InvalidNonce { tx_nonce, ak_nonce }));
                         continue;
                     }
-                    Err(e) => return Err(Error::Rpc(e)),
+                    Err(e) => {
+                        tracing::error!(error = %e, "Transaction send failed");
+                        return Err(Error::Rpc(e));
+                    }
                 }
             }
 

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -776,8 +776,8 @@ impl TransactionBuilder {
         );
 
         // Sign with the key
-        let signature = key.sign(tx.get_hash().as_bytes()).await?;
         let tx_hash = tx.get_hash();
+        let signature = key.sign(tx_hash.as_bytes()).await?;
 
         tracing::info!(
             tx_hash = %tx_hash,

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -309,8 +309,7 @@ impl FungibleToken {
         amount: impl Into<u128>,
     ) -> CallBuilder {
         let receiver_id: AccountId = receiver_id.into();
-        tracing::info!(contract = %self.contract_id, receiver = %receiver_id, "FT transfer");
-
+        tracing::debug!(contract = %self.contract_id, receiver = %receiver_id, "ft_transfer");
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -386,7 +385,7 @@ impl FungibleToken {
         msg: impl Into<String>,
     ) -> CallBuilder {
         let receiver_id: AccountId = receiver_id.into();
-        tracing::info!(contract = %self.contract_id, receiver = %receiver_id, "FT transfer_call");
+        tracing::debug!(contract = %self.contract_id, receiver = %receiver_id, "ft_transfer_call");
 
         #[derive(Serialize)]
         struct TransferCallArgs {

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -135,6 +135,7 @@ impl FungibleToken {
     /// ```
     pub async fn balance_of(&self, account_id: impl Into<AccountId>) -> Result<FtAmount, Error> {
         let account_id: AccountId = account_id.into();
+        tracing::debug!(contract = %self.contract_id, account = %account_id, "Querying FT balance");
         let metadata = self.metadata().await?;
 
         #[derive(Serialize)]
@@ -308,6 +309,7 @@ impl FungibleToken {
         amount: impl Into<u128>,
     ) -> CallBuilder {
         let receiver_id: AccountId = receiver_id.into();
+        tracing::info!(contract = %self.contract_id, receiver = %receiver_id, "FT transfer");
 
         #[derive(Serialize)]
         struct TransferArgs {
@@ -384,6 +386,7 @@ impl FungibleToken {
         msg: impl Into<String>,
     ) -> CallBuilder {
         let receiver_id: AccountId = receiver_id.into();
+        tracing::info!(contract = %self.contract_id, receiver = %receiver_id, "FT transfer_call");
 
         #[derive(Serialize)]
         struct TransferCallArgs {

--- a/crates/near-kit/src/tokens/nft.rs
+++ b/crates/near-kit/src/tokens/nft.rs
@@ -301,7 +301,7 @@ impl NonFungibleToken {
         receiver_id: impl Into<AccountId>,
         token_id: impl AsRef<str>,
     ) -> CallBuilder {
-        tracing::info!(contract = %self.contract_id, token_id = token_id.as_ref(), "NFT transfer");
+        tracing::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), "nft_transfer");
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -395,7 +395,7 @@ impl NonFungibleToken {
         token_id: impl AsRef<str>,
         msg: impl Into<String>,
     ) -> CallBuilder {
-        tracing::info!(contract = %self.contract_id, token_id = token_id.as_ref(), "NFT transfer_call");
+        tracing::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), "nft_transfer_call");
         #[derive(Serialize)]
         struct TransferCallArgs {
             receiver_id: String,

--- a/crates/near-kit/src/tokens/nft.rs
+++ b/crates/near-kit/src/tokens/nft.rs
@@ -133,6 +133,7 @@ impl NonFungibleToken {
     /// # }
     /// ```
     pub async fn token(&self, token_id: impl AsRef<str>) -> Result<Option<NftToken>, Error> {
+        tracing::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), "Querying NFT token");
         #[derive(Serialize)]
         struct Args<'a> {
             token_id: &'a str,
@@ -185,6 +186,7 @@ impl NonFungibleToken {
         limit: Option<u64>,
     ) -> Result<Vec<NftToken>, Error> {
         let account_id: AccountId = account_id.into();
+        tracing::debug!(contract = %self.contract_id, account = %account_id, "Querying NFT tokens for owner");
 
         #[derive(Serialize)]
         struct Args<'a> {
@@ -299,6 +301,7 @@ impl NonFungibleToken {
         receiver_id: impl Into<AccountId>,
         token_id: impl AsRef<str>,
     ) -> CallBuilder {
+        tracing::info!(contract = %self.contract_id, token_id = token_id.as_ref(), "NFT transfer");
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -392,6 +395,7 @@ impl NonFungibleToken {
         token_id: impl AsRef<str>,
         msg: impl Into<String>,
     ) -> CallBuilder {
+        tracing::info!(contract = %self.contract_id, token_id = token_id.as_ref(), "NFT transfer_call");
         #[derive(Serialize)]
         struct TransferCallArgs {
             receiver_id: String,


### PR DESCRIPTION
## Summary
Add tracing instrumentation to near-kit for observability into RPC calls, transaction signing/sending, nonce management, and token operations.

### Design
- **One log line per operation** — each high-level RPC method (`view_account`, `view_access_key`, `view_function`, `block`, `send_tx`, etc.) logs a descriptive `debug!` event with relevant fields
- **Nonce management** has a dedicated span (`nonce{account_id, public_key}`) that distinguishes RPC fetches from cache hits
- **Token operations** (FT/NFT transfer, balance queries) log at the appropriate level
- **Retries and errors** are logged from the low-level `call()` method at `warn`/`error` level
- No `#[instrument]` — manual events keep things simple and avoid span overhead

### Log levels
- `debug` — RPC queries, nonce cache hits, routine operations
- `info` — transaction signing and sending
- `warn` — retries (RPC, nonce collisions)
- `error` — RPC failures, transaction send failures

### Example output
```
 INFO near_kit::client::transaction: Sending transaction sender=sandbox receiver=alice.sandbox action_count=3
DEBUG nonce{account_id="sandbox" public_key="ed25519:5BGS..."}: Fetching nonce from RPC
DEBUG near_kit::client::rpc: view_access_key account_id=sandbox public_key=ed25519:5BGS...
DEBUG nonce{account_id="sandbox" public_key="ed25519:5BGS..."}: Nonce acquired from RPC nonce=1
DEBUG near_kit::client::rpc: block
 INFO near_kit::client::rpc: Sending transaction tx_hash=8jQo... sender=sandbox receiver=alice.sandbox

# Second tx — nonce from cache, no RPC call:
DEBUG nonce{account_id="sandbox" public_key="ed25519:5BGS..."}: Nonce from cache nonce=2
```

Closes #64

## Test plan
- [x] All 377 unit tests pass
- [x] Trybuild tests pass
- [x] Verified output against testnet (read-only queries)
- [x] Verified full transaction flow against sandbox (nonce fetch, signing, send, cache hit)