### PR TITLE
feat: TransactionOutcome newtype for type-safe transaction results

### DIFF
--- a/crates/near-kit/examples/meta_transactions.rs
+++ b/crates/near-kit/examples/meta_transactions.rs
@@ -53,7 +53,7 @@ async fn user_creates_delegate(
 async fn relayer_submits_delegate(
     relayer_near: &Near,
     delegate_result: DelegateResult,
-) -> Result<FinalExecutionOutcome, Error> {
+) -> Result<TransactionOutcome, Error> {
     println!("\n=== Relayer Side ===\n");
 
     // Relayer decodes and wraps the user's signed action

--- a/crates/near-kit/examples/rotating_signer.rs
+++ b/crates/near-kit/examples/rotating_signer.rs
@@ -90,8 +90,7 @@ async fn high_throughput_example() -> Result<(), Error> {
         })
         .collect();
 
-    let results: Vec<Result<FinalExecutionOutcome, Error>> =
-        futures::future::join_all(futures).await;
+    let results: Vec<Result<TransactionOutcome, Error>> = futures::future::join_all(futures).await;
     let duration = start.elapsed();
 
     let succeeded = results.iter().filter(|r| r.is_ok()).count();

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -654,7 +654,7 @@ impl Near {
     pub async fn send(
         &self,
         signed_tx: &crate::types::SignedTransaction,
-    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
+    ) -> Result<crate::types::TransactionOutcome, Error> {
         self.send_with_options(signed_tx, TxExecutionStatus::ExecutedOptimistic)
             .await
     }
@@ -664,7 +664,7 @@ impl Near {
         &self,
         signed_tx: &crate::types::SignedTransaction,
         wait_until: TxExecutionStatus,
-    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
+    ) -> Result<crate::types::TransactionOutcome, Error> {
         let response = self.rpc.send_tx(signed_tx, wait_until).await?;
         let outcome = response.outcome.ok_or_else(|| {
             Error::InvalidTransaction(format!(
@@ -674,13 +674,11 @@ impl Near {
             ))
         })?;
 
-        if outcome.is_failure() {
-            return Err(Error::TransactionFailed(
-                outcome.failure_message().unwrap_or_default(),
-            ));
+        if let Some(err) = outcome.failure_error() {
+            return Err(Error::TransactionFailed(err.clone()));
         }
 
-        Ok(outcome)
+        Ok(crate::types::TransactionOutcome::new(outcome))
     }
 
     // ========================================================================
@@ -706,7 +704,7 @@ impl Near {
         contract_id: impl TryIntoAccountId,
         method: &str,
         args: &A,
-    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
+    ) -> Result<crate::types::TransactionOutcome, Error> {
         self.call(contract_id, method).args(args).await
     }
 
@@ -718,7 +716,7 @@ impl Near {
         args: &A,
         gas: Gas,
         deposit: NearToken,
-    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
+    ) -> Result<crate::types::TransactionOutcome, Error> {
         self.call(contract_id, method)
             .args(args)
             .gas(gas)

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -677,6 +677,12 @@ impl Near {
         if let Some(err) = outcome.failure_error() {
             return Err(Error::TransactionFailed(err.clone()));
         }
+        if !outcome.is_success() {
+            return Err(Error::InvalidTransaction(format!(
+                "Transaction executed but status is {:?}, expected SuccessValue",
+                outcome.status,
+            )));
+        }
 
         Ok(crate::types::TransactionOutcome::new(outcome))
     }

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -674,17 +674,7 @@ impl Near {
             ))
         })?;
 
-        if let Some(err) = outcome.failure_error() {
-            return Err(Error::TransactionFailed(err.clone()));
-        }
-        if !outcome.is_success() {
-            return Err(Error::InvalidTransaction(format!(
-                "Transaction executed but status is {:?}, expected SuccessValue",
-                outcome.status,
-            )));
-        }
-
-        Ok(crate::types::TransactionOutcome::new(outcome))
+        outcome.try_into()
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1273,16 +1273,7 @@ impl IntoFuture for TransactionSend {
                                 response.transaction_hash, builder.wait_until,
                             ))
                         })?;
-                        if let Some(err) = outcome.failure_error() {
-                            return Err(Error::TransactionFailed(err.clone()));
-                        }
-                        if !outcome.is_success() {
-                            return Err(Error::InvalidTransaction(format!(
-                                "Transaction executed but status is {:?}, expected SuccessValue",
-                                outcome.status,
-                            )));
-                        }
-                        return Ok(TransactionOutcome::new(outcome));
+                        return outcome.try_into();
                     }
                     Err(RpcError::InvalidNonce { tx_nonce, ak_nonce })
                         if attempt < max_nonce_retries - 1 =>

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -36,9 +36,9 @@ use std::sync::{Arc, OnceLock};
 use crate::error::{Error, RpcError};
 use crate::types::{
     AccountId, Action, BlockReference, CryptoHash, DelegateAction, DeterministicAccountStateInit,
-    DeterministicAccountStateInitV1, FinalExecutionOutcome, Finality, Gas,
-    GlobalContractIdentifier, IntoGas, IntoNearToken, NearToken, NonDelegateAction, PublicKey,
-    SignedDelegateAction, SignedTransaction, Transaction, TryIntoAccountId, TxExecutionStatus,
+    DeterministicAccountStateInitV1, Finality, Gas, GlobalContractIdentifier, IntoGas,
+    IntoNearToken, NearToken, NonDelegateAction, PublicKey, SignedDelegateAction,
+    SignedTransaction, Transaction, TransactionOutcome, TryIntoAccountId, TxExecutionStatus,
 };
 
 use super::nonce_manager::NonceManager;
@@ -1142,7 +1142,7 @@ impl CallBuilder {
 }
 
 impl IntoFuture for CallBuilder {
-    type Output = Result<FinalExecutionOutcome, Error>;
+    type Output = Result<TransactionOutcome, Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -1168,7 +1168,7 @@ impl TransactionSend {
 }
 
 impl IntoFuture for TransactionSend {
-    type Output = Result<FinalExecutionOutcome, Error>;
+    type Output = Result<TransactionOutcome, Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -1273,12 +1273,10 @@ impl IntoFuture for TransactionSend {
                                 response.transaction_hash, builder.wait_until,
                             ))
                         })?;
-                        if outcome.is_failure() {
-                            return Err(Error::TransactionFailed(
-                                outcome.failure_message().unwrap_or_default(),
-                            ));
+                        if let Some(err) = outcome.failure_error() {
+                            return Err(Error::TransactionFailed(err.clone()));
                         }
-                        return Ok(outcome);
+                        return Ok(TransactionOutcome::new(outcome));
                     }
                     Err(RpcError::InvalidNonce { tx_nonce, ak_nonce })
                         if attempt < max_nonce_retries - 1 =>
@@ -1310,7 +1308,7 @@ impl IntoFuture for TransactionSend {
 }
 
 impl IntoFuture for TransactionBuilder {
-    type Output = Result<FinalExecutionOutcome, Error>;
+    type Output = Result<TransactionOutcome, Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1276,6 +1276,12 @@ impl IntoFuture for TransactionSend {
                         if let Some(err) = outcome.failure_error() {
                             return Err(Error::TransactionFailed(err.clone()));
                         }
+                        if !outcome.is_success() {
+                            return Err(Error::InvalidTransaction(format!(
+                                "Transaction executed but status is {:?}, expected SuccessValue",
+                                outcome.status,
+                            )));
+                        }
                         return Ok(TransactionOutcome::new(outcome));
                     }
                     Err(RpcError::InvalidNonce { tx_nonce, ak_nonce })

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -973,7 +973,12 @@ mod tests {
             )),
         });
         let err = Error::TransactionFailed(tx_err);
-        assert!(err.to_string().starts_with("Transaction failed: "));
+        let msg = err.to_string();
+        assert!(msg.starts_with("Transaction failed: "));
+        assert!(
+            msg.contains("execution error"),
+            "should contain inner error: {msg}"
+        );
     }
 
     #[test]

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -46,7 +46,7 @@
 
 use thiserror::Error;
 
-use crate::types::{AccountId, DelegateDecodeError, PublicKey};
+use crate::types::{AccountId, DelegateDecodeError, PublicKey, TxExecutionError};
 
 /// Error parsing an account ID.
 ///
@@ -412,7 +412,7 @@ pub enum Error {
 
     // ─── Transaction ───
     #[error("Transaction failed: {0}")]
-    TransactionFailed(String),
+    TransactionFailed(TxExecutionError),
 
     #[error("Invalid transaction: {0}")]
     InvalidTransaction(String),
@@ -965,10 +965,15 @@ mod tests {
 
     #[test]
     fn test_error_transaction_failed_display() {
-        assert_eq!(
-            Error::TransactionFailed("execution error".to_string()).to_string(),
-            "Transaction failed: execution error"
-        );
+        use crate::types::{ActionError, ActionErrorKind, FunctionCallError, TxExecutionError};
+        let tx_err = TxExecutionError::ActionError(ActionError {
+            index: Some(0),
+            kind: ActionErrorKind::FunctionCallError(FunctionCallError::ExecutionError(
+                "execution error".to_string(),
+            )),
+        });
+        let err = Error::TransactionFailed(tx_err);
+        assert!(err.to_string().starts_with("Transaction failed: "));
     }
 
     #[test]

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -648,18 +648,19 @@ impl IntoFuture for StorageDepositCall {
                 ))
             })?;
 
-            if outcome.is_failure() {
-                return Err(Error::TransactionFailed(
-                    outcome.failure_message().unwrap_or_default(),
-                ));
+            if let Some(err) = outcome.failure_error() {
+                return Err(Error::TransactionFailed(err.clone()));
+            }
+            if !outcome.is_success() {
+                return Err(Error::InvalidTransaction(format!(
+                    "Transaction executed but status is {:?}, expected SuccessValue",
+                    outcome.status,
+                )));
             }
 
             // Parse return value
-            let return_value = outcome
-                .success_value()
-                .ok_or_else(|| Error::TransactionFailed("No return value".to_string()))?;
-
-            let storage_balance: StorageBalance = serde_json::from_slice(&return_value)?;
+            let tx_outcome = crate::types::TransactionOutcome::new(outcome);
+            let storage_balance: StorageBalance = tx_outcome.json()?;
             Ok(storage_balance)
         })
     }

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -648,18 +648,8 @@ impl IntoFuture for StorageDepositCall {
                 ))
             })?;
 
-            if let Some(err) = outcome.failure_error() {
-                return Err(Error::TransactionFailed(err.clone()));
-            }
-            if !outcome.is_success() {
-                return Err(Error::InvalidTransaction(format!(
-                    "Transaction executed but status is {:?}, expected SuccessValue",
-                    outcome.status,
-                )));
-            }
-
             // Parse return value
-            let tx_outcome = crate::types::TransactionOutcome::new(outcome);
+            let tx_outcome: crate::types::TransactionOutcome = outcome.try_into()?;
             let storage_balance: StorageBalance = tx_outcome.json()?;
             Ok(storage_balance)
         })

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -89,8 +89,8 @@ pub use rpc::{
     FinalExecutionOutcome, FinalExecutionOutcomeWithReceipts, FinalExecutionStatus, GasPrice,
     GasProfileEntry, GlobalContractIdentifierView, MerkleDirection, MerklePathItem, NodeVersion,
     Receipt, ReceiptContent, STORAGE_AMOUNT_PER_BYTE, SendTxResponse, SendTxWithReceiptsResponse,
-    SlashedValidator, StatusResponse, SyncInfo, TransactionView, TrieSplit, ValidatorInfo,
-    ValidatorStakeView, ValidatorStakeViewV1, ViewFunctionResult,
+    SlashedValidator, StatusResponse, SyncInfo, TransactionOutcome, TransactionView, TrieSplit,
+    ValidatorInfo, ValidatorStakeView, ValidatorStakeViewV1, ViewFunctionResult,
 };
 pub use rpc_extra::{
     BlockHeaderInnerLiteView, CurrentEpochValidatorInfo, EpochValidatorInfo,

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -655,7 +655,16 @@ pub struct TransactionOutcome(FinalExecutionOutcome);
 
 impl TransactionOutcome {
     /// Create from a known-successful `FinalExecutionOutcome`.
+    ///
+    /// # Panics
+    ///
+    /// Debug-asserts that the outcome status is `SuccessValue`.
     pub(crate) fn new(outcome: FinalExecutionOutcome) -> Self {
+        debug_assert!(
+            outcome.is_success(),
+            "TransactionOutcome constructed from non-success status: {:?}",
+            outcome.status,
+        );
         Self(outcome)
     }
 

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -670,7 +670,8 @@ impl TransactionOutcome {
     /// Get the return value as raw bytes (base64-decoded).
     ///
     /// This is infallible because the transaction is guaranteed to have succeeded.
-    /// Returns an empty `Vec` if the success value is empty.
+    /// Returns an empty `Vec` if the success value is empty or if base64 decoding
+    /// fails (which would indicate a protocol-level bug in nearcore).
     pub fn value(&self) -> Vec<u8> {
         match &self.0.status {
             FinalExecutionStatus::SuccessValue(s) => STANDARD.decode(s).unwrap_or_default(),

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -654,19 +654,27 @@ impl FinalExecutionOutcome {
 #[derive(Debug, Clone)]
 pub struct TransactionOutcome(FinalExecutionOutcome);
 
-impl TransactionOutcome {
-    /// Create from a known-successful `FinalExecutionOutcome`.
-    ///
-    /// In debug builds, asserts that the outcome status is `SuccessValue`.
-    pub(crate) fn new(outcome: FinalExecutionOutcome) -> Self {
-        debug_assert!(
-            outcome.is_success(),
-            "TransactionOutcome constructed from non-success status: {:?}",
-            outcome.status,
-        );
-        Self(outcome)
-    }
+impl TryFrom<FinalExecutionOutcome> for TransactionOutcome {
+    type Error = crate::error::Error;
 
+    /// Convert a [`FinalExecutionOutcome`] into a [`TransactionOutcome`].
+    ///
+    /// Returns `Err` if the transaction failed or has not reached `SuccessValue` status.
+    fn try_from(outcome: FinalExecutionOutcome) -> Result<Self, Self::Error> {
+        if let Some(err) = outcome.failure_error() {
+            return Err(crate::error::Error::TransactionFailed(err.clone()));
+        }
+        if !outcome.is_success() {
+            return Err(crate::error::Error::InvalidTransaction(format!(
+                "Transaction executed but status is {:?}, expected SuccessValue",
+                outcome.status,
+            )));
+        }
+        Ok(Self(outcome))
+    }
+}
+
+impl TransactionOutcome {
     /// Get the return value as raw bytes (base64-decoded).
     ///
     /// This is infallible because the transaction is guaranteed to have succeeded.
@@ -1724,20 +1732,20 @@ mod tests {
     #[test]
     fn test_transaction_outcome_value() {
         // "hello" in base64
-        let outcome = TransactionOutcome::new(make_success_outcome("aGVsbG8="));
+        let outcome = TransactionOutcome::try_from(make_success_outcome("aGVsbG8=")).unwrap();
         assert_eq!(outcome.value(), b"hello");
     }
 
     #[test]
     fn test_transaction_outcome_value_empty() {
-        let outcome = TransactionOutcome::new(make_success_outcome(""));
+        let outcome = TransactionOutcome::try_from(make_success_outcome("")).unwrap();
         assert_eq!(outcome.value(), b"");
     }
 
     #[test]
     fn test_transaction_outcome_json() {
         // JSON `42` in base64
-        let outcome = TransactionOutcome::new(make_success_outcome("NDI="));
+        let outcome = TransactionOutcome::try_from(make_success_outcome("NDI=")).unwrap();
         let val: u64 = outcome.json().unwrap();
         assert_eq!(val, 42);
     }
@@ -1745,7 +1753,7 @@ mod tests {
     #[test]
     fn test_transaction_outcome_json_bad_data() {
         // "hello" is not valid JSON
-        let outcome = TransactionOutcome::new(make_success_outcome("aGVsbG8="));
+        let outcome = TransactionOutcome::try_from(make_success_outcome("aGVsbG8=")).unwrap();
         let result: Result<u64, _> = outcome.json();
         assert!(result.is_err());
     }
@@ -1754,25 +1762,26 @@ mod tests {
     fn test_transaction_outcome_value_invalid_base64_returns_empty() {
         // If the RPC somehow returns invalid base64 (protocol bug),
         // value() returns empty bytes rather than panicking.
-        let outcome = TransactionOutcome::new(make_success_outcome("not-valid-base64!!!"));
+        let outcome =
+            TransactionOutcome::try_from(make_success_outcome("not-valid-base64!!!")).unwrap();
         assert_eq!(outcome.value(), b"");
     }
 
     #[test]
     fn test_transaction_outcome_transaction_hash() {
-        let outcome = TransactionOutcome::new(make_success_outcome(""));
+        let outcome = TransactionOutcome::try_from(make_success_outcome("")).unwrap();
         assert!(!outcome.transaction_hash().is_zero());
     }
 
     #[test]
     fn test_transaction_outcome_total_gas_used() {
-        let outcome = TransactionOutcome::new(make_success_outcome(""));
+        let outcome = TransactionOutcome::try_from(make_success_outcome("")).unwrap();
         assert!(outcome.total_gas_used().as_gas() > 0);
     }
 
     #[test]
     fn test_transaction_outcome_raw() {
-        let outcome = TransactionOutcome::new(make_success_outcome(""));
+        let outcome = TransactionOutcome::try_from(make_success_outcome("")).unwrap();
         assert!(outcome.raw().is_success());
     }
 

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -590,25 +590,6 @@ impl FinalExecutionOutcome {
         matches!(&self.status, FinalExecutionStatus::Failure(_))
     }
 
-    /// Get the success value if present (base64 decoded).
-    pub fn success_value(&self) -> Option<Vec<u8>> {
-        match &self.status {
-            FinalExecutionStatus::SuccessValue(s) => STANDARD.decode(s).ok(),
-            _ => None,
-        }
-    }
-
-    /// Get the success value as a string if present.
-    pub fn success_value_string(&self) -> Option<String> {
-        self.success_value().and_then(|v| String::from_utf8(v).ok())
-    }
-
-    /// Get the success value deserialized as JSON.
-    pub fn success_value_json<T: serde::de::DeserializeOwned>(&self) -> Option<T> {
-        self.success_value()
-            .and_then(|v| serde_json::from_slice(&v).ok())
-    }
-
     /// Get the failure message if present.
     pub fn failure_message(&self) -> Option<String> {
         match &self.status {
@@ -639,6 +620,77 @@ impl FinalExecutionOutcome {
             .map(|r| r.outcome.gas_burnt.as_gas())
             .sum();
         Gas::from_gas(tx_gas + receipt_gas)
+    }
+}
+
+// =============================================================================
+// TransactionOutcome
+// =============================================================================
+
+/// The result of a successful transaction.
+///
+/// Returned by `.await?` on transaction builders ([`CallBuilder`](crate::CallBuilder),
+/// [`TransactionBuilder`](crate::TransactionBuilder)). The transaction is guaranteed
+/// to have succeeded — failures are returned as `Err(Error::TransactionFailed(...))`.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use near_kit::*;
+/// # async fn example(near: &Near) -> Result<(), Error> {
+/// let outcome = near.call("counter.testnet", "increment").await?;
+///
+/// // Get raw return value (infallible — success is guaranteed)
+/// let bytes: Vec<u8> = outcome.value();
+///
+/// // Deserialize as JSON (only fails on deserialization errors)
+/// let count: u64 = outcome.json()?;
+///
+/// println!("Gas used: {}", outcome.total_gas_used());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct TransactionOutcome(FinalExecutionOutcome);
+
+impl TransactionOutcome {
+    /// Create from a known-successful `FinalExecutionOutcome`.
+    pub(crate) fn new(outcome: FinalExecutionOutcome) -> Self {
+        Self(outcome)
+    }
+
+    /// Get the return value as raw bytes (base64-decoded).
+    ///
+    /// This is infallible because the transaction is guaranteed to have succeeded.
+    /// Returns an empty `Vec` if the success value is empty.
+    pub fn value(&self) -> Vec<u8> {
+        match &self.0.status {
+            FinalExecutionStatus::SuccessValue(s) => STANDARD.decode(s).unwrap_or_default(),
+            _ => Vec::new(),
+        }
+    }
+
+    /// Deserialize the return value as JSON.
+    ///
+    /// Only fails if the return value cannot be deserialized into `T`.
+    pub fn json<T: serde::de::DeserializeOwned>(&self) -> Result<T, crate::error::Error> {
+        let bytes = self.value();
+        serde_json::from_slice(&bytes).map_err(crate::error::Error::from)
+    }
+
+    /// Get the transaction hash.
+    pub fn transaction_hash(&self) -> &CryptoHash {
+        self.0.transaction_hash()
+    }
+
+    /// Get total gas used across all receipts.
+    pub fn total_gas_used(&self) -> Gas {
+        self.0.total_gas_used()
+    }
+
+    /// Access the underlying [`FinalExecutionOutcome`].
+    pub fn raw(&self) -> &FinalExecutionOutcome {
+        &self.0
     }
 }
 
@@ -1622,6 +1674,89 @@ mod tests {
         assert!(!outcome.is_success());
         assert!(outcome.failure_message().is_some());
         assert!(outcome.failure_error().is_some());
+    }
+
+    // ========================================================================
+    // TransactionOutcome tests
+    // ========================================================================
+
+    fn make_success_outcome(base64_value: &str) -> FinalExecutionOutcome {
+        let json = serde_json::json!({
+            "final_execution_status": "FINAL",
+            "status": {"SuccessValue": base64_value},
+            "transaction": {
+                "signer_id": "alice.near",
+                "public_key": "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp",
+                "nonce": 1,
+                "receiver_id": "bob.near",
+                "actions": [],
+                "signature": "ed25519:3s1dvMqNDCByoMnDnkhB4GPjTSXCRt4nt3Af5n1RX8W7aJ2FC6MfRf5BNXZ52EBifNJnNVBsGvke6GRYuaEYJXt5",
+                "hash": "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8U"
+            },
+            "transaction_outcome": {
+                "id": "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8U",
+                "outcome": {
+                    "executor_id": "alice.near",
+                    "gas_burnt": 223182562500_i64,
+                    "tokens_burnt": "22318256250000000000",
+                    "logs": [],
+                    "receipt_ids": [],
+                    "status": {"SuccessReceiptId": "3GTGoiN3FEoJenSw5ob4YMmFEV2Fbiichj3FDBnM78xK"}
+                },
+                "block_hash": "A6DJpKBhmAMmBuQXtY3dWbo8dGVSQ9yH7BQSJBfn8rBo",
+                "proof": []
+            },
+            "receipts_outcome": []
+        });
+        let response: SendTxResponse = serde_json::from_value(json).unwrap();
+        response.outcome.unwrap()
+    }
+
+    #[test]
+    fn test_transaction_outcome_value() {
+        // "hello" in base64
+        let outcome = TransactionOutcome::new(make_success_outcome("aGVsbG8="));
+        assert_eq!(outcome.value(), b"hello");
+    }
+
+    #[test]
+    fn test_transaction_outcome_value_empty() {
+        let outcome = TransactionOutcome::new(make_success_outcome(""));
+        assert_eq!(outcome.value(), b"");
+    }
+
+    #[test]
+    fn test_transaction_outcome_json() {
+        // JSON `42` in base64
+        let outcome = TransactionOutcome::new(make_success_outcome("NDI="));
+        let val: u64 = outcome.json().unwrap();
+        assert_eq!(val, 42);
+    }
+
+    #[test]
+    fn test_transaction_outcome_json_bad_data() {
+        // "hello" is not valid JSON
+        let outcome = TransactionOutcome::new(make_success_outcome("aGVsbG8="));
+        let result: Result<u64, _> = outcome.json();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_transaction_outcome_transaction_hash() {
+        let outcome = TransactionOutcome::new(make_success_outcome(""));
+        assert!(!outcome.transaction_hash().is_zero());
+    }
+
+    #[test]
+    fn test_transaction_outcome_total_gas_used() {
+        let outcome = TransactionOutcome::new(make_success_outcome(""));
+        assert!(outcome.total_gas_used().as_gas() > 0);
+    }
+
+    #[test]
+    fn test_transaction_outcome_raw() {
+        let outcome = TransactionOutcome::new(make_success_outcome(""));
+        assert!(outcome.raw().is_success());
     }
 
     // ========================================================================

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -629,8 +629,9 @@ impl FinalExecutionOutcome {
 
 /// The result of a successful transaction.
 ///
-/// Returned by `.await?` on transaction builders ([`CallBuilder`](crate::CallBuilder),
-/// [`TransactionBuilder`](crate::TransactionBuilder)). The transaction is guaranteed
+/// Returned by `.await?` on transaction builders and futures
+/// ([`CallBuilder`](crate::CallBuilder), [`TransactionBuilder`](crate::TransactionBuilder),
+/// [`TransactionSend`](crate::TransactionSend)). The transaction is guaranteed
 /// to have succeeded — failures are returned as `Err(Error::TransactionFailed(...))`.
 ///
 /// # Example
@@ -656,9 +657,7 @@ pub struct TransactionOutcome(FinalExecutionOutcome);
 impl TransactionOutcome {
     /// Create from a known-successful `FinalExecutionOutcome`.
     ///
-    /// # Panics
-    ///
-    /// Debug-asserts that the outcome status is `SuccessValue`.
+    /// In debug builds, asserts that the outcome status is `SuccessValue`.
     pub(crate) fn new(outcome: FinalExecutionOutcome) -> Self {
         debug_assert!(
             outcome.is_success(),

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -1751,6 +1751,14 @@ mod tests {
     }
 
     #[test]
+    fn test_transaction_outcome_value_invalid_base64_returns_empty() {
+        // If the RPC somehow returns invalid base64 (protocol bug),
+        // value() returns empty bytes rather than panicking.
+        let outcome = TransactionOutcome::new(make_success_outcome("not-valid-base64!!!"));
+        assert_eq!(outcome.value(), b"");
+    }
+
+    #[test]
     fn test_transaction_outcome_transaction_hash() {
         let outcome = TransactionOutcome::new(make_success_outcome(""));
         assert!(!outcome.transaction_hash().is_zero());

--- a/crates/near-kit/tests/integration/debug_rpc_responses.rs
+++ b/crates/near-kit/tests/integration/debug_rpc_responses.rs
@@ -162,14 +162,15 @@ async fn debug_transaction_receipts() {
         .await
         .unwrap();
 
+    let raw = outcome.raw();
     println!("\n========================================");
     println!("TRANSACTION OUTCOME");
     println!("========================================");
-    println!("Is success: {}", outcome.is_success());
-    println!("Status: {:?}", outcome.status);
+    println!("Is success: {}", raw.is_success());
+    println!("Status: {:?}", raw.status);
 
     {
-        let tx = &outcome.transaction;
+        let tx = &raw.transaction;
         println!("\n--- Transaction ---");
         println!("Hash: {}", tx.hash);
         println!("Signer: {}", tx.signer_id);
@@ -185,7 +186,7 @@ async fn debug_transaction_receipts() {
     }
 
     {
-        let tx_outcome = &outcome.transaction_outcome;
+        let tx_outcome = &raw.transaction_outcome;
         println!("\n--- Transaction Outcome ---");
         println!("ID: {}", tx_outcome.id);
         println!("Block hash: {}", tx_outcome.block_hash);
@@ -213,9 +214,9 @@ async fn debug_transaction_receipts() {
 
     println!(
         "\n--- Receipt Outcomes ({}) ---",
-        outcome.receipts_outcome.len()
+        raw.receipts_outcome.len()
     );
-    for (i, ro) in outcome.receipts_outcome.iter().enumerate() {
+    for (i, ro) in raw.receipts_outcome.iter().enumerate() {
         println!("\n  Receipt Outcome [{}]:", i);
         println!("    ID: {}", ro.id);
         println!("    Block hash: {}", ro.block_hash);

--- a/crates/near-kit/tests/integration/delegate_action_integration.rs
+++ b/crates/near-kit/tests/integration/delegate_action_integration.rs
@@ -132,11 +132,9 @@ async fn test_delegate_action_transfer() {
         .unwrap();
 
     println!(
-        "Relayer submitted delegate action: success={}, hash={:?}",
-        outcome.is_success(),
+        "Relayer submitted delegate action: hash={:?}",
         outcome.transaction_hash()
     );
-    assert!(outcome.is_success());
 
     // --- VERIFY: Check that the transfer happened ---
     let final_balance = root_near.balance(&recipient_id).await.unwrap();
@@ -236,7 +234,7 @@ async fn test_delegate_action_function_call() {
 
     let signed_delegate = SignedDelegateAction::from_base64(&delegate_result.payload).unwrap();
 
-    let outcome = relayer_near
+    let _outcome = relayer_near
         .transaction(signed_delegate.sender_id())
         .signed_delegate_action(signed_delegate)
         .send()
@@ -244,15 +242,6 @@ async fn test_delegate_action_function_call() {
         .await
         .unwrap();
 
-    println!(
-        "Relayer submitted delegate action: success={}",
-        outcome.is_success()
-    );
-    assert!(outcome.is_success());
-
-    // --- VERIFY: Check that the message was added ---
-    // The guestbook contract stores messages, so we verify by checking it didn't error
-    // (The contract doesn't have a get_messages view, so we just check success)
     println!("Delegate action function call successful!");
 }
 
@@ -327,7 +316,7 @@ async fn test_delegate_action_multiple_actions() {
 
     let signed_delegate = SignedDelegateAction::from_base64(&delegate_result.payload).unwrap();
 
-    let outcome = relayer_near
+    let _outcome = relayer_near
         .transaction(signed_delegate.sender_id())
         .signed_delegate_action(signed_delegate)
         .send()
@@ -335,11 +324,7 @@ async fn test_delegate_action_multiple_actions() {
         .await
         .unwrap();
 
-    println!(
-        "Relayer submitted delegate action: success={}",
-        outcome.is_success()
-    );
-    assert!(outcome.is_success());
+    println!("Delegate action with multiple actions succeeded");
 
     // --- VERIFY: Check that the new account was created ---
     assert!(root_near.account_exists(&new_account_id).await.unwrap());

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -86,7 +86,6 @@ async fn test_publish_contract_by_account() {
         "Publish contract succeeded: {:?}",
         outcome.transaction_hash()
     );
-    assert!(outcome.is_success());
 }
 
 /// Test publishing a contract to the global registry by code hash (immutable).
@@ -115,7 +114,6 @@ async fn test_publish_contract_by_hash() {
         "Publish contract by hash succeeded: {:?}",
         outcome.transaction_hash()
     );
-    assert!(outcome.is_success());
 }
 
 /// Test deploying a contract from a publisher account.
@@ -157,7 +155,6 @@ async fn test_deploy_from_publisher() {
         "Deploy from publisher succeeded: {:?}",
         outcome.transaction_hash()
     );
-    assert!(outcome.is_success());
 
     // Verify the contract was deployed by calling a view method
     // (with global contracts, the account references global code, not a local code_hash)
@@ -213,7 +210,6 @@ async fn test_deploy_from_hash() {
         "Deploy from hash succeeded: {:?}",
         outcome.transaction_hash()
     );
-    assert!(outcome.is_success());
 
     // Verify the contract was deployed by calling a view method
     // (with global contracts, the account references global code, not a local code_hash)
@@ -266,7 +262,6 @@ async fn test_state_init_by_hash() {
         "State init by hash succeeded: {:?}",
         outcome.transaction_hash()
     );
-    assert!(outcome.is_success());
 }
 
 /// Test NEP-616 deterministic state init with publisher account.
@@ -308,7 +303,6 @@ async fn test_state_init_by_publisher() {
         "State init by publisher succeeded: {:?}",
         outcome.transaction_hash()
     );
-    assert!(outcome.is_success());
 }
 
 // =============================================================================
@@ -328,7 +322,7 @@ async fn test_action_create_account() {
     let child_key = SecretKey::generate_ed25519();
     let child_id: AccountId = format!("child.{}", parent_id).parse().unwrap();
 
-    let outcome = parent_near
+    let _outcome = parent_near
         .transaction(&child_id)
         .create_account()
         .transfer(NearToken::from_near(5))
@@ -338,7 +332,6 @@ async fn test_action_create_account() {
         .await
         .unwrap();
 
-    assert!(outcome.is_success());
     assert!(root_near.account_exists(&child_id).await.unwrap());
 }
 
@@ -382,15 +375,13 @@ async fn test_action_deploy_contract() {
 
     let wasm_code = load_test_contract();
 
-    let outcome = contract_near
+    let _outcome = contract_near
         .transaction(&contract_id)
         .deploy(wasm_code)
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
         .unwrap();
-
-    assert!(outcome.is_success());
 
     // Verify contract was deployed
     let account = root_near.account(&contract_id).await.unwrap();
@@ -419,7 +410,7 @@ async fn test_action_function_call() {
         .unwrap();
 
     // Call a method on the contract
-    let outcome = contract_near
+    let _outcome = contract_near
         .transaction(&contract_id)
         .call("add_message")
         .args(serde_json::json!({ "text": "Hello from test!" }))
@@ -429,8 +420,6 @@ async fn test_action_function_call() {
         .wait_until(TxExecutionStatus::Final)
         .await
         .unwrap();
-
-    assert!(outcome.is_success());
 }
 
 /// Test AddKey action with full access
@@ -445,15 +434,13 @@ async fn test_action_add_full_access_key() {
 
     let new_key = SecretKey::generate_ed25519();
 
-    let outcome = account_near
+    let _outcome = account_near
         .transaction(&account_id)
         .add_full_access_key(new_key.public_key())
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
         .unwrap();
-
-    assert!(outcome.is_success());
 
     // Verify the key was added
     let keys = root_near.access_keys(&account_id).await.unwrap();
@@ -473,7 +460,7 @@ async fn test_action_add_function_call_key() {
     let fc_key = SecretKey::generate_ed25519();
     let receiver_contract: AccountId = "some-contract.sandbox".parse().unwrap();
 
-    let outcome = account_near
+    let _outcome = account_near
         .transaction(&account_id)
         .add_function_call_key(
             fc_key.public_key(),
@@ -485,8 +472,6 @@ async fn test_action_add_function_call_key() {
         .wait_until(TxExecutionStatus::Final)
         .await
         .unwrap();
-
-    assert!(outcome.is_success());
 
     // Verify the key was added
     let keys = root_near.access_keys(&account_id).await.unwrap();
@@ -608,10 +593,6 @@ async fn test_action_stake() {
         .unwrap();
 
     println!("Stake action completed: {:?}", outcome.transaction_hash());
-    assert!(
-        outcome.is_success(),
-        "Stake action should succeed with sufficient balance"
-    );
 
     // Verify locked balance reflects the stake
     let account = root_near.account(&staker_id).await.unwrap();
@@ -635,7 +616,7 @@ async fn test_multiple_actions() {
     let wasm_code = load_test_contract();
 
     // Create account, fund it, add key, deploy contract - all in one tx
-    let outcome = parent_near
+    let _outcome = parent_near
         .transaction(&child_id)
         .create_account()
         .transfer(NearToken::from_near(20))
@@ -645,8 +626,6 @@ async fn test_multiple_actions() {
         .wait_until(TxExecutionStatus::Final)
         .await
         .unwrap();
-
-    assert!(outcome.is_success());
 
     // Verify everything worked
     let account = root_near.account(&child_id).await.unwrap();
@@ -694,7 +673,6 @@ async fn test_multiple_function_calls() {
         .await
         .unwrap();
 
-    assert!(outcome.is_success());
     println!(
         "Multiple function calls: gas used = {}",
         outcome.total_gas_used()

--- a/crates/near-kit/tests/integration/offline_signing_integration.rs
+++ b/crates/near-kit/tests/integration/offline_signing_integration.rs
@@ -101,7 +101,6 @@ async fn test_sign_offline_transfer() {
     // Step 3: Send the signed transaction (online machine)
     let outcome = sender_near.send(&signed).await.unwrap();
 
-    assert!(outcome.is_success());
     println!("Transaction succeeded: {:?}", outcome.transaction_hash());
 
     // Verify the transfer happened
@@ -169,8 +168,7 @@ async fn test_sign_offline_function_call() {
         .unwrap();
 
     // Send
-    let outcome = contract_near.send(&signed).await.unwrap();
-    assert!(outcome.is_success());
+    let _outcome = contract_near.send(&signed).await.unwrap();
 
     // Verify the message was added
     let messages: Vec<serde_json::Value> = contract_near
@@ -257,8 +255,7 @@ async fn test_signed_transaction_roundtrip_bytes() {
     );
 
     // Verify the deserialized transaction can be sent
-    let outcome = sender_near.send(&deserialized).await.unwrap();
-    assert!(outcome.is_success());
+    let _outcome = sender_near.send(&deserialized).await.unwrap();
 }
 
 #[tokio::test]
@@ -323,8 +320,7 @@ async fn test_signed_transaction_roundtrip_base64() {
     );
 
     // Verify the deserialized transaction can be sent
-    let outcome = sender_near.send(&deserialized).await.unwrap();
-    assert!(outcome.is_success());
+    let _outcome = sender_near.send(&deserialized).await.unwrap();
 }
 
 #[tokio::test]
@@ -406,8 +402,8 @@ async fn test_offline_sign_and_transport_simulation() {
     println!("Online: received tx hash={}", received_tx.get_hash());
 
     // Send it
-    let outcome = sender_near.send(&received_tx).await.unwrap();
-    assert!(outcome.is_success());
+    let _outcome = sender_near.send(&received_tx).await.unwrap();
+
     println!("Online: transaction confirmed!");
 
     // Verify

--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -269,15 +269,16 @@ async fn test_final_execution_outcome_full_fields() {
         .await
         .unwrap();
 
-    // Verify FinalExecutionOutcome fields
-    assert!(outcome.is_success(), "Transaction should succeed");
+    // Verify FinalExecutionOutcome fields via .raw()
+    let raw = outcome.raw();
+    assert!(raw.is_success(), "Transaction should succeed");
     assert!(
-        !outcome.receipts_outcome.is_empty(),
+        !raw.receipts_outcome.is_empty(),
         "Should have receipt outcomes"
     );
 
     // Check transaction view (now a required field)
-    let tx = &outcome.transaction;
+    let tx = &raw.transaction;
     assert_eq!(tx.signer_id, root_account);
     assert_eq!(tx.receiver_id, receiver_id);
     assert!(tx.nonce > 0, "Nonce should be positive");
@@ -285,7 +286,7 @@ async fn test_final_execution_outcome_full_fields() {
     assert!(!tx.actions.is_empty(), "Should have actions");
 
     // Check transaction outcome (now a required field)
-    let tx_outcome = &outcome.transaction_outcome;
+    let tx_outcome = &raw.transaction_outcome;
     assert!(!tx_outcome.id.is_zero(), "Outcome ID should exist");
     assert!(!tx_outcome.block_hash.is_zero(), "Block hash should exist");
     assert_eq!(tx_outcome.outcome.executor_id, root_account);
@@ -296,7 +297,7 @@ async fn test_final_execution_outcome_full_fields() {
     );
 
     // Check receipts outcome
-    for receipt_outcome in &outcome.receipts_outcome {
+    for receipt_outcome in &raw.receipts_outcome {
         assert!(!receipt_outcome.id.is_zero(), "Receipt ID should exist");
         assert!(
             !receipt_outcome.block_hash.is_zero(),
@@ -319,7 +320,7 @@ async fn test_final_execution_outcome_full_fields() {
     println!("Transaction outcome:");
     println!("  Hash: {:?}", outcome.transaction_hash());
     println!("  Gas used: {}", outcome.total_gas_used());
-    println!("  Receipt outcomes: {}", outcome.receipts_outcome.len());
+    println!("  Receipt outcomes: {}", raw.receipts_outcome.len());
 }
 
 #[tokio::test]
@@ -343,7 +344,7 @@ async fn test_execution_metadata_and_gas_profile() {
 
     // Check if metadata is present (may not be in all protocol versions)
     let mut found_metadata = false;
-    for receipt_outcome in &outcome.receipts_outcome {
+    for receipt_outcome in &outcome.raw().receipts_outcome {
         if let Some(metadata) = &receipt_outcome.outcome.metadata {
             found_metadata = true;
             println!("Execution metadata version: {}", metadata.version);
@@ -483,7 +484,7 @@ async fn test_action_view_variants() {
         .await
         .unwrap();
 
-    let tx = &outcome.transaction;
+    let tx = &outcome.raw().transaction;
     println!("Transaction actions:");
     for action in &tx.actions {
         match action {

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -91,8 +91,7 @@ async fn test_sandbox_transfer() {
         .unwrap();
 
     println!(
-        "Create account outcome: success={}, hash={:?}",
-        outcome.is_success(),
+        "Create account outcome: hash={:?}",
         outcome.transaction_hash()
     );
 
@@ -270,8 +269,6 @@ async fn test_sandbox_create_account_outcome() {
 
     println!("Transaction hash: {:?}", outcome.transaction_hash());
     println!("Gas used: {}", outcome.total_gas_used());
-
-    assert!(outcome.is_success());
 }
 
 #[tokio::test]
@@ -606,10 +603,6 @@ async fn test_sandbox_set_balance_for_staking() {
         .unwrap();
 
     println!("Stake transaction: {:?}", outcome.transaction_hash());
-    assert!(
-        outcome.is_success(),
-        "Stake action should succeed with sufficient balance"
-    );
 
     // Verify locked balance reflects the stake
     let account = root_near.account(&validator_id).await.unwrap();
@@ -796,7 +789,6 @@ async fn test_send_with_options_final() {
         .await
         .unwrap();
 
-    assert!(outcome.is_success());
     println!("Transaction succeeded: {:?}", outcome.transaction_hash());
 
     // Verify the transfer happened
@@ -854,6 +846,5 @@ async fn test_send_pre_signed_transaction() {
     // Use the simple send() method (uses ExecutedOptimistic by default)
     let outcome = sender_near.send(&signed).await.unwrap();
 
-    assert!(outcome.is_success());
     println!("Transaction completed: {:?}", outcome.transaction_hash());
 }


### PR DESCRIPTION
## Summary

Addresses #77 — introduces `TransactionOutcome`, a newtype wrapper around `FinalExecutionOutcome` that guarantees success at the type level.

- **`TransactionOutcome`** is now returned by `.await?` on `CallBuilder`, `TransactionBuilder`, and `TransactionSend`. Since failures are already converted to `Err(Error::TransactionFailed(...))`, the returned type guarantees success — no more `is_success()` checks after `.await?`
- **`Error::TransactionFailed`** now holds `TxExecutionError` instead of `String`, preserving the typed error for programmatic handling (e.g., distinguishing "insufficient balance" from "method not found")
- **Removed** `success_value()`, `success_value_string()`, `success_value_json()` from `FinalExecutionOutcome` — these silently swallowed decode/parse errors via `Option`. Replaced by `TransactionOutcome::value()` and `::json()` with proper error handling

### `TransactionOutcome` API

| Method | Returns | Notes |
|--------|---------|-------|
| `value()` | `Vec<u8>` | Infallible — success is guaranteed |
| `json::<T>()` | `Result<T, Error>` | Only fails on deserialization |
| `transaction_hash()` | `&CryptoHash` | |
| `total_gas_used()` | `Gas` | |
| `raw()` | `&FinalExecutionOutcome` | Escape hatch for receipt inspection etc. |

### Before/After

```rust
// Before — outcome could be failure (but never is after .await?)
let outcome: FinalExecutionOutcome = near.call("c.near", "inc").await?;
let val: Option<u64> = outcome.success_value_json(); // silently swallows errors

// After — type guarantees success, errors are surfaced
let outcome: TransactionOutcome = near.call("c.near", "inc").await?;
let val: u64 = outcome.json()?; // only fails on deser
let bytes = outcome.value();     // infallible

// Typed error handling
match near.call("c.near", "inc").await {
    Err(Error::TransactionFailed(tx_err)) => { /* TxExecutionError, not String */ }
    _ => {}
}
```

### Breaking Changes

- `IntoFuture` output changed from `Result<FinalExecutionOutcome, Error>` to `Result<TransactionOutcome, Error>`
- `Error::TransactionFailed(String)` → `Error::TransactionFailed(TxExecutionError)`
- `FinalExecutionOutcome::success_value*()` methods removed

## Test plan

- [x] All 373 unit tests pass
- [x] Clippy clean (zero warnings)
- [x] Examples compile
- [x] Integration tests updated (removed redundant `is_success()` assertions, use `.raw()` for field access)
- [ ] Sandbox integration tests pass

Closes #77