### PR TITLE
feat: add FunctionCall type for composable transaction building

### DIFF
--- a/crates/near-kit/src/client/mod.rs
+++ b/crates/near-kit/src/client/mod.rs
@@ -51,7 +51,7 @@ pub use query::{
 pub use rpc::{RetryConfig, RpcClient};
 pub use signer::{EnvSigner, FileSigner, InMemorySigner, RotatingSigner, Signer, SigningKey};
 pub use transaction::{
-    CallBuilder, DelegateOptions, DelegateResult, TransactionBuilder, TransactionSend,
+    CallBuilder, DelegateOptions, DelegateResult, FunctionCall, TransactionBuilder, TransactionSend,
 };
 
 #[cfg(feature = "keyring")]

--- a/crates/near-kit/src/client/mod.rs
+++ b/crates/near-kit/src/client/mod.rs
@@ -33,6 +33,7 @@
 //!
 //! - [`TransactionBuilder`] — Multi-action transaction builder
 //! - [`CallBuilder`] — Function call builder (part of transactions)
+//! - [`FunctionCall`] — Standalone function call for composable transactions
 
 mod near;
 mod nonce_manager;

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -879,10 +879,6 @@ impl TransactionBuilder {
 }
 
 // ============================================================================
-// CallBuilder
-// ============================================================================
-
-// ============================================================================
 // FunctionCall
 // ============================================================================
 
@@ -891,6 +887,10 @@ impl TransactionBuilder {
 /// Use this when you need to pre-build calls and compose them into a transaction
 /// later. This is especially useful for dynamic transaction composition (e.g. in
 /// a loop) or for batching typed contract calls into a single transaction.
+///
+/// Note: `FunctionCall` does not capture a receiver/contract account. The call
+/// will execute against whichever `receiver_id` is set on the transaction it's
+/// added to.
 ///
 /// # Examples
 ///

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1130,7 +1130,19 @@ impl CallBuilder {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Debug-panics if the underlying transaction builder already has accumulated
+    /// actions, since those would be silently dropped. Use [`finish`](Self::finish)
+    /// instead when chaining multiple actions on the same transaction.
     pub fn into_action(self) -> Action {
+        debug_assert!(
+            self.builder.actions.is_empty(),
+            "into_action() discards {} previously accumulated action(s) — \
+             use .finish() to keep them in the transaction",
+            self.builder.actions.len(),
+        );
         Action::function_call(self.method, self.args, self.gas, self.deposit)
     }
 

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -677,47 +677,6 @@ impl TransactionBuilder {
         self
     }
 
-    /// Add a function call action directly, without going through [`CallBuilder`].
-    ///
-    /// This is a one-shot alternative to the `.call("method").args(...).gas(...).deposit(...)`
-    /// builder pattern. It's especially useful for dynamic transaction composition
-    /// (e.g. building calls in a loop or conditionally).
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use near_kit::*;
-    /// # async fn example(near: Near) -> Result<(), near_kit::Error> {
-    /// near.transaction("contract.testnet")
-    ///     .function_call("init", serde_json::json!({"owner": "alice.testnet"}), Gas::from_tgas(50), NearToken::ZERO)
-    ///     .function_call("notify", serde_json::json!({"msg": "done"}), Gas::from_tgas(30), NearToken::ZERO)
-    ///     .send()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the gas or deposit values cannot be parsed. Use [`Gas::from_str()`]
-    /// and [`NearToken::from_str()`] for fallible parsing of user input.
-    pub fn function_call(
-        self,
-        method: impl Into<String>,
-        args: impl serde::Serialize,
-        gas: impl IntoGas,
-        deposit: impl IntoNearToken,
-    ) -> Self {
-        let args = serde_json::to_vec(&args).unwrap_or_default();
-        let gas = gas
-            .into_gas()
-            .expect("invalid gas format - use Gas::from_str() for user input");
-        let deposit = deposit
-            .into_near_token()
-            .expect("invalid deposit amount - use NearToken::from_str() for user input");
-        self.add_action(Action::function_call(method, args, gas, deposit))
-    }
-
     // ========================================================================
     // Configuration methods
     // ========================================================================
@@ -1047,20 +1006,6 @@ impl CallBuilder {
     /// Add another function call.
     pub fn call(self, method: &str) -> CallBuilder {
         self.finish().call(method)
-    }
-
-    /// Add a function call action directly.
-    ///
-    /// Finishes this function call, then adds the given function call.
-    /// See [`TransactionBuilder::function_call`] for details.
-    pub fn function_call(
-        self,
-        method: impl Into<String>,
-        args: impl serde::Serialize,
-        gas: impl IntoGas,
-        deposit: impl IntoNearToken,
-    ) -> TransactionBuilder {
-        self.finish().function_call(method, args, gas, deposit)
     }
 
     /// Add a create account action.
@@ -1416,66 +1361,6 @@ mod tests {
             .add_action(extra_action);
 
         // Should have two actions: the function call from CallBuilder + the transfer
-        assert_eq!(builder.actions.len(), 2);
-    }
-
-    #[test]
-    fn function_call_one_shot() {
-        let builder = test_builder().function_call(
-            "init",
-            serde_json::json!({"owner": "alice.testnet"}),
-            Gas::from_tgas(50),
-            NearToken::from_near(1),
-        );
-
-        assert_eq!(builder.actions.len(), 1);
-        match &builder.actions[0] {
-            Action::FunctionCall(fc) => {
-                assert_eq!(fc.method_name, "init");
-                assert_eq!(
-                    fc.args,
-                    serde_json::to_vec(&serde_json::json!({"owner": "alice.testnet"})).unwrap()
-                );
-                assert_eq!(fc.gas, Gas::from_tgas(50));
-                assert_eq!(fc.deposit, NearToken::from_near(1));
-            }
-            other => panic!("expected FunctionCall, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn function_call_chains_multiple() {
-        let builder = test_builder()
-            .deploy(vec![0u8])
-            .function_call(
-                "init",
-                serde_json::json!({"owner": "alice.testnet"}),
-                Gas::from_tgas(50),
-                NearToken::ZERO,
-            )
-            .function_call(
-                "notify",
-                serde_json::json!({"msg": "done"}),
-                Gas::from_tgas(30),
-                NearToken::ZERO,
-            );
-
-        assert_eq!(builder.actions.len(), 3);
-    }
-
-    #[test]
-    fn function_call_from_call_builder() {
-        let builder = test_builder()
-            .call("setup")
-            .args(serde_json::json!({"admin": "alice.testnet"}))
-            .gas(Gas::from_tgas(50))
-            .function_call(
-                "notify",
-                serde_json::json!({"msg": "done"}),
-                Gas::from_tgas(30),
-                NearToken::ZERO,
-            );
-
         assert_eq!(builder.actions.len(), 2);
     }
 }

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1133,11 +1133,11 @@ impl CallBuilder {
     ///
     /// # Panics
     ///
-    /// Debug-panics if the underlying transaction builder already has accumulated
+    /// Panics if the underlying transaction builder already has accumulated
     /// actions, since those would be silently dropped. Use [`finish`](Self::finish)
     /// instead when chaining multiple actions on the same transaction.
     pub fn into_action(self) -> Action {
-        debug_assert!(
+        assert!(
             self.builder.actions.is_empty(),
             "into_action() discards {} previously accumulated action(s) — \
              use .finish() to keep them in the transaction",

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -672,8 +672,8 @@ impl TransactionBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn add_action(mut self, action: Action) -> Self {
-        self.actions.push(action);
+    pub fn add_action(mut self, action: impl Into<Action>) -> Self {
+        self.actions.push(action.into());
         self
     }
 
@@ -882,6 +882,133 @@ impl TransactionBuilder {
 // CallBuilder
 // ============================================================================
 
+// ============================================================================
+// FunctionCall
+// ============================================================================
+
+/// A standalone function call configuration, decoupled from any transaction.
+///
+/// Use this when you need to pre-build calls and compose them into a transaction
+/// later. This is especially useful for dynamic transaction composition (e.g. in
+/// a loop) or for batching typed contract calls into a single transaction.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// # use near_kit::*;
+/// # async fn example(near: Near) -> Result<(), near_kit::Error> {
+/// // Pre-build calls independently
+/// let init = FunctionCall::new("init")
+///     .args(serde_json::json!({"owner": "alice.testnet"}))
+///     .gas(Gas::from_tgas(50));
+///
+/// let notify = FunctionCall::new("notify")
+///     .args(serde_json::json!({"msg": "done"}));
+///
+/// // Compose into a single atomic transaction
+/// near.transaction("contract.testnet")
+///     .add_action(init)
+///     .add_action(notify)
+///     .send()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ```rust,no_run
+/// # use near_kit::*;
+/// # async fn example(near: Near) -> Result<(), near_kit::Error> {
+/// // Dynamic composition in a loop
+/// let calls = vec![
+///     FunctionCall::new("method_a").args(serde_json::json!({"x": 1})),
+///     FunctionCall::new("method_b").args(serde_json::json!({"y": 2})),
+/// ];
+///
+/// let mut tx = near.transaction("contract.testnet");
+/// for call in calls {
+///     tx = tx.add_action(call);
+/// }
+/// tx.send().await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct FunctionCall {
+    method: String,
+    args: Vec<u8>,
+    gas: Gas,
+    deposit: NearToken,
+}
+
+impl FunctionCall {
+    /// Create a new function call for the given method name.
+    pub fn new(method: impl Into<String>) -> Self {
+        Self {
+            method: method.into(),
+            args: Vec::new(),
+            gas: Gas::from_tgas(30),
+            deposit: NearToken::ZERO,
+        }
+    }
+
+    /// Set JSON arguments.
+    pub fn args(mut self, args: impl serde::Serialize) -> Self {
+        self.args = serde_json::to_vec(&args).unwrap_or_default();
+        self
+    }
+
+    /// Set raw byte arguments.
+    pub fn args_raw(mut self, args: Vec<u8>) -> Self {
+        self.args = args;
+        self
+    }
+
+    /// Set Borsh-encoded arguments.
+    pub fn args_borsh(mut self, args: impl borsh::BorshSerialize) -> Self {
+        self.args = borsh::to_vec(&args).unwrap_or_default();
+        self
+    }
+
+    /// Set gas limit.
+    ///
+    /// Defaults to 30 TGas if not set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the gas string cannot be parsed. Use [`Gas`]'s `FromStr` impl
+    /// for fallible parsing of user input.
+    pub fn gas(mut self, gas: impl IntoGas) -> Self {
+        self.gas = gas
+            .into_gas()
+            .expect("invalid gas format - use Gas::from_str() for user input");
+        self
+    }
+
+    /// Set attached deposit.
+    ///
+    /// Defaults to zero if not set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the amount string cannot be parsed. Use [`NearToken`]'s `FromStr`
+    /// impl for fallible parsing of user input.
+    pub fn deposit(mut self, amount: impl IntoNearToken) -> Self {
+        self.deposit = amount
+            .into_near_token()
+            .expect("invalid deposit amount - use NearToken::from_str() for user input");
+        self
+    }
+}
+
+impl From<FunctionCall> for Action {
+    fn from(call: FunctionCall) -> Self {
+        Action::function_call(call.method, call.args, call.gas, call.deposit)
+    }
+}
+
+// ============================================================================
+// CallBuilder
+// ============================================================================
+
 /// Builder for configuring a function call within a transaction.
 ///
 /// Created via [`TransactionBuilder::call`]. Allows setting args, gas, and deposit
@@ -977,18 +1104,44 @@ impl CallBuilder {
         self
     }
 
+    /// Convert this call into a standalone [`Action`], discarding the
+    /// underlying transaction builder.
+    ///
+    /// This is useful for extracting a typed contract call so it can be
+    /// composed into a different transaction.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example(near: Near) -> Result<(), near_kit::Error> {
+    /// // Extract actions from the fluent builder
+    /// let action = near.transaction("contract.testnet")
+    ///     .call("method")
+    ///     .args(serde_json::json!({"key": "value"}))
+    ///     .gas(Gas::from_tgas(50))
+    ///     .into_action();
+    ///
+    /// // Compose into a different transaction
+    /// near.transaction("contract.testnet")
+    ///     .add_action(action)
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn into_action(self) -> Action {
+        Action::function_call(self.method, self.args, self.gas, self.deposit)
+    }
+
     /// Finish this call and return to the transaction builder.
     ///
     /// This is useful when you need to conditionally add actions to a
     /// transaction, since it gives back the [`TransactionBuilder`] so you can
     /// branch on runtime state before starting the next action.
     pub fn finish(self) -> TransactionBuilder {
-        self.builder.add_action(Action::function_call(
-            self.method,
-            self.args,
-            self.gas,
-            self.deposit,
-        ))
+        let action = Action::function_call(self.method, self.args, self.gas, self.deposit);
+        self.builder.add_action(action)
     }
 
     // ========================================================================
@@ -999,7 +1152,7 @@ impl CallBuilder {
     ///
     /// Finishes this function call, then adds the given action.
     /// See [`TransactionBuilder::add_action`] for details.
-    pub fn add_action(self, action: Action) -> TransactionBuilder {
+    pub fn add_action(self, action: impl Into<Action>) -> TransactionBuilder {
         self.finish().add_action(action)
     }
 
@@ -1361,6 +1514,109 @@ mod tests {
             .add_action(extra_action);
 
         // Should have two actions: the function call from CallBuilder + the transfer
+        assert_eq!(builder.actions.len(), 2);
+    }
+
+    // FunctionCall tests
+
+    #[test]
+    fn function_call_into_action() {
+        let call = FunctionCall::new("init")
+            .args(serde_json::json!({"owner": "alice.testnet"}))
+            .gas(Gas::from_tgas(50))
+            .deposit(NearToken::from_near(1));
+
+        let action: Action = call.into();
+        match &action {
+            Action::FunctionCall(fc) => {
+                assert_eq!(fc.method_name, "init");
+                assert_eq!(
+                    fc.args,
+                    serde_json::to_vec(&serde_json::json!({"owner": "alice.testnet"})).unwrap()
+                );
+                assert_eq!(fc.gas, Gas::from_tgas(50));
+                assert_eq!(fc.deposit, NearToken::from_near(1));
+            }
+            other => panic!("expected FunctionCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn function_call_defaults() {
+        let call = FunctionCall::new("method");
+        let action: Action = call.into();
+        match &action {
+            Action::FunctionCall(fc) => {
+                assert_eq!(fc.method_name, "method");
+                assert!(fc.args.is_empty());
+                assert_eq!(fc.gas, Gas::from_tgas(30));
+                assert_eq!(fc.deposit, NearToken::ZERO);
+            }
+            other => panic!("expected FunctionCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn function_call_compose_into_transaction() {
+        let init = FunctionCall::new("init")
+            .args(serde_json::json!({"owner": "alice.testnet"}))
+            .gas(Gas::from_tgas(50));
+
+        let notify = FunctionCall::new("notify").args(serde_json::json!({"msg": "done"}));
+
+        let builder = test_builder()
+            .deploy(vec![0u8])
+            .add_action(init)
+            .add_action(notify);
+
+        assert_eq!(builder.actions.len(), 3);
+    }
+
+    #[test]
+    fn function_call_dynamic_loop_composition() {
+        let methods = vec!["step1", "step2", "step3"];
+
+        let mut tx = test_builder();
+        for method in methods {
+            tx = tx.add_action(FunctionCall::new(method));
+        }
+
+        assert_eq!(tx.actions.len(), 3);
+    }
+
+    #[test]
+    fn call_builder_into_action() {
+        let action = test_builder()
+            .call("setup")
+            .args(serde_json::json!({"admin": "alice.testnet"}))
+            .gas(Gas::from_tgas(50))
+            .deposit(NearToken::from_near(1))
+            .into_action();
+
+        match &action {
+            Action::FunctionCall(fc) => {
+                assert_eq!(fc.method_name, "setup");
+                assert_eq!(fc.gas, Gas::from_tgas(50));
+                assert_eq!(fc.deposit, NearToken::from_near(1));
+            }
+            other => panic!("expected FunctionCall, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn call_builder_into_action_compose() {
+        let action1 = test_builder()
+            .call("method_a")
+            .gas(Gas::from_tgas(50))
+            .into_action();
+
+        let action2 = test_builder()
+            .call("method_b")
+            .deposit(NearToken::from_near(1))
+            .into_action();
+
+        let builder = test_builder().add_action(action1).add_action(action2);
+
         assert_eq!(builder.actions.len(), 2);
     }
 }

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1015,38 +1015,32 @@ impl From<FunctionCall> for Action {
 /// before continuing to chain more actions or sending.
 pub struct CallBuilder {
     builder: TransactionBuilder,
-    method: String,
-    args: Vec<u8>,
-    gas: Gas,
-    deposit: NearToken,
+    call: FunctionCall,
 }
 
 impl CallBuilder {
     fn new(builder: TransactionBuilder, method: String) -> Self {
         Self {
             builder,
-            method,
-            args: Vec::new(),
-            gas: Gas::from_tgas(30),
-            deposit: NearToken::ZERO,
+            call: FunctionCall::new(method),
         }
     }
 
     /// Set JSON arguments.
     pub fn args<A: serde::Serialize>(mut self, args: A) -> Self {
-        self.args = serde_json::to_vec(&args).unwrap_or_default();
+        self.call = self.call.args(args);
         self
     }
 
     /// Set raw byte arguments.
     pub fn args_raw(mut self, args: Vec<u8>) -> Self {
-        self.args = args;
+        self.call = self.call.args_raw(args);
         self
     }
 
     /// Set Borsh-encoded arguments.
     pub fn args_borsh<A: borsh::BorshSerialize>(mut self, args: A) -> Self {
-        self.args = borsh::to_vec(&args).unwrap_or_default();
+        self.call = self.call.args_borsh(args);
         self
     }
 
@@ -1071,9 +1065,7 @@ impl CallBuilder {
     /// Panics if the gas string cannot be parsed. Use [`Gas`]'s `FromStr` impl
     /// for fallible parsing of user input.
     pub fn gas(mut self, gas: impl IntoGas) -> Self {
-        self.gas = gas
-            .into_gas()
-            .expect("invalid gas format - use Gas::from_str() for user input");
+        self.call = self.call.gas(gas);
         self
     }
 
@@ -1098,9 +1090,7 @@ impl CallBuilder {
     /// Panics if the amount string cannot be parsed. Use [`NearToken`]'s `FromStr`
     /// impl for fallible parsing of user input.
     pub fn deposit(mut self, amount: impl IntoNearToken) -> Self {
-        self.deposit = amount
-            .into_near_token()
-            .expect("invalid deposit amount - use NearToken::from_str() for user input");
+        self.call = self.call.deposit(amount);
         self
     }
 
@@ -1143,7 +1133,7 @@ impl CallBuilder {
              use .finish() to keep them in the transaction",
             self.builder.actions.len(),
         );
-        Action::function_call(self.method, self.args, self.gas, self.deposit)
+        self.call.into()
     }
 
     /// Finish this call and return to the transaction builder.
@@ -1152,8 +1142,7 @@ impl CallBuilder {
     /// transaction, since it gives back the [`TransactionBuilder`] so you can
     /// branch on runtime state before starting the next action.
     pub fn finish(self) -> TransactionBuilder {
-        let action = Action::function_call(self.method, self.args, self.gas, self.deposit);
-        self.builder.add_action(action)
+        self.builder.add_action(self.call)
     }
 
     // ========================================================================

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -407,8 +407,8 @@ pub use contract::{Contract, ContractClient};
 // Re-export client types
 pub use client::{
     AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, CallBuilder, DelegateOptions,
-    DelegateResult, EnvSigner, FileSigner, InMemorySigner, Near, NearBuilder, RetryConfig,
-    RotatingSigner, RpcClient, SandboxNetwork, Signer, SigningKey, TransactionBuilder,
+    DelegateResult, EnvSigner, FileSigner, FunctionCall, InMemorySigner, Near, NearBuilder,
+    RetryConfig, RotatingSigner, RpcClient, SandboxNetwork, Signer, SigningKey, TransactionBuilder,
     TransactionSend, ViewCall, ViewCallBorsh,
 };
 


### PR DESCRIPTION
## Summary

- Reverts the `function_call()` one-shot from #81 in favor of a more composable approach
- Adds `FunctionCall` — a standalone struct for pre-building function calls independently of any transaction, then composing them via `add_action()`
- Adds `CallBuilder::into_action()` so typed contract calls can be extracted and batched into a single transaction
- `TransactionBuilder::add_action()` now accepts `impl Into<Action>`, so both `FunctionCall` and `Action` work directly

## API

```rust
// Standalone composition
let init = FunctionCall::new("init")
    .args(json!({"owner": "alice.near"}))
    .gas(Gas::from_tgas(50));
let notify = FunctionCall::new("notify")
    .args(json!({"msg": "done"}));

near.transaction("contract.near")
    .add_action(init)
    .add_action(notify)
    .send().await?;

// Dynamic loop composition
let mut tx = near.transaction("contract.near");
for call in calls {
    tx = tx.add_action(FunctionCall::new(call.method).args(call.args));
}
tx.send().await?;

// Typed contract composition via into_action()
let a = contract.method_a(args1).gas("50 Tgas").into_action();
let b = contract.method_b(args2).deposit("1 NEAR").into_action();

near.transaction(contract.contract_id())
    .add_action(a)
    .add_action(b)
    .send().await?;
```

Closes #82

## Test plan

- [x] Unit tests for `FunctionCall` defaults and field values
- [x] Unit tests for `FunctionCall` composition into transactions
- [x] Unit tests for dynamic loop composition
- [x] Unit tests for `CallBuilder::into_action()`
- [x] Unit tests for composing extracted actions into transactions
- [x] Clippy and rustfmt pass via pre-commit hooks