### PR TITLE
feat: support NEAR_MAX_NONCE_RETRIES env var and add Debug impls

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -123,6 +123,8 @@ impl Near {
     ///   Defaults to `"testnet"` if not set.
     /// - `NEAR_ACCOUNT_ID` (optional): Account ID for signing transactions.
     /// - `NEAR_PRIVATE_KEY` (optional): Private key for signing (e.g., `"ed25519:..."`).
+    /// - `NEAR_MAX_NONCE_RETRIES` (optional): Maximum number of transaction send
+    ///   attempts on `InvalidNonce` errors. Defaults to `3`.
     ///
     /// If `NEAR_ACCOUNT_ID` and `NEAR_PRIVATE_KEY` are both set, the client will
     /// be configured with signing capability. Otherwise, it will be read-only.
@@ -134,6 +136,7 @@ impl Near {
     /// export NEAR_NETWORK=testnet
     /// export NEAR_ACCOUNT_ID=alice.testnet
     /// export NEAR_PRIVATE_KEY=ed25519:...
+    /// export NEAR_MAX_NONCE_RETRIES=10
     /// ```
     ///
     /// ```rust,no_run
@@ -153,6 +156,7 @@ impl Near {
     /// Returns an error if:
     /// - `NEAR_ACCOUNT_ID` is set without `NEAR_PRIVATE_KEY` (or vice versa)
     /// - `NEAR_PRIVATE_KEY` contains an invalid key format
+    /// - `NEAR_MAX_NONCE_RETRIES` is set but not a valid positive integer
     pub fn from_env() -> Result<Near, Error> {
         let network = std::env::var("NEAR_NETWORK").ok();
         let account_id = std::env::var("NEAR_ACCOUNT_ID").ok();
@@ -183,6 +187,21 @@ impl Near {
             (None, None) => {
                 // Read-only client, no credentials
             }
+        }
+
+        // Configure max nonce retries if set
+        if let Ok(retries) = std::env::var("NEAR_MAX_NONCE_RETRIES") {
+            let retries: u32 = retries.parse().map_err(|_| {
+                Error::Config(format!(
+                    "NEAR_MAX_NONCE_RETRIES must be a positive integer, got: {retries}"
+                ))
+            })?;
+            if retries == 0 {
+                return Err(Error::Config(
+                    "NEAR_MAX_NONCE_RETRIES must be at least 1".into(),
+                ));
+            }
+            builder = builder.max_nonce_retries(retries);
         }
 
         Ok(builder.build())
@@ -1332,6 +1351,54 @@ mod tests {
             assert!(
                 err.to_string().contains("NEAR_ACCOUNT_ID"),
                 "Error should mention NEAR_ACCOUNT_ID: {}",
+                err
+            );
+        }
+
+        // Scenario 7: Custom max_nonce_retries
+        clear_env();
+        unsafe {
+            std::env::set_var("NEAR_MAX_NONCE_RETRIES", "10");
+        }
+        {
+            let near = Near::from_env().unwrap();
+            assert_eq!(near.max_nonce_retries, 10);
+        }
+
+        // Scenario 8: Invalid max_nonce_retries (not a number)
+        clear_env();
+        unsafe {
+            std::env::set_var("NEAR_MAX_NONCE_RETRIES", "abc");
+        }
+        {
+            let result = Near::from_env();
+            assert!(
+                result.is_err(),
+                "Expected error for non-numeric NEAR_MAX_NONCE_RETRIES"
+            );
+            let err = result.unwrap_err();
+            assert!(
+                err.to_string().contains("NEAR_MAX_NONCE_RETRIES"),
+                "Error should mention NEAR_MAX_NONCE_RETRIES: {}",
+                err
+            );
+        }
+
+        // Scenario 9: Invalid max_nonce_retries (zero)
+        clear_env();
+        unsafe {
+            std::env::set_var("NEAR_MAX_NONCE_RETRIES", "0");
+        }
+        {
+            let result = Near::from_env();
+            assert!(
+                result.is_err(),
+                "Expected error for zero NEAR_MAX_NONCE_RETRIES"
+            );
+            let err = result.unwrap_err();
+            assert!(
+                err.to_string().contains("NEAR_MAX_NONCE_RETRIES"),
+                "Error should mention NEAR_MAX_NONCE_RETRIES: {}",
                 err
             );
         }

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -1258,6 +1258,7 @@ mod tests {
                 std::env::remove_var("NEAR_NETWORK");
                 std::env::remove_var("NEAR_ACCOUNT_ID");
                 std::env::remove_var("NEAR_PRIVATE_KEY");
+                std::env::remove_var("NEAR_MAX_NONCE_RETRIES");
             }
         }
 

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -29,6 +29,7 @@
 //! ```
 
 use std::collections::BTreeMap;
+use std::fmt;
 use std::future::{Future, IntoFuture};
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
@@ -161,6 +162,25 @@ pub struct TransactionBuilder {
     signer_override: Option<Arc<dyn Signer>>,
     wait_until: TxExecutionStatus,
     max_nonce_retries: u32,
+}
+
+impl fmt::Debug for TransactionBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransactionBuilder")
+            .field(
+                "signer_id",
+                &self
+                    .signer_override
+                    .as_ref()
+                    .or(self.signer.as_ref())
+                    .map(|s| s.account_id()),
+            )
+            .field("receiver_id", &self.receiver_id)
+            .field("action_count", &self.actions.len())
+            .field("wait_until", &self.wait_until)
+            .field("max_nonce_retries", &self.max_nonce_retries)
+            .finish()
+    }
 }
 
 impl TransactionBuilder {
@@ -939,6 +959,17 @@ pub struct FunctionCall {
     deposit: NearToken,
 }
 
+impl fmt::Debug for FunctionCall {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FunctionCall")
+            .field("method", &self.method)
+            .field("args_len", &self.args.len())
+            .field("gas", &self.gas)
+            .field("deposit", &self.deposit)
+            .finish()
+    }
+}
+
 impl FunctionCall {
     /// Create a new function call for the given method name.
     pub fn new(method: impl Into<String>) -> Self {
@@ -1016,6 +1047,15 @@ impl From<FunctionCall> for Action {
 pub struct CallBuilder {
     builder: TransactionBuilder,
     call: FunctionCall,
+}
+
+impl fmt::Debug for CallBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CallBuilder")
+            .field("call", &self.call)
+            .field("builder", &self.builder)
+            .finish()
+    }
 }
 
 impl CallBuilder {


### PR DESCRIPTION
## Summary

Addresses the underlying needs from #83 without adding post-construction mutation to `Near`:

- **`from_env()` now reads `NEAR_MAX_NONCE_RETRIES`** — closes the gap where env-var users couldn't configure nonce retry behavior. Builder users already have `NearBuilder::max_nonce_retries()`.
- **Manual `Debug` impls for `TransactionBuilder`, `FunctionCall`, and `CallBuilder`** — safe for logging (shows action counts and arg lengths, not raw byte payloads).

## Test plan

- [x] New tests for `NEAR_MAX_NONCE_RETRIES` parsing (valid value, non-numeric, zero)
- [x] All 380 existing tests pass