### PR TITLE
feat!: implement Signer for Arc<T: Signer> instead of Arc<dyn Signer>

### DIFF
--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -95,8 +95,12 @@ pub trait Signer: Send + Sync {
     }
 }
 
-/// Implement `Signer` for `Arc<dyn Signer>` for convenience.
-impl Signer for Arc<dyn Signer> {
+/// Implement `Signer` for `Arc<T>` where `T: Signer`.
+///
+/// This covers `Arc<dyn Signer>` (since `dyn Signer: Signer`) as well as
+/// concrete types like `Arc<InMemorySigner>`, `Arc<RotatingSigner>`, etc.
+/// without requiring a cast to `Arc<dyn Signer>` first.
+impl<T: Signer + ?Sized> Signer for Arc<T> {
     fn account_id(&self) -> &AccountId {
         (**self).account_id()
     }


### PR DESCRIPTION
## Summary
- Replace `impl Signer for Arc<dyn Signer>` with generic `impl<T: Signer + ?Sized> Signer for Arc<T>`
- Enables `Arc<InMemorySigner>`, `Arc<RotatingSigner>`, etc. without requiring a cast to `Arc<dyn Signer>`
- Still covers `Arc<dyn Signer>` since `dyn Signer: Signer`

## Test plan
- [x] All 18 existing signer tests pass
- [x] `cargo check` passes
- [x] Clippy + rustfmt pass (pre-commit hook)

Closes #73