### PR TITLE
feat!: add Near::state_init() and simplify state init API

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -646,6 +646,33 @@ impl Near {
         )
     }
 
+    /// Create a NEP-616 deterministic state init transaction.
+    ///
+    /// The receiver_id is automatically derived from the state init parameters,
+    /// so unlike [`transaction()`](Self::transaction), no receiver needs to be specified.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example(near: Near, code_hash: CryptoHash) -> Result<(), near_kit::Error> {
+    /// let si = DeterministicAccountStateInit::by_hash(code_hash, Default::default());
+    /// let outcome = near.state_init(si, NearToken::from_near(5))
+    ///     .send()
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn state_init(
+        &self,
+        state_init: crate::types::DeterministicAccountStateInit,
+        deposit: impl IntoNearToken,
+    ) -> TransactionBuilder {
+        let receiver_id = state_init.derive_account_id();
+        self.transaction(receiver_id)
+            .state_init(state_init, deposit)
+    }
+
     /// Send a pre-signed transaction.
     ///
     /// Use this with transactions signed via `.sign()` for offline signing

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -663,6 +663,10 @@ impl Near {
     /// # Ok(())
     /// # }
     /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the deposit amount string cannot be parsed.
     pub fn state_init(
         &self,
         state_init: crate::types::DeterministicAccountStateInit,

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -668,9 +668,14 @@ impl Near {
         state_init: crate::types::DeterministicAccountStateInit,
         deposit: impl IntoNearToken,
     ) -> TransactionBuilder {
+        // Derive once and pass directly to avoid TransactionBuilder::state_init()
+        // re-deriving the same account ID.
+        let deposit = deposit
+            .into_near_token()
+            .expect("invalid deposit amount - use NearToken::from_str() for user input");
         let receiver_id = state_init.derive_account_id();
         self.transaction(receiver_id)
-            .state_init(state_init, deposit)
+            .add_action(crate::types::Action::state_init(state_init, deposit))
     }
 
     /// Send a pre-signed transaction.

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -577,7 +577,8 @@ impl TransactionBuilder {
     /// # use near_kit::*;
     /// # async fn example(near: Near, code_hash: CryptoHash) -> Result<(), near_kit::Error> {
     /// let si = DeterministicAccountStateInit::by_hash(code_hash, Default::default());
-    /// let outcome = near.state_init(si, NearToken::from_near(1))
+    /// let outcome = near.transaction("alice.testnet")
+    ///     .state_init(si, NearToken::from_near(1))
     ///     .send()
     ///     .await?;
     /// # Ok(())

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -28,7 +28,6 @@
 //! # }
 //! ```
 
-use std::collections::BTreeMap;
 use std::fmt;
 use std::future::{Future, IntoFuture};
 use std::pin::Pin;
@@ -37,9 +36,9 @@ use std::sync::{Arc, OnceLock};
 use crate::error::{Error, RpcError};
 use crate::types::{
     AccountId, Action, BlockReference, CryptoHash, DelegateAction, DeterministicAccountStateInit,
-    DeterministicAccountStateInitV1, Finality, Gas, GlobalContractIdentifier, IntoGas,
-    IntoNearToken, NearToken, NonDelegateAction, PublicKey, SignedDelegateAction,
-    SignedTransaction, Transaction, TransactionOutcome, TryIntoAccountId, TxExecutionStatus,
+    Finality, Gas, IntoGas, IntoNearToken, NearToken, NonDelegateAction, PublicKey,
+    SignedDelegateAction, SignedTransaction, Transaction, TransactionOutcome, TryIntoAccountId,
+    TxExecutionStatus,
 };
 
 use super::nonce_manager::NonceManager;
@@ -567,7 +566,7 @@ impl TransactionBuilder {
         self
     }
 
-    /// Create a NEP-616 deterministic state init action with code hash reference.
+    /// Create a NEP-616 deterministic state init action.
     ///
     /// The receiver_id is automatically set to the deterministically derived account ID:
     /// `"0s" + hex(keccak256(borsh(state_init))[12..32])`
@@ -577,76 +576,13 @@ impl TransactionBuilder {
     /// ```rust,no_run
     /// # use near_kit::*;
     /// # async fn example(near: Near, code_hash: CryptoHash) -> Result<(), near_kit::Error> {
-    /// // Note: the receiver_id passed to transaction() is ignored for state_init -
-    /// // it will be replaced with the derived deterministic account ID
-    /// let outcome = near.transaction("alice.testnet")
-    ///     .state_init_by_hash(code_hash, Default::default(), NearToken::from_near(1))
+    /// let si = DeterministicAccountStateInit::by_hash(code_hash, Default::default());
+    /// let outcome = near.state_init(si, NearToken::from_near(1))
     ///     .send()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the deposit amount string cannot be parsed.
-    pub fn state_init_by_hash(
-        self,
-        code_hash: CryptoHash,
-        data: BTreeMap<Vec<u8>, Vec<u8>>,
-        deposit: impl IntoNearToken,
-    ) -> Self {
-        let state_init = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::CodeHash(code_hash),
-            data,
-        });
-        self.state_init(state_init, deposit)
-    }
-
-    /// Create a NEP-616 deterministic state init action with publisher account reference.
-    ///
-    /// The receiver_id is automatically set to the deterministically derived account ID.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use near_kit::*;
-    /// # async fn example(near: Near) -> Result<(), near_kit::Error> {
-    /// // Note: the receiver_id passed to transaction() is ignored for state_init -
-    /// // it will be replaced with the derived deterministic account ID
-    /// let outcome = near.transaction("alice.testnet")
-    ///     .state_init_by_publisher("contract-publisher.near", Default::default(), NearToken::from_near(1))
-    ///     .send()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if the deposit amount string cannot be parsed.
-    pub fn state_init_by_publisher(
-        self,
-        publisher_id: impl TryIntoAccountId,
-        data: BTreeMap<Vec<u8>, Vec<u8>>,
-        deposit: impl IntoNearToken,
-    ) -> Self {
-        let publisher_id = publisher_id
-            .try_into_account_id()
-            .expect("invalid account ID");
-        let state_init = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::AccountId(publisher_id),
-            data,
-        });
-        self.state_init(state_init, deposit)
-    }
-
-    /// Create a NEP-616 deterministic state init action from a pre-built state init.
-    ///
-    /// This is a convenience method that accepts a [`DeterministicAccountStateInit`] directly,
-    /// avoiding the need to branch on [`GlobalContractIdentifier`] variants.
-    ///
-    /// The receiver_id is automatically set to the deterministically derived account ID.
     ///
     /// # Panics
     ///
@@ -1264,28 +1200,7 @@ impl CallBuilder {
         self.finish().deploy_from_publisher(publisher_id)
     }
 
-    /// Create a NEP-616 deterministic state init action with code hash reference.
-    pub fn state_init_by_hash(
-        self,
-        code_hash: CryptoHash,
-        data: BTreeMap<Vec<u8>, Vec<u8>>,
-        deposit: impl IntoNearToken,
-    ) -> TransactionBuilder {
-        self.finish().state_init_by_hash(code_hash, data, deposit)
-    }
-
-    /// Create a NEP-616 deterministic state init action with publisher account reference.
-    pub fn state_init_by_publisher(
-        self,
-        publisher_id: impl TryIntoAccountId,
-        data: BTreeMap<Vec<u8>, Vec<u8>>,
-        deposit: impl IntoNearToken,
-    ) -> TransactionBuilder {
-        self.finish()
-            .state_init_by_publisher(publisher_id, data, deposit)
-    }
-
-    /// Create a NEP-616 deterministic state init action from a pre-built state init.
+    /// Create a NEP-616 deterministic state init action.
     pub fn state_init(
         self,
         state_init: DeterministicAccountStateInit,

--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -310,6 +310,22 @@ pub struct DeterministicStateInitAction {
 }
 
 impl DeterministicAccountStateInit {
+    /// Create a state init referencing a global contract by its code hash (immutable).
+    pub fn by_hash(code_hash: CryptoHash, data: BTreeMap<Vec<u8>, Vec<u8>>) -> Self {
+        Self::V1(DeterministicAccountStateInitV1 {
+            code: GlobalContractIdentifier::CodeHash(code_hash),
+            data,
+        })
+    }
+
+    /// Create a state init referencing a global contract by its publisher account (updatable).
+    pub fn by_publisher(publisher_id: AccountId, data: BTreeMap<Vec<u8>, Vec<u8>>) -> Self {
+        Self::V1(DeterministicAccountStateInitV1 {
+            code: GlobalContractIdentifier::AccountId(publisher_id),
+            data,
+        })
+    }
+
     /// Derive the deterministic account ID from this state init.
     ///
     /// The account ID is derived as: `"0s" + hex(keccak256(borsh(state_init))[12..32])`
@@ -321,13 +337,10 @@ impl DeterministicAccountStateInit {
     /// # Example
     ///
     /// ```rust
-    /// use near_kit::types::{DeterministicAccountStateInit, DeterministicAccountStateInitV1, GlobalContractIdentifier, CryptoHash};
+    /// use near_kit::types::{DeterministicAccountStateInit, CryptoHash};
     /// use std::collections::BTreeMap;
     ///
-    /// let state_init = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-    ///     code: GlobalContractIdentifier::CodeHash(CryptoHash::default()),
-    ///     data: BTreeMap::new(),
-    /// });
+    /// let state_init = DeterministicAccountStateInit::by_hash(CryptoHash::default(), BTreeMap::new());
     ///
     /// let account_id = state_init.derive_account_id();
     /// assert!(account_id.as_str().starts_with("0s"));
@@ -553,36 +566,6 @@ impl Action {
     pub fn state_init(state_init: DeterministicAccountStateInit, deposit: NearToken) -> Self {
         Self::DeterministicStateInit(DeterministicStateInitAction {
             state_init,
-            deposit,
-        })
-    }
-
-    /// Create a NEP-616 deterministic state init action with code hash reference.
-    pub fn state_init_by_hash(
-        code_hash: CryptoHash,
-        data: BTreeMap<Vec<u8>, Vec<u8>>,
-        deposit: NearToken,
-    ) -> Self {
-        Self::DeterministicStateInit(DeterministicStateInitAction {
-            state_init: DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-                code: GlobalContractIdentifier::CodeHash(code_hash),
-                data,
-            }),
-            deposit,
-        })
-    }
-
-    /// Create a NEP-616 deterministic state init action with account reference.
-    pub fn state_init_by_account(
-        account_id: AccountId,
-        data: BTreeMap<Vec<u8>, Vec<u8>>,
-        deposit: NearToken,
-    ) -> Self {
-        Self::DeterministicStateInit(DeterministicStateInitAction {
-            state_init: DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-                code: GlobalContractIdentifier::AccountId(account_id),
-                data,
-            }),
             deposit,
         })
     }
@@ -915,8 +898,10 @@ mod tests {
         );
 
         // DeterministicStateInit (discriminant = 11)
-        let state_init =
-            Action::state_init_by_hash(code_hash, BTreeMap::new(), NearToken::from_near(1));
+        let state_init = Action::state_init(
+            DeterministicAccountStateInit::by_hash(code_hash, BTreeMap::new()),
+            NearToken::from_near(1),
+        );
         let bytes = borsh::to_vec(&state_init).unwrap();
         assert_eq!(
             bytes[0], 11,

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -249,10 +249,9 @@ async fn test_state_init_by_hash() {
     let initial_data: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
 
     // Use state_init to create a deterministic account
-    // Note: The receiver_id doesn't matter for state_init - the account ID is derived
+    let si = near_kit::DeterministicAccountStateInit::by_hash(code_hash, initial_data);
     let outcome = publisher_near
-        .transaction(&publisher_id)
-        .state_init_by_hash(code_hash, initial_data, NearToken::from_near(5))
+        .state_init(si, NearToken::from_near(5))
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
@@ -291,9 +290,10 @@ async fn test_state_init_by_publisher() {
     initial_data.insert(b"key1".to_vec(), b"value1".to_vec());
 
     // Use state_init to create a deterministic account
+    let si =
+        near_kit::DeterministicAccountStateInit::by_publisher(publisher_id.clone(), initial_data);
     let outcome = publisher_near
-        .transaction(&publisher_id)
-        .state_init_by_publisher(&publisher_id, initial_data, NearToken::from_near(5))
+        .state_init(si, NearToken::from_near(5))
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await


### PR DESCRIPTION
## Summary
- Adds `DeterministicAccountStateInit::by_hash()` and `::by_publisher()` constructors
- Adds `Near::state_init(state_init, deposit)` — no dummy receiver_id needed
- Removes `state_init_by_hash` and `state_init_by_publisher` from `TransactionBuilder`, `CallBuilder`, and `Action`
- Consolidates to a single `state_init()` method on each builder

## Breaking Changes
- `TransactionBuilder::state_init_by_hash()` removed — use `DeterministicAccountStateInit::by_hash()` + `.state_init()`
- `TransactionBuilder::state_init_by_publisher()` removed — use `DeterministicAccountStateInit::by_publisher()` + `.state_init()`
- `Action::state_init_by_hash()` and `Action::state_init_by_account()` removed — use `Action::state_init()` with the new constructors

## Test plan
- [x] `cargo check` passes
- [x] All 115 doc tests pass
- [x] Pre-commit hooks (clippy + rustfmt) pass
- [ ] Integration tests (require sandbox)

Closes #72