### PR TITLE
feat: add function_call() one-shot method on TransactionBuilder

### DIFF
--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -683,9 +683,6 @@ impl TransactionBuilder {
     /// builder pattern. It's especially useful for dynamic transaction composition
     /// (e.g. building calls in a loop or conditionally).
     ///
-    /// Uses the same default gas as [`CallBuilder`] (30 TGas) when called with
-    /// [`Gas::default()`].
-    ///
     /// # Example
     ///
     /// ```rust,no_run
@@ -699,6 +696,11 @@ impl TransactionBuilder {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the gas or deposit values cannot be parsed. Use [`Gas::from_str()`]
+    /// and [`NearToken::from_str()`] for fallible parsing of user input.
     pub fn function_call(
         self,
         method: impl Into<String>,
@@ -1423,10 +1425,22 @@ mod tests {
             "init",
             serde_json::json!({"owner": "alice.testnet"}),
             Gas::from_tgas(50),
-            NearToken::ZERO,
+            NearToken::from_near(1),
         );
 
         assert_eq!(builder.actions.len(), 1);
+        match &builder.actions[0] {
+            Action::FunctionCall(fc) => {
+                assert_eq!(fc.method_name, "init");
+                assert_eq!(
+                    fc.args,
+                    serde_json::to_vec(&serde_json::json!({"owner": "alice.testnet"})).unwrap()
+                );
+                assert_eq!(fc.gas, Gas::from_tgas(50));
+                assert_eq!(fc.deposit, NearToken::from_near(1));
+            }
+            other => panic!("expected FunctionCall, got {:?}", other),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `TransactionBuilder::function_call(method, args, gas, deposit)` — a one-shot method that accepts `impl Serialize` for args, enabling ergonomic dynamic transaction composition without going through the `CallBuilder` ownership dance
- Adds corresponding delegation on `CallBuilder` for mid-chain switching
- The existing `.call("method").args(...).gas(...).finish()` pattern remains for cases where the builder ergonomics are preferred

## Test plan
- [x] Unit test: standalone `function_call` adds action correctly
- [x] Unit test: multiple `function_call` calls chain with other actions (deploy)
- [x] Unit test: transitioning from `CallBuilder` to `function_call` mid-chain
- [x] Clippy and rustfmt pass via pre-commit hooks

Closes #74