### PR TITLE
feat!: return FinalExecutionOutcome directly, remove TransactionOutcome newtype

### DIFF
--- a/crates/near-kit/examples/meta_transactions.rs
+++ b/crates/near-kit/examples/meta_transactions.rs
@@ -53,7 +53,7 @@ async fn user_creates_delegate(
 async fn relayer_submits_delegate(
     relayer_near: &Near,
     delegate_result: DelegateResult,
-) -> Result<TransactionOutcome, Error> {
+) -> Result<FinalExecutionOutcome, Error> {
     println!("\n=== Relayer Side ===\n");
 
     // Relayer decodes and wraps the user's signed action

--- a/crates/near-kit/examples/rotating_signer.rs
+++ b/crates/near-kit/examples/rotating_signer.rs
@@ -90,7 +90,8 @@ async fn high_throughput_example() -> Result<(), Error> {
         })
         .collect();
 
-    let results: Vec<Result<TransactionOutcome, Error>> = futures::future::join_all(futures).await;
+    let results: Vec<Result<FinalExecutionOutcome, Error>> =
+        futures::future::join_all(futures).await;
     let duration = start.elapsed();
 
     let succeeded = results.iter().filter(|r| r.is_ok()).count();

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -709,7 +709,7 @@ impl Near {
     pub async fn send(
         &self,
         signed_tx: &crate::types::SignedTransaction,
-    ) -> Result<crate::types::TransactionOutcome, Error> {
+    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
         self.send_with_options(signed_tx, TxExecutionStatus::ExecutedOptimistic)
             .await
     }
@@ -719,7 +719,7 @@ impl Near {
         &self,
         signed_tx: &crate::types::SignedTransaction,
         wait_until: TxExecutionStatus,
-    ) -> Result<crate::types::TransactionOutcome, Error> {
+    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
         let response = self.rpc.send_tx(signed_tx, wait_until).await?;
         let outcome = response.outcome.ok_or_else(|| {
             Error::InvalidTransaction(format!(
@@ -729,7 +729,7 @@ impl Near {
             ))
         })?;
 
-        outcome.try_into()
+        Ok(outcome)
     }
 
     // ========================================================================
@@ -755,7 +755,7 @@ impl Near {
         contract_id: impl TryIntoAccountId,
         method: &str,
         args: &A,
-    ) -> Result<crate::types::TransactionOutcome, Error> {
+    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
         self.call(contract_id, method).args(args).await
     }
 
@@ -767,7 +767,7 @@ impl Near {
         args: &A,
         gas: Gas,
         deposit: NearToken,
-    ) -> Result<crate::types::TransactionOutcome, Error> {
+    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
         self.call(contract_id, method)
             .args(args)
             .gas(gas)

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -36,8 +36,8 @@ use std::sync::{Arc, OnceLock};
 use crate::error::{Error, RpcError};
 use crate::types::{
     AccountId, Action, BlockReference, CryptoHash, DelegateAction, DeterministicAccountStateInit,
-    Finality, Gas, IntoGas, IntoNearToken, NearToken, NonDelegateAction, PublicKey,
-    SignedDelegateAction, SignedTransaction, Transaction, TransactionOutcome, TryIntoAccountId,
+    FinalExecutionOutcome, Finality, Gas, IntoGas, IntoNearToken, NearToken, NonDelegateAction,
+    PublicKey, SignedDelegateAction, SignedTransaction, Transaction, TryIntoAccountId,
     TxExecutionStatus,
 };
 
@@ -1252,7 +1252,7 @@ impl CallBuilder {
 }
 
 impl IntoFuture for CallBuilder {
-    type Output = Result<TransactionOutcome, Error>;
+    type Output = Result<FinalExecutionOutcome, Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -1278,7 +1278,7 @@ impl TransactionSend {
 }
 
 impl IntoFuture for TransactionSend {
-    type Output = Result<TransactionOutcome, Error>;
+    type Output = Result<FinalExecutionOutcome, Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -1383,7 +1383,7 @@ impl IntoFuture for TransactionSend {
                                 response.transaction_hash, builder.wait_until,
                             ))
                         })?;
-                        return outcome.try_into();
+                        return Ok(outcome);
                     }
                     Err(RpcError::InvalidNonce { tx_nonce, ak_nonce })
                         if attempt < max_nonce_retries - 1 =>
@@ -1415,7 +1415,7 @@ impl IntoFuture for TransactionSend {
 }
 
 impl IntoFuture for TransactionBuilder {
-    type Output = Result<TransactionOutcome, Error>;
+    type Output = Result<FinalExecutionOutcome, Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -89,8 +89,8 @@ pub use rpc::{
     FinalExecutionOutcome, FinalExecutionOutcomeWithReceipts, FinalExecutionStatus, GasPrice,
     GasProfileEntry, GlobalContractIdentifierView, MerkleDirection, MerklePathItem, NodeVersion,
     Receipt, ReceiptContent, STORAGE_AMOUNT_PER_BYTE, SendTxResponse, SendTxWithReceiptsResponse,
-    SlashedValidator, StatusResponse, SyncInfo, TransactionOutcome, TransactionView, TrieSplit,
-    ValidatorInfo, ValidatorStakeView, ValidatorStakeViewV1, ViewFunctionResult,
+    SlashedValidator, StatusResponse, SyncInfo, TransactionView, TrieSplit, ValidatorInfo,
+    ValidatorStakeView, ValidatorStakeViewV1, ViewFunctionResult,
 };
 pub use rpc_extra::{
     BlockHeaderInnerLiteView, CurrentEpochValidatorInfo, EpochValidatorInfo,

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -630,7 +630,11 @@ impl FinalExecutionOutcome {
             return Err(crate::error::Error::TransactionFailed(err.clone()));
         }
         match &self.status {
-            FinalExecutionStatus::SuccessValue(s) => Ok(STANDARD.decode(s).unwrap_or_default()),
+            FinalExecutionStatus::SuccessValue(s) => STANDARD.decode(s).map_err(|e| {
+                crate::error::Error::InvalidTransaction(format!(
+                    "Failed to decode base64 SuccessValue: {e}"
+                ))
+            }),
             other => Err(crate::error::Error::InvalidTransaction(format!(
                 "Transaction status is {:?}, expected SuccessValue",
                 other,
@@ -1695,11 +1699,15 @@ mod tests {
     }
 
     #[test]
-    fn test_outcome_result_invalid_base64_returns_empty() {
+    fn test_outcome_result_invalid_base64_returns_err() {
         // If the RPC somehow returns invalid base64 (protocol bug),
-        // result() returns empty bytes rather than panicking.
+        // result() returns an error so callers can distinguish it from empty values.
         let outcome = make_success_outcome("not-valid-base64!!!");
-        assert_eq!(outcome.result().unwrap(), b"");
+        let err = outcome.result().unwrap_err();
+        assert!(
+            err.to_string().contains("base64"),
+            "Error should mention base64 decode failure, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -624,7 +624,8 @@ impl FinalExecutionOutcome {
 
     /// Get the return value as raw bytes (base64-decoded).
     ///
-    /// Returns `Err` if the transaction failed on-chain.
+    /// Returns `Err` if the transaction failed on-chain, if the status is not
+    /// `SuccessValue`, or if the value is not valid base64.
     pub fn result(&self) -> Result<Vec<u8>, crate::error::Error> {
         if let Some(err) = self.failure_error() {
             return Err(crate::error::Error::TransactionFailed(err.clone()));
@@ -644,7 +645,8 @@ impl FinalExecutionOutcome {
 
     /// Deserialize the return value as JSON.
     ///
-    /// Returns `Err` if the transaction failed on-chain or if deserialization fails.
+    /// Returns `Err` if `result()` fails (on-chain failure, unexpected status,
+    /// or invalid base64) or if JSON deserialization fails.
     pub fn json<T: serde::de::DeserializeOwned>(&self) -> Result<T, crate::error::Error> {
         let bytes = self.result()?;
         serde_json::from_slice(&bytes).map_err(crate::error::Error::from)

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -621,93 +621,29 @@ impl FinalExecutionOutcome {
             .sum();
         Gas::from_gas(tx_gas + receipt_gas)
     }
-}
 
-// =============================================================================
-// TransactionOutcome
-// =============================================================================
-
-/// The result of a successful transaction.
-///
-/// Returned by `.await?` on transaction builders and futures
-/// ([`CallBuilder`](crate::CallBuilder), [`TransactionBuilder`](crate::TransactionBuilder),
-/// [`TransactionSend`](crate::TransactionSend)). The transaction is guaranteed
-/// to have succeeded — failures are returned as `Err(Error::TransactionFailed(...))`.
-///
-/// # Example
-///
-/// ```rust,no_run
-/// # use near_kit::*;
-/// # async fn example(near: &Near) -> Result<(), Error> {
-/// let outcome = near.call("counter.testnet", "increment").await?;
-///
-/// // Get raw return value (infallible — success is guaranteed)
-/// let bytes: Vec<u8> = outcome.value();
-///
-/// // Deserialize as JSON (only fails on deserialization errors)
-/// let count: u64 = outcome.json()?;
-///
-/// println!("Gas used: {}", outcome.total_gas_used());
-/// # Ok(())
-/// # }
-/// ```
-#[derive(Debug, Clone)]
-pub struct TransactionOutcome(FinalExecutionOutcome);
-
-impl TryFrom<FinalExecutionOutcome> for TransactionOutcome {
-    type Error = crate::error::Error;
-
-    /// Convert a [`FinalExecutionOutcome`] into a [`TransactionOutcome`].
-    ///
-    /// Returns `Err` if the transaction failed or has not reached `SuccessValue` status.
-    fn try_from(outcome: FinalExecutionOutcome) -> Result<Self, Self::Error> {
-        if let Some(err) = outcome.failure_error() {
-            return Err(crate::error::Error::TransactionFailed(err.clone()));
-        }
-        if !outcome.is_success() {
-            return Err(crate::error::Error::InvalidTransaction(format!(
-                "Transaction executed but status is {:?}, expected SuccessValue",
-                outcome.status,
-            )));
-        }
-        Ok(Self(outcome))
-    }
-}
-
-impl TransactionOutcome {
     /// Get the return value as raw bytes (base64-decoded).
     ///
-    /// This is infallible because the transaction is guaranteed to have succeeded.
-    /// Returns an empty `Vec` if the success value is empty or if base64 decoding
-    /// fails (which would indicate a protocol-level bug in nearcore).
-    pub fn value(&self) -> Vec<u8> {
-        match &self.0.status {
-            FinalExecutionStatus::SuccessValue(s) => STANDARD.decode(s).unwrap_or_default(),
-            _ => Vec::new(),
+    /// Returns `Err` if the transaction failed on-chain.
+    pub fn result(&self) -> Result<Vec<u8>, crate::error::Error> {
+        if let Some(err) = self.failure_error() {
+            return Err(crate::error::Error::TransactionFailed(err.clone()));
+        }
+        match &self.status {
+            FinalExecutionStatus::SuccessValue(s) => Ok(STANDARD.decode(s).unwrap_or_default()),
+            other => Err(crate::error::Error::InvalidTransaction(format!(
+                "Transaction status is {:?}, expected SuccessValue",
+                other,
+            ))),
         }
     }
 
     /// Deserialize the return value as JSON.
     ///
-    /// Only fails if the return value cannot be deserialized into `T`.
+    /// Returns `Err` if the transaction failed on-chain or if deserialization fails.
     pub fn json<T: serde::de::DeserializeOwned>(&self) -> Result<T, crate::error::Error> {
-        let bytes = self.value();
+        let bytes = self.result()?;
         serde_json::from_slice(&bytes).map_err(crate::error::Error::from)
-    }
-
-    /// Get the transaction hash.
-    pub fn transaction_hash(&self) -> &CryptoHash {
-        self.0.transaction_hash()
-    }
-
-    /// Get total gas used across all receipts.
-    pub fn total_gas_used(&self) -> Gas {
-        self.0.total_gas_used()
-    }
-
-    /// Access the underlying [`FinalExecutionOutcome`].
-    pub fn raw(&self) -> &FinalExecutionOutcome {
-        &self.0
     }
 }
 
@@ -1694,7 +1630,7 @@ mod tests {
     }
 
     // ========================================================================
-    // TransactionOutcome tests
+    // FinalExecutionOutcome result/json tests
     // ========================================================================
 
     fn make_success_outcome(base64_value: &str) -> FinalExecutionOutcome {
@@ -1730,59 +1666,80 @@ mod tests {
     }
 
     #[test]
-    fn test_transaction_outcome_value() {
+    fn test_outcome_result() {
         // "hello" in base64
-        let outcome = TransactionOutcome::try_from(make_success_outcome("aGVsbG8=")).unwrap();
-        assert_eq!(outcome.value(), b"hello");
+        let outcome = make_success_outcome("aGVsbG8=");
+        assert_eq!(outcome.result().unwrap(), b"hello");
     }
 
     #[test]
-    fn test_transaction_outcome_value_empty() {
-        let outcome = TransactionOutcome::try_from(make_success_outcome("")).unwrap();
-        assert_eq!(outcome.value(), b"");
+    fn test_outcome_result_empty() {
+        let outcome = make_success_outcome("");
+        assert_eq!(outcome.result().unwrap(), b"");
     }
 
     #[test]
-    fn test_transaction_outcome_json() {
+    fn test_outcome_json() {
         // JSON `42` in base64
-        let outcome = TransactionOutcome::try_from(make_success_outcome("NDI=")).unwrap();
+        let outcome = make_success_outcome("NDI=");
         let val: u64 = outcome.json().unwrap();
         assert_eq!(val, 42);
     }
 
     #[test]
-    fn test_transaction_outcome_json_bad_data() {
+    fn test_outcome_json_bad_data() {
         // "hello" is not valid JSON
-        let outcome = TransactionOutcome::try_from(make_success_outcome("aGVsbG8=")).unwrap();
+        let outcome = make_success_outcome("aGVsbG8=");
         let result: Result<u64, _> = outcome.json();
         assert!(result.is_err());
     }
 
     #[test]
-    fn test_transaction_outcome_value_invalid_base64_returns_empty() {
+    fn test_outcome_result_invalid_base64_returns_empty() {
         // If the RPC somehow returns invalid base64 (protocol bug),
-        // value() returns empty bytes rather than panicking.
-        let outcome =
-            TransactionOutcome::try_from(make_success_outcome("not-valid-base64!!!")).unwrap();
-        assert_eq!(outcome.value(), b"");
+        // result() returns empty bytes rather than panicking.
+        let outcome = make_success_outcome("not-valid-base64!!!");
+        assert_eq!(outcome.result().unwrap(), b"");
     }
 
     #[test]
-    fn test_transaction_outcome_transaction_hash() {
-        let outcome = TransactionOutcome::try_from(make_success_outcome("")).unwrap();
+    fn test_outcome_failure_result_returns_err() {
+        let json = serde_json::json!({
+            "final_execution_status": "FINAL",
+            "status": {"Failure": {"ActionError": {"index": 0, "kind": {"FunctionCallError": {"ExecutionError": "test error"}}}}},
+            "transaction": {
+                "signer_id": "alice.near",
+                "public_key": "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp",
+                "nonce": 1,
+                "receiver_id": "bob.near",
+                "actions": [],
+                "signature": "ed25519:3s1dvMqNDCByoMnDnkhB4GPjTSXCRt4nt3Af5n1RX8W7aJ2FC6MfRf5BNXZ52EBifNJnNVBsGvke6GRYuaEYJXt5",
+                "hash": "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8U"
+            },
+            "transaction_outcome": {
+                "id": "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8U",
+                "outcome": {
+                    "executor_id": "alice.near",
+                    "gas_burnt": 223182562500_i64,
+                    "tokens_burnt": "22318256250000000000",
+                    "logs": [],
+                    "receipt_ids": [],
+                    "status": {"SuccessReceiptId": "3GTGoiN3FEoJenSw5ob4YMmFEV2Fbiichj3FDBnM78xK"}
+                },
+                "block_hash": "A6DJpKBhmAMmBuQXtY3dWbo8dGVSQ9yH7BQSJBfn8rBo",
+                "proof": []
+            },
+            "receipts_outcome": []
+        });
+        let outcome: FinalExecutionOutcome = serde_json::from_value(json).unwrap();
+
+        assert!(outcome.is_failure());
+        assert!(!outcome.is_success());
+        assert!(outcome.result().is_err());
+        assert!(outcome.json::<u64>().is_err());
+        // Metadata is still accessible
         assert!(!outcome.transaction_hash().is_zero());
-    }
-
-    #[test]
-    fn test_transaction_outcome_total_gas_used() {
-        let outcome = TransactionOutcome::try_from(make_success_outcome("")).unwrap();
         assert!(outcome.total_gas_used().as_gas() > 0);
-    }
-
-    #[test]
-    fn test_transaction_outcome_raw() {
-        let outcome = TransactionOutcome::try_from(make_success_outcome("")).unwrap();
-        assert!(outcome.raw().is_success());
     }
 
     // ========================================================================

--- a/crates/near-kit/tests/integration/debug_rpc_responses.rs
+++ b/crates/near-kit/tests/integration/debug_rpc_responses.rs
@@ -162,15 +162,14 @@ async fn debug_transaction_receipts() {
         .await
         .unwrap();
 
-    let raw = outcome.raw();
     println!("\n========================================");
     println!("TRANSACTION OUTCOME");
     println!("========================================");
-    println!("Is success: {}", raw.is_success());
-    println!("Status: {:?}", raw.status);
+    println!("Is success: {}", outcome.is_success());
+    println!("Status: {:?}", outcome.status);
 
     {
-        let tx = &raw.transaction;
+        let tx = &outcome.transaction;
         println!("\n--- Transaction ---");
         println!("Hash: {}", tx.hash);
         println!("Signer: {}", tx.signer_id);
@@ -186,7 +185,7 @@ async fn debug_transaction_receipts() {
     }
 
     {
-        let tx_outcome = &raw.transaction_outcome;
+        let tx_outcome = &outcome.transaction_outcome;
         println!("\n--- Transaction Outcome ---");
         println!("ID: {}", tx_outcome.id);
         println!("Block hash: {}", tx_outcome.block_hash);
@@ -214,9 +213,9 @@ async fn debug_transaction_receipts() {
 
     println!(
         "\n--- Receipt Outcomes ({}) ---",
-        raw.receipts_outcome.len()
+        outcome.receipts_outcome.len()
     );
-    for (i, ro) in raw.receipts_outcome.iter().enumerate() {
+    for (i, ro) in outcome.receipts_outcome.iter().enumerate() {
         println!("\n  Receipt Outcome [{}]:", i);
         println!("    ID: {}", ro.id);
         println!("    Block hash: {}", ro.block_hash);

--- a/crates/near-kit/tests/integration/error_handling_integration.rs
+++ b/crates/near-kit/tests/integration/error_handling_integration.rs
@@ -329,12 +329,19 @@ async fn test_error_insufficient_balance_transfer() {
         .unwrap();
 
     // Try to transfer more than available
-    let result = sender_near
+    let outcome = sender_near
         .transfer(&receiver_id, NearToken::from_near(1000))
-        .await;
+        .await
+        .expect("RPC send should succeed");
 
-    assert!(result.is_err(), "Should fail with insufficient balance");
-    println!("Insufficient balance error: {:?}", result.unwrap_err());
+    assert!(
+        outcome.is_failure(),
+        "Should fail with insufficient balance"
+    );
+    println!(
+        "Insufficient balance error: {:?}",
+        outcome.result().unwrap_err()
+    );
 }
 
 #[tokio::test]
@@ -364,20 +371,24 @@ async fn test_error_create_account_that_already_exists() {
 
     // Try to create the same account again
     let new_key = SecretKey::generate_ed25519();
-    let result = parent_near
+    let outcome = parent_near
         .transaction(&account_id)
         .create_account()
         .transfer(NearToken::from_near(1))
         .add_full_access_key(new_key.public_key())
         .send()
         .wait_until(TxExecutionStatus::Final)
-        .await;
+        .await
+        .expect("RPC send should succeed");
 
     assert!(
-        result.is_err(),
+        outcome.is_failure(),
         "Should fail when creating duplicate account"
     );
-    println!("Duplicate account error: {:?}", result.unwrap_err());
+    println!(
+        "Duplicate account error: {:?}",
+        outcome.result().unwrap_err()
+    );
 }
 
 #[tokio::test]
@@ -406,18 +417,22 @@ async fn test_error_delete_nonexistent_key() {
 
     // Try to delete a key that doesn't exist on the account
     let fake_key = SecretKey::generate_ed25519();
-    let result = account_near
+    let outcome = account_near
         .transaction(&account_id)
         .delete_key(fake_key.public_key())
         .send()
         .wait_until(TxExecutionStatus::Final)
-        .await;
+        .await
+        .expect("RPC send should succeed");
 
     assert!(
-        result.is_err(),
+        outcome.is_failure(),
         "Should fail when deleting non-existent key"
     );
-    println!("Delete non-existent key error: {:?}", result.unwrap_err());
+    println!(
+        "Delete non-existent key error: {:?}",
+        outcome.result().unwrap_err()
+    );
 }
 
 // =============================================================================
@@ -452,17 +467,18 @@ async fn test_error_function_call_panic() {
         .build();
 
     // Call a method that doesn't exist (should fail during execution)
-    let result = contract_near
+    let outcome = contract_near
         .call(&contract_id, "nonexistent_method")
         .args(serde_json::json!({}))
         .gas(Gas::from_tgas(30))
-        .await;
+        .await
+        .expect("RPC send should succeed");
 
     assert!(
-        result.is_err(),
+        outcome.is_failure(),
         "Should fail when calling non-existent method"
     );
-    println!("Function call error: {:?}", result.unwrap_err());
+    println!("Function call error: {:?}", outcome.result().unwrap_err());
 }
 
 #[tokio::test]
@@ -499,8 +515,12 @@ async fn test_error_function_call_insufficient_gas() {
         .gas(Gas::from_gas(1000)) // Extremely low gas
         .await;
 
-    assert!(result.is_err(), "Should fail with insufficient gas");
-    println!("Insufficient gas error: {:?}", result.unwrap_err());
+    let outcome = result.expect("RPC send should succeed");
+    assert!(outcome.is_failure(), "Should fail with insufficient gas");
+    println!(
+        "Insufficient gas error: {:?}",
+        outcome.result().unwrap_err()
+    );
 }
 
 // =============================================================================

--- a/crates/near-kit/tests/integration/error_handling_integration.rs
+++ b/crates/near-kit/tests/integration/error_handling_integration.rs
@@ -328,20 +328,14 @@ async fn test_error_insufficient_balance_transfer() {
         .await
         .unwrap();
 
-    // Try to transfer more than available
-    let outcome = sender_near
+    // Try to transfer more than available — rejected at RPC validation level
+    // (NotEnoughBalance is caught before on-chain execution)
+    let result = sender_near
         .transfer(&receiver_id, NearToken::from_near(1000))
-        .await
-        .expect("RPC send should succeed");
+        .await;
 
-    assert!(
-        outcome.is_failure(),
-        "Should fail with insufficient balance"
-    );
-    println!(
-        "Insufficient balance error: {:?}",
-        outcome.result().unwrap_err()
-    );
+    assert!(result.is_err(), "Should fail with insufficient balance");
+    println!("Insufficient balance error: {:?}", result.unwrap_err());
 }
 
 #[tokio::test]

--- a/crates/near-kit/tests/integration/main.rs
+++ b/crates/near-kit/tests/integration/main.rs
@@ -18,6 +18,7 @@ mod signer_edge_cases_integration;
 mod token_error_integration;
 mod token_integration;
 mod transaction_failure_integration;
+mod transaction_outcome_integration;
 mod typed_contract_error_integration;
 mod typed_contract_integration;
 mod typed_error_integration;

--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -269,16 +269,15 @@ async fn test_final_execution_outcome_full_fields() {
         .await
         .unwrap();
 
-    // Verify FinalExecutionOutcome fields via .raw()
-    let raw = outcome.raw();
-    assert!(raw.is_success(), "Transaction should succeed");
+    // Verify FinalExecutionOutcome fields
+    assert!(outcome.is_success(), "Transaction should succeed");
     assert!(
-        !raw.receipts_outcome.is_empty(),
+        !outcome.receipts_outcome.is_empty(),
         "Should have receipt outcomes"
     );
 
     // Check transaction view (now a required field)
-    let tx = &raw.transaction;
+    let tx = &outcome.transaction;
     assert_eq!(tx.signer_id, root_account);
     assert_eq!(tx.receiver_id, receiver_id);
     assert!(tx.nonce > 0, "Nonce should be positive");
@@ -286,7 +285,7 @@ async fn test_final_execution_outcome_full_fields() {
     assert!(!tx.actions.is_empty(), "Should have actions");
 
     // Check transaction outcome (now a required field)
-    let tx_outcome = &raw.transaction_outcome;
+    let tx_outcome = &outcome.transaction_outcome;
     assert!(!tx_outcome.id.is_zero(), "Outcome ID should exist");
     assert!(!tx_outcome.block_hash.is_zero(), "Block hash should exist");
     assert_eq!(tx_outcome.outcome.executor_id, root_account);
@@ -297,7 +296,7 @@ async fn test_final_execution_outcome_full_fields() {
     );
 
     // Check receipts outcome
-    for receipt_outcome in &raw.receipts_outcome {
+    for receipt_outcome in &outcome.receipts_outcome {
         assert!(!receipt_outcome.id.is_zero(), "Receipt ID should exist");
         assert!(
             !receipt_outcome.block_hash.is_zero(),
@@ -320,7 +319,7 @@ async fn test_final_execution_outcome_full_fields() {
     println!("Transaction outcome:");
     println!("  Hash: {:?}", outcome.transaction_hash());
     println!("  Gas used: {}", outcome.total_gas_used());
-    println!("  Receipt outcomes: {}", raw.receipts_outcome.len());
+    println!("  Receipt outcomes: {}", outcome.receipts_outcome.len());
 }
 
 #[tokio::test]
@@ -344,7 +343,7 @@ async fn test_execution_metadata_and_gas_profile() {
 
     // Check if metadata is present (may not be in all protocol versions)
     let mut found_metadata = false;
-    for receipt_outcome in &outcome.raw().receipts_outcome {
+    for receipt_outcome in &outcome.receipts_outcome {
         if let Some(metadata) = &receipt_outcome.outcome.metadata {
             found_metadata = true;
             println!("Execution metadata version: {}", metadata.version);
@@ -484,7 +483,7 @@ async fn test_action_view_variants() {
         .await
         .unwrap();
 
-    let tx = &outcome.raw().transaction;
+    let tx = &outcome.transaction;
     println!("Transaction actions:");
     for action in &tx.actions {
         match action {

--- a/crates/near-kit/tests/integration/transaction_failure_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_failure_integration.rs
@@ -476,12 +476,12 @@ async fn test_transfer_max_amount() {
         .unwrap()
         .build();
 
-    // Transfer max u128 (way more than balance)
+    // Transfer max u128 (way more than balance) — rejected at RPC validation
+    // level (CostOverflow is caught before on-chain execution)
     let result = account_near
         .transfer(ROOT_ACCOUNT, NearToken::from_yoctonear(u128::MAX))
         .await;
 
-    let outcome = result.expect("RPC send should succeed");
-    assert!(outcome.is_failure(), "Should fail with max amount");
-    println!("Max transfer error: {:?}", outcome.result().unwrap_err());
+    assert!(result.is_err(), "Should fail with max amount");
+    println!("Max transfer error: {:?}", result.unwrap_err());
 }

--- a/crates/near-kit/tests/integration/transaction_failure_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_failure_integration.rs
@@ -98,12 +98,16 @@ async fn test_add_key_to_nonexistent_account() {
     let nonexistent: AccountId = "nonexistent-for-add-key.sandbox".parse().unwrap();
 
     // Try to add a key to a non-existent account
-    let result = near
+    let outcome = near
         .add_full_access_key(&nonexistent, key.public_key())
-        .await;
+        .await
+        .expect("RPC send should succeed");
 
-    assert!(result.is_err(), "Should fail for non-existent account");
-    println!("Add key to non-existent: {:?}", result.unwrap_err());
+    assert!(outcome.is_failure(), "Should fail for non-existent account");
+    println!(
+        "Add key to non-existent: {:?}",
+        outcome.result().unwrap_err()
+    );
 }
 
 #[tokio::test]
@@ -130,12 +134,16 @@ async fn test_add_duplicate_key() {
         .build();
 
     // Try to add the same key again
-    let result = account_near
+    let outcome = account_near
         .add_full_access_key(&account_id, key.public_key())
-        .await;
+        .await
+        .expect("RPC send should succeed");
 
-    assert!(result.is_err(), "Should fail when adding duplicate key");
-    println!("Duplicate key error: {:?}", result.unwrap_err());
+    assert!(
+        outcome.is_failure(),
+        "Should fail when adding duplicate key"
+    );
+    println!("Duplicate key error: {:?}", outcome.result().unwrap_err());
 }
 
 #[tokio::test]
@@ -191,8 +199,12 @@ async fn test_create_subaccount_of_nonexistent_parent() {
         .wait_until(TxExecutionStatus::Final)
         .await;
 
-    assert!(result.is_err(), "Should fail for non-existent parent");
-    println!("Non-existent parent error: {:?}", result.unwrap_err());
+    let outcome = result.expect("RPC send should succeed");
+    assert!(outcome.is_failure(), "Should fail for non-existent parent");
+    println!(
+        "Non-existent parent error: {:?}",
+        outcome.result().unwrap_err()
+    );
 }
 
 #[tokio::test]
@@ -280,8 +292,9 @@ async fn test_transaction_with_failing_action_in_middle() {
         .wait_until(TxExecutionStatus::Final)
         .await;
 
-    assert!(result.is_err(), "Should fail when action fails");
-    println!("Multi-action failure: {:?}", result.unwrap_err());
+    let outcome = result.expect("RPC send should succeed");
+    assert!(outcome.is_failure(), "Should fail when action fails");
+    println!("Multi-action failure: {:?}", outcome.result().unwrap_err());
 }
 
 // =============================================================================
@@ -303,8 +316,12 @@ async fn test_delete_nonexistent_account() {
         .wait_until(TxExecutionStatus::Final)
         .await;
 
-    assert!(result.is_err(), "Should fail for non-existent account");
-    println!("Delete non-existent account: {:?}", result.unwrap_err());
+    let outcome = result.expect("RPC send should succeed");
+    assert!(outcome.is_failure(), "Should fail for non-existent account");
+    println!(
+        "Delete non-existent account: {:?}",
+        outcome.result().unwrap_err()
+    );
 }
 
 #[tokio::test]
@@ -377,11 +394,15 @@ async fn test_stake_with_insufficient_balance() {
         .wait_until(TxExecutionStatus::Final)
         .await;
 
+    let outcome = result.expect("RPC send should succeed");
     assert!(
-        result.is_err(),
+        outcome.is_failure(),
         "Should fail with insufficient balance to stake"
     );
-    println!("Insufficient stake balance: {:?}", result.unwrap_err());
+    println!(
+        "Insufficient stake balance: {:?}",
+        outcome.result().unwrap_err()
+    );
 }
 
 // =============================================================================
@@ -460,6 +481,7 @@ async fn test_transfer_max_amount() {
         .transfer(ROOT_ACCOUNT, NearToken::from_yoctonear(u128::MAX))
         .await;
 
-    assert!(result.is_err(), "Should fail with max amount");
-    println!("Max transfer error: {:?}", result.unwrap_err());
+    let outcome = result.expect("RPC send should succeed");
+    assert!(outcome.is_failure(), "Should fail with max amount");
+    println!("Max transfer error: {:?}", outcome.result().unwrap_err());
 }

--- a/crates/near-kit/tests/integration/transaction_outcome_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_outcome_integration.rs
@@ -3,7 +3,7 @@
 //! Verifies that failed transactions still expose the full outcome,
 //! allowing callers to inspect receipts, logs, and gas usage.
 //!
-//! Run with: `cargo test --features sandbox --test integration transaction_outcome`
+//! Run with: `cargo test --features sandbox --test integration -- transaction_outcome`
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 

--- a/crates/near-kit/tests/integration/transaction_outcome_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_outcome_integration.rs
@@ -1,0 +1,82 @@
+//! Integration tests for FinalExecutionOutcome receipt inspection on failure.
+//!
+//! Verifies that failed transactions still expose the full outcome,
+//! allowing callers to inspect receipts, logs, and gas usage.
+//!
+//! Run with: `cargo test --features sandbox --test integration transaction_outcome`
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use near_kit::sandbox::{ROOT_ACCOUNT, SandboxConfig};
+use near_kit::*;
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_account() -> AccountId {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("txout{}.{}", n, ROOT_ACCOUNT).parse().unwrap()
+}
+
+#[tokio::test]
+async fn test_failed_transaction_preserves_receipts() {
+    let sandbox = SandboxConfig::shared().await;
+    let near = sandbox.client();
+
+    // Deploy the guestbook contract
+    let key = SecretKey::generate_ed25519();
+    let contract_id = unique_account();
+    let wasm = std::fs::read("tests/contracts/guestbook.wasm").expect("guestbook.wasm not found");
+
+    near.transaction(&contract_id)
+        .create_account()
+        .transfer(NearToken::from_near(10))
+        .add_full_access_key(key.public_key())
+        .deploy(wasm)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .expect("setup: deploy should succeed")
+        .result()
+        .expect("setup: deploy should succeed on-chain");
+
+    let account_near = Near::custom(sandbox.rpc_url())
+        .credentials(key.to_string(), &contract_id)
+        .unwrap()
+        .build();
+
+    // Call a non-existent method — the transaction executes but fails on-chain
+    let outcome = account_near
+        .call(&contract_id, "nonexistent_method")
+        .args(serde_json::json!({}))
+        .gas(Gas::from_tgas(10))
+        .await
+        .expect("RPC send should succeed");
+
+    // The outcome should indicate failure
+    assert!(outcome.is_failure(), "Should fail for non-existent method");
+    assert!(!outcome.is_success());
+
+    // Extracting the return value should give a TransactionFailed error
+    let err = outcome.result().unwrap_err();
+    match &err {
+        Error::TransactionFailed(tx_err) => {
+            println!("Got expected error: {tx_err}");
+        }
+        other => panic!("Expected TransactionFailed, got: {other:?}"),
+    }
+
+    // Receipt details are directly accessible
+    assert!(
+        !outcome.receipts_outcome.is_empty(),
+        "Should have receipt outcomes even on failure"
+    );
+    assert!(outcome.total_gas_used().as_gas() > 0);
+    assert!(!outcome.transaction_hash().is_zero());
+
+    for (i, receipt) in outcome.receipts_outcome.iter().enumerate() {
+        println!(
+            "Receipt {i}: executor={}, status={:?}",
+            receipt.outcome.executor_id, receipt.outcome.status
+        );
+    }
+}

--- a/crates/near-kit/tests/integration/typed_contract_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_error_integration.rs
@@ -219,15 +219,19 @@ async fn test_typed_contract_call_with_insufficient_gas() {
         .gas(Gas::from_ggas(1)) // Way too little gas
         .await;
 
-    assert!(result.is_err(), "Should error with insufficient gas");
-    let err = result.unwrap_err();
-    println!("Insufficient gas error: {:?}", err);
-
-    // Should be a transaction failure
-    match err {
-        Error::TransactionFailed(_) => { /* Expected */ }
-        Error::Rpc(_) => { /* RPC errors also acceptable */ }
-        _ => panic!("Expected TransactionFailed, got: {:?}", err),
+    match result {
+        Ok(outcome) => {
+            // Transaction executed but should have failed on-chain
+            assert!(outcome.is_failure(), "Should fail with insufficient gas");
+            let err = outcome.result().unwrap_err();
+            println!("Insufficient gas error: {:?}", err);
+            match err {
+                Error::TransactionFailed(_) => { /* Expected */ }
+                _ => panic!("Expected TransactionFailed from result(), got: {:?}", err),
+            }
+        }
+        Err(Error::Rpc(_)) => { /* RPC errors also acceptable */ }
+        Err(other) => panic!("Expected Ok or Rpc error, got: {:?}", other),
     }
 }
 


### PR DESCRIPTION
## Summary

- Removes the `TransactionOutcome` newtype wrapper — transaction builders now return `FinalExecutionOutcome` directly
- `.await?` only fails for transport-level errors (RPC, signing, network). On-chain execution failures return `Ok(FinalExecutionOutcome)` where `is_failure() == true`
- Adds `result()` and `json()` methods to `FinalExecutionOutcome` for extracting return values (replaces the old `value()` method)
- Callers always have access to receipts, logs, and gas usage regardless of success or failure

### Before

```rust
// On-chain failure → Err, full outcome lost
let outcome: TransactionOutcome = near.call("c.near", "inc").await?;
let val = outcome.value(); // infallible, but you never get here on failure
```

### After

```rust
// On-chain failure → Ok, full outcome preserved
let outcome: FinalExecutionOutcome = near.call("c.near", "inc").await?;
let val: u64 = outcome.json()?; // fails if tx failed OR deser fails

// Inspect receipts regardless of success/failure
if outcome.is_failure() {
    for receipt in &outcome.receipts_outcome { /* ... */ }
}
```

Closes #94
Closes #77

## Breaking Changes

- `TransactionOutcome` type removed
- `IntoFuture` output changed from `Result<TransactionOutcome, Error>` to `Result<FinalExecutionOutcome, Error>`
- On-chain failures no longer surface as `Err` from `.await` — use `.is_failure()` or `.result()`/`.json()`
- `.value()` removed, replaced by `.result()` which returns `Result<Vec<u8>, Error>`

## Test plan

- [x] 378 unit tests pass
- [x] Clippy clean
- [x] All examples compile
- [x] New unit test for `result()` on failed outcomes
- [x] New integration test verifying receipt inspection on failed transactions
- [x] Existing integration tests updated for new API
- [ ] Sandbox integration tests pass