### PR TITLE
feat: expose signer accessor and fix RotatingSigner public_key

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -239,8 +239,18 @@ impl Near {
     }
 
     /// Get the signer's public key, if a signer is configured.
+    ///
+    /// This does not advance the rotation counter on [`RotatingSigner`](crate::RotatingSigner).
     pub fn public_key(&self) -> Option<PublicKey> {
-        self.signer.as_ref().map(|s| s.key().public_key().clone())
+        self.signer.as_ref().map(|s| s.public_key())
+    }
+
+    /// Get the signer, if one is configured.
+    ///
+    /// This is useful when you need to pass the signer to another system
+    /// or construct clients manually.
+    pub fn signer(&self) -> Option<Arc<dyn Signer>> {
+        self.signer.clone()
     }
 
     /// Get the network this client is connected to.

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -83,6 +83,15 @@ pub trait Signer: Send + Sync {
     /// For single-key signers, this always returns the same key.
     /// For rotating signers, this atomically claims the next key in rotation.
     fn key(&self) -> SigningKey;
+
+    /// Get the signer's public key without side effects.
+    ///
+    /// Unlike [`key()`](Signer::key), this does not advance the rotation counter
+    /// on [`RotatingSigner`]. The default implementation calls `key().public_key().clone()`,
+    /// which is correct for single-key signers.
+    fn public_key(&self) -> PublicKey {
+        self.key().public_key().clone()
+    }
 }
 
 /// Implement `Signer` for `Arc<dyn Signer>` for convenience.
@@ -93,6 +102,10 @@ impl Signer for Arc<dyn Signer> {
 
     fn key(&self) -> SigningKey {
         (**self).key()
+    }
+
+    fn public_key(&self) -> PublicKey {
+        (**self).public_key()
     }
 }
 
@@ -805,6 +818,10 @@ impl Signer for RotatingSigner {
         let idx = self.counter.fetch_add(1, Ordering::Relaxed) % self.keys.len();
         SigningKey::new(self.keys[idx].clone())
     }
+
+    fn public_key(&self) -> PublicKey {
+        self.keys[0].public_key()
+    }
 }
 
 // ============================================================================
@@ -1098,6 +1115,32 @@ mod tests {
             assert_eq!(ims.account_id().as_str(), "bot.testnet");
             assert_eq!(ims.public_key(), expected_pk);
         }
+    }
+
+    #[test]
+    fn test_rotating_signer_public_key_no_side_effect() {
+        let keys = vec![
+            SecretKey::generate_ed25519(),
+            SecretKey::generate_ed25519(),
+            SecretKey::generate_ed25519(),
+        ];
+        let first_pk = keys[0].public_key();
+
+        let signer = RotatingSigner::new("bot.testnet", keys).unwrap();
+
+        // Calling public_key() multiple times should always return the first key
+        // and should NOT advance the rotation counter
+        assert_eq!(signer.public_key(), first_pk);
+        assert_eq!(signer.public_key(), first_pk);
+        assert_eq!(signer.public_key(), first_pk);
+
+        // key() should still start from the first key (counter wasn't advanced)
+        let claimed = signer.key();
+        assert_eq!(claimed.public_key(), &first_pk);
+
+        // Now the counter has advanced, next key() should be the second
+        let second_pk = signer.key();
+        assert_ne!(second_pk.public_key(), &first_pk);
     }
 
     #[test]

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -86,9 +86,10 @@ pub trait Signer: Send + Sync {
 
     /// Get the signer's public key without side effects.
     ///
-    /// Unlike [`key()`](Signer::key), this does not advance the rotation counter
-    /// on [`RotatingSigner`]. The default implementation calls `key().public_key().clone()`,
-    /// which is correct for single-key signers.
+    /// The default implementation calls `key().public_key().clone()`,
+    /// which is correct for single-key signers. Implementors where `key()`
+    /// has side effects (e.g. advancing a rotation counter) **must** override
+    /// this method to avoid unintended state changes.
     fn public_key(&self) -> PublicKey {
         self.key().public_key().clone()
     }

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -820,7 +820,9 @@ impl Signer for RotatingSigner {
     }
 
     fn public_key(&self) -> PublicKey {
-        self.keys[0].public_key()
+        // Peek at whichever key will be claimed next, without advancing the counter
+        let idx = self.counter.load(Ordering::Relaxed) % self.keys.len();
+        self.keys[idx].public_key()
     }
 }
 
@@ -1124,23 +1126,31 @@ mod tests {
             SecretKey::generate_ed25519(),
             SecretKey::generate_ed25519(),
         ];
-        let first_pk = keys[0].public_key();
+        let pks: Vec<_> = keys.iter().map(|k| k.public_key()).collect();
 
         let signer = RotatingSigner::new("bot.testnet", keys).unwrap();
 
-        // Calling public_key() multiple times should always return the first key
-        // and should NOT advance the rotation counter
-        assert_eq!(signer.public_key(), first_pk);
-        assert_eq!(signer.public_key(), first_pk);
-        assert_eq!(signer.public_key(), first_pk);
+        // public_key() peeks at the next key without advancing the counter
+        assert_eq!(signer.public_key(), pks[0]);
+        assert_eq!(signer.public_key(), pks[0]);
+        assert_eq!(signer.public_key(), pks[0]);
 
         // key() should still start from the first key (counter wasn't advanced)
         let claimed = signer.key();
-        assert_eq!(claimed.public_key(), &first_pk);
+        assert_eq!(claimed.public_key(), &pks[0]);
 
-        // Now the counter has advanced, next key() should be the second
-        let second_pk = signer.key();
-        assert_ne!(second_pk.public_key(), &first_pk);
+        // After one key() call, public_key() should now reflect the second key
+        assert_eq!(signer.public_key(), pks[1]);
+
+        // Claim the second key, public_key() should reflect the third
+        let claimed = signer.key();
+        assert_eq!(claimed.public_key(), &pks[1]);
+        assert_eq!(signer.public_key(), pks[2]);
+
+        // Claim the third key, counter wraps around to the first
+        let claimed = signer.key();
+        assert_eq!(claimed.public_key(), &pks[2]);
+        assert_eq!(signer.public_key(), pks[0]);
     }
 
     #[test]

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -80,11 +80,9 @@ impl FungibleToken {
         &self.contract_id
     }
 
-    /// Create a new client with a different signer, sharing the same RPC connection
-    /// and cached metadata.
+    /// Create a new client with a different signer, sharing the same RPC connection.
     ///
-    /// This is useful for reusing a token client across multiple signers without
-    /// re-fetching metadata.
+    /// Metadata and storage bounds will be re-fetched on first access.
     ///
     /// # Example
     ///

--- a/crates/near-kit/src/tokens/nft.rs
+++ b/crates/near-kit/src/tokens/nft.rs
@@ -76,11 +76,9 @@ impl NonFungibleToken {
         &self.contract_id
     }
 
-    /// Create a new client with a different signer, sharing the same RPC connection
-    /// and cached metadata.
+    /// Create a new client with a different signer, sharing the same RPC connection.
     ///
-    /// This is useful for reusing a token client across multiple signers without
-    /// re-fetching metadata.
+    /// Metadata will be re-fetched on first access.
     pub fn with_signer(&self, signer: impl Signer + 'static) -> Self {
         Self {
             rpc: self.rpc.clone(),


### PR DESCRIPTION
## Summary
- Add `Near::signer()` returning `Option<Arc<dyn Signer>>` — lets users extract the signer to pass to other systems or construct clients manually
- Add `Signer::public_key()` trait method that doesn't advance rotation on `RotatingSigner` (fixes the side effect identified in #61 review)
- Fix `Near::public_key()` to use the new trait method
- Add test verifying `RotatingSigner::public_key()` doesn't advance the counter

## Context
User feedback: when receiving a configured `Near` instance, there's no way to extract the signer to pass it elsewhere. The signer field was private with no accessor.

Also addresses Copilot review feedback on #61 regarding the `RotatingSigner` side effect.

## Test plan
- [x] `test_rotating_signer_public_key_no_side_effect` — verifies repeated `public_key()` calls don't advance rotation, and subsequent `key()` calls still start from the expected position
- [x] All 378 existing tests pass