### PR TITLE
fix: refactor StorageDepositCall to use CallBuilder

### DIFF
--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -418,8 +418,7 @@ pub use client::KeyringSigner;
 // Re-export token types
 pub use tokens::{
     FtAmount, FtMetadata, FungibleToken, IntoContractId, KnownToken, NftContractMetadata, NftToken,
-    NftTokenMetadata, NonFungibleToken, StorageBalance, StorageBalanceBounds, StorageDepositCall,
-    USDC, USDT, W_NEAR,
+    NftTokenMetadata, NonFungibleToken, StorageBalance, StorageBalanceBounds, USDC, USDT, W_NEAR,
 };
 
 // Re-export proc macros

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -269,9 +269,8 @@ impl FungibleToken {
     ///
     /// Returns the minimum and maximum storage deposit amounts.
     /// The minimum is typically needed for [`storage_deposit`](Self::storage_deposit).
-    pub async fn storage_balance_bounds(&self) -> Result<StorageBalanceBounds, Error> {
-        let bounds = self
-            .storage_bounds
+    pub async fn storage_balance_bounds(&self) -> Result<&StorageBalanceBounds, Error> {
+        self.storage_bounds
             .get_or_try_init(|| async {
                 let result = self
                     .rpc
@@ -285,8 +284,7 @@ impl FungibleToken {
                     .map_err(Error::from)?;
                 result.json::<StorageBalanceBounds>().map_err(Error::from)
             })
-            .await?;
-        Ok(bounds.clone())
+            .await
     }
 
     /// Register an account on this token contract (storage_deposit).

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -316,7 +316,6 @@ impl FungibleToken {
         let account_id: AccountId = account_id
             .try_into_account_id()
             .expect("invalid account ID");
-        let deposit = deposit.into_near_token().expect("invalid deposit amount");
 
         #[derive(Serialize)]
         struct DepositArgs {

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -1,7 +1,5 @@
 //! Fungible token client (NEP-141).
 
-use std::future::{Future, IntoFuture};
-use std::pin::Pin;
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -10,8 +8,7 @@ use tokio::sync::OnceCell;
 use crate::client::{CallBuilder, RpcClient, Signer, TransactionBuilder};
 use crate::error::Error;
 use crate::types::{
-    AccountId, Action, BlockReference, Finality, Gas, IntoNearToken, NearToken, Transaction,
-    TryIntoAccountId, TxExecutionStatus,
+    AccountId, BlockReference, Finality, Gas, IntoNearToken, NearToken, TryIntoAccountId,
 };
 
 use super::types::{FtAmount, FtMetadata, StorageBalance, StorageBalanceBounds};
@@ -268,10 +265,31 @@ impl FungibleToken {
         result.json().map_err(Error::from)
     }
 
-    /// Register an account on this token contract (storage_deposit).
+    /// Get storage balance bounds for this token contract.
     ///
-    /// This deposits the minimum required NEAR to register the account for
-    /// receiving tokens.
+    /// Returns the minimum and maximum storage deposit amounts.
+    /// The minimum is typically needed for [`storage_deposit`](Self::storage_deposit).
+    pub async fn storage_balance_bounds(&self) -> Result<StorageBalanceBounds, Error> {
+        let bounds = self
+            .storage_bounds
+            .get_or_try_init(|| async {
+                let result = self
+                    .rpc
+                    .view_function(
+                        &self.contract_id,
+                        "storage_balance_bounds",
+                        &[],
+                        BlockReference::Finality(Finality::Optimistic),
+                    )
+                    .await
+                    .map_err(Error::from)?;
+                result.json::<StorageBalanceBounds>().map_err(Error::from)
+            })
+            .await?;
+        Ok(bounds.clone())
+    }
+
+    /// Register an account on this token contract (storage_deposit).
     ///
     /// # Example
     ///
@@ -283,22 +301,39 @@ impl FungibleToken {
     ///     .build();
     /// let usdc = near.ft(tokens::USDC)?;
     ///
-    /// // Register bob to receive USDC
-    /// usdc.storage_deposit("bob.near").await?;
+    /// // Register bob with auto-detected minimum deposit
+    /// let bounds = usdc.storage_balance_bounds().await?;
+    /// usdc.storage_deposit("bob.near", bounds.min).await?;
+    ///
+    /// // Or with a known amount
+    /// usdc.storage_deposit("bob.near", NearToken::from_millinear(50)).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn storage_deposit(&self, account_id: impl TryIntoAccountId) -> StorageDepositCall {
+    pub fn storage_deposit(
+        &self,
+        account_id: impl TryIntoAccountId,
+        deposit: impl IntoNearToken,
+    ) -> CallBuilder {
         let account_id: AccountId = account_id
             .try_into_account_id()
             .expect("invalid account ID");
-        StorageDepositCall::new(
-            self.rpc.clone(),
-            self.signer.clone(),
-            self.contract_id.clone(),
-            Some(account_id.to_string()),
-            self.storage_bounds.clone(),
-        )
+        let deposit = deposit.into_near_token().expect("invalid deposit amount");
+
+        #[derive(Serialize)]
+        struct DepositArgs {
+            account_id: String,
+            registration_only: bool,
+        }
+
+        self.transaction()
+            .call("storage_deposit")
+            .args(DepositArgs {
+                account_id: account_id.to_string(),
+                registration_only: true,
+            })
+            .deposit(deposit)
+            .gas(Gas::from_tgas(30))
     }
 
     // =========================================================================
@@ -462,196 +497,5 @@ impl std::fmt::Debug for FungibleToken {
             .field("contract_id", &self.contract_id)
             .field("metadata_cached", &self.metadata.initialized())
             .finish()
-    }
-}
-
-// =============================================================================
-// StorageDepositCall Builder
-// =============================================================================
-
-/// Builder for storage deposit transactions.
-///
-/// This builder needs special handling because it fetches storage bounds
-/// to determine the deposit amount, which requires async prep work.
-pub struct StorageDepositCall {
-    rpc: Arc<RpcClient>,
-    signer: Option<Arc<dyn Signer>>,
-    contract_id: AccountId,
-    account_id: Option<String>,
-    deposit: Option<NearToken>,
-    registration_only: bool,
-    storage_bounds: OnceCell<StorageBalanceBounds>,
-    signer_override: Option<Arc<dyn Signer>>,
-    wait_until: TxExecutionStatus,
-}
-
-impl StorageDepositCall {
-    fn new(
-        rpc: Arc<RpcClient>,
-        signer: Option<Arc<dyn Signer>>,
-        contract_id: AccountId,
-        account_id: Option<String>,
-        storage_bounds: OnceCell<StorageBalanceBounds>,
-    ) -> Self {
-        Self {
-            rpc,
-            signer,
-            contract_id,
-            account_id,
-            deposit: None,
-            registration_only: true,
-            storage_bounds,
-            signer_override: None,
-            wait_until: TxExecutionStatus::ExecutedOptimistic,
-        }
-    }
-
-    /// Set a custom deposit amount (overrides automatic minimum).
-    ///
-    /// # Panics
-    ///
-    /// Panics if the amount string cannot be parsed. Use [`NearToken`]'s `FromStr`
-    /// impl for fallible parsing of user input.
-    pub fn deposit(mut self, amount: impl IntoNearToken) -> Self {
-        self.deposit = Some(
-            amount
-                .into_near_token()
-                .expect("invalid deposit amount - use NearToken::from_str() for user input"),
-        );
-        self
-    }
-
-    /// Set registration_only flag (default: true).
-    ///
-    /// When true, any excess deposit is refunded. When false, excess is kept
-    /// as additional storage deposit.
-    pub fn registration_only(mut self, value: bool) -> Self {
-        self.registration_only = value;
-        self
-    }
-
-    /// Override the signer for this transaction.
-    pub fn sign_with(mut self, signer: impl Signer + 'static) -> Self {
-        self.signer_override = Some(Arc::new(signer));
-        self
-    }
-
-    /// Set the execution wait level.
-    pub fn wait_until(mut self, status: TxExecutionStatus) -> Self {
-        self.wait_until = status;
-        self
-    }
-}
-
-impl IntoFuture for StorageDepositCall {
-    type Output = Result<StorageBalance, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
-
-    fn into_future(self) -> Self::IntoFuture {
-        Box::pin(async move {
-            let signer = self
-                .signer_override
-                .as_ref()
-                .or(self.signer.as_ref())
-                .ok_or(Error::NoSigner)?;
-
-            let signer_id = signer.account_id().clone();
-
-            // Determine deposit amount
-            let deposit = if let Some(d) = self.deposit {
-                d
-            } else {
-                // Fetch storage bounds to get minimum
-                let bounds = self
-                    .storage_bounds
-                    .get_or_try_init(|| async {
-                        let result = self
-                            .rpc
-                            .view_function(
-                                &self.contract_id,
-                                "storage_balance_bounds",
-                                &[],
-                                BlockReference::Finality(Finality::Optimistic),
-                            )
-                            .await
-                            .map_err(Error::from)?;
-                        result.json::<StorageBalanceBounds>().map_err(Error::from)
-                    })
-                    .await?;
-                bounds.min
-            };
-
-            // Build args
-            #[derive(Serialize)]
-            struct DepositArgs {
-                #[serde(skip_serializing_if = "Option::is_none")]
-                account_id: Option<String>,
-                #[serde(skip_serializing_if = "std::ops::Not::not")]
-                registration_only: bool,
-            }
-
-            let args = serde_json::to_vec(&DepositArgs {
-                account_id: self.account_id,
-                registration_only: self.registration_only,
-            })?;
-
-            // Get a signing key atomically
-            let key = signer.key();
-            let public_key = key.public_key().clone();
-
-            // Get access key for nonce
-            let access_key = self
-                .rpc
-                .view_access_key(
-                    &signer_id,
-                    &public_key,
-                    BlockReference::Finality(Finality::Optimistic),
-                )
-                .await?;
-
-            // Get recent block hash
-            let block = self
-                .rpc
-                .block(BlockReference::Finality(Finality::Final))
-                .await?;
-
-            // Build transaction
-            let tx = Transaction::new(
-                signer_id,
-                public_key,
-                access_key.nonce + 1,
-                self.contract_id,
-                block.header.hash,
-                vec![Action::function_call(
-                    "storage_deposit".to_string(),
-                    args,
-                    Gas::from_tgas(30),
-                    deposit,
-                )],
-            );
-
-            // Sign
-            let signature = key.sign(tx.get_hash().as_bytes()).await?;
-            let signed_tx = crate::types::SignedTransaction {
-                transaction: tx,
-                signature,
-            };
-
-            // Send
-            let response = self.rpc.send_tx(&signed_tx, self.wait_until).await?;
-            let outcome = response.outcome.ok_or_else(|| {
-                Error::InvalidTransaction(format!(
-                    "Transaction {} submitted with wait_until={:?} but no execution \
-                     outcome was returned. Use rpc().send_tx() for fire-and-forget \
-                     submission.",
-                    response.transaction_hash, self.wait_until,
-                ))
-            })?;
-
-            // Parse return value
-            let tx_outcome: crate::types::TransactionOutcome = outcome.try_into()?;
-            let storage_balance: StorageBalance = tx_outcome.json()?;
-            Ok(storage_balance)
-        })
     }
 }

--- a/crates/near-kit/tests/integration/token_error_integration.rs
+++ b/crates/near-kit/tests/integration/token_error_integration.rs
@@ -146,7 +146,11 @@ async fn test_ft_storage_deposit_without_signer() {
     let no_signer_near = Near::custom(sandbox.rpc_url()).build();
 
     let ft = no_signer_near.ft("any-token.sandbox").unwrap();
-    let result = ft.storage_deposit("alice.near").await;
+
+    // storage_deposit builds a CallBuilder synchronously, NoSigner surfaces at send time
+    let result = ft
+        .storage_deposit("alice.near", NearToken::from_millinear(50))
+        .await;
 
     assert!(result.is_err(), "Should error when no signer configured");
     match result.unwrap_err() {

--- a/crates/near-kit/tests/integration/token_integration.rs
+++ b/crates/near-kit/tests/integration/token_integration.rs
@@ -217,7 +217,8 @@ async fn test_ft_transfer() {
     let ft = owner_near.ft(&ft_id).unwrap();
 
     // First, register receiver for storage
-    ft.storage_deposit(&receiver_id)
+    let bounds = ft.storage_balance_bounds().await.unwrap();
+    ft.storage_deposit(&receiver_id, bounds.min)
         .wait_until(TxExecutionStatus::Final)
         .await
         .unwrap();
@@ -309,13 +310,11 @@ async fn test_ft_storage_deposit() {
     assert!(!ft.is_registered(&user_id).await.unwrap());
 
     // Register user
-    let balance = ft
-        .storage_deposit(&user_id)
+    let bounds = ft.storage_balance_bounds().await.unwrap();
+    ft.storage_deposit(&user_id, bounds.min)
         .wait_until(TxExecutionStatus::Final)
         .await
         .unwrap();
-
-    println!("Storage balance after deposit: {:?}", balance);
 
     // User should now be registered
     assert!(ft.is_registered(&user_id).await.unwrap());


### PR DESCRIPTION
## Summary
`StorageDepositCall` had its own transaction building/signing/sending logic that bypassed `TransactionBuilder`'s nonce retry loop. This meant `storage_deposit` would fail on nonce collisions instead of retrying.

Replaced with:
- `storage_deposit(account_id, deposit)` — sync, returns `CallBuilder` directly
- `storage_balance_bounds()` — new public async method to fetch min deposit from contract

Users who want auto-detected deposit call `storage_balance_bounds()` first. Single await, no custom transaction type, nonce retries for free. Net -163 lines.

## API change

```rust
// Before (single await, but no nonce retry)
ft.storage_deposit("bob.near").await?;

// After (explicit deposit amount, nonce retries built in)
let bounds = ft.storage_balance_bounds().await?;
ft.storage_deposit("bob.near", bounds.min).await?;

// Or with a known amount
ft.storage_deposit("bob.near", NearToken::from_millinear(50)).await?;
```

## Test plan
- [x] `test_ft_storage_deposit` — registers account, verifies storage balance (sandbox)
- [x] `test_ft_transfer` — full flow: deploy, register via storage_deposit, transfer tokens (sandbox)
- [x] `test_ft_storage_deposit_without_signer` — NoSigner error at send time
- [x] `test_ft_transfer_without_signer` — NoSigner error
- [x] All 366 unit tests pass
- [x] Clippy clean

Closes #78