### PR TITLE
feat: typed contract composition via trait inheritance and .typed_call::<T>()

### DIFF
--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -349,6 +349,132 @@ fn generate_call_method(method: &MethodInfo, contract_format: SerializationForma
     }
 }
 
+/// Generate a view method for the `{Trait}Methods` trait (uses `HasContractContext`).
+fn generate_methods_trait_view(
+    method: &MethodInfo,
+    contract_format: SerializationFormat,
+) -> TokenStream2 {
+    let method_name = &method.name;
+    let method_name_str = method_name.to_string();
+    let format = method.format_override.unwrap_or(contract_format);
+
+    let return_type = method
+        .return_type
+        .as_ref()
+        .map(|t| quote! { #t })
+        .unwrap_or_else(|| quote! { () });
+
+    let view_return_type = match format {
+        SerializationFormat::Json => quote! { near_kit::ViewCall<#return_type> },
+        SerializationFormat::Borsh => quote! { near_kit::ViewCallBorsh<#return_type> },
+    };
+
+    let borsh_suffix = match format {
+        SerializationFormat::Json => quote! {},
+        SerializationFormat::Borsh => quote! { .borsh() },
+    };
+
+    if let (Some(arg_name), Some(arg_type)) = (&method.arg_name, &method.arg_type) {
+        let args_method = match format {
+            SerializationFormat::Json => quote! { .args(#arg_name) },
+            SerializationFormat::Borsh => quote! { .args_borsh(#arg_name) },
+        };
+        quote! {
+            fn #method_name(&self, #arg_name: #arg_type) -> #view_return_type {
+                self.near().view::<#return_type>(self.contract_id(), #method_name_str)
+                    #args_method
+                    #borsh_suffix
+            }
+        }
+    } else {
+        match format {
+            SerializationFormat::Json => quote! {
+                fn #method_name(&self) -> #view_return_type {
+                    self.near().view::<#return_type>(self.contract_id(), #method_name_str)
+                        .args(serde_json::json!({}))
+                }
+            },
+            SerializationFormat::Borsh => quote! {
+                fn #method_name(&self) -> #view_return_type {
+                    self.near().view::<#return_type>(self.contract_id(), #method_name_str)
+                        .borsh()
+                }
+            },
+        }
+    }
+}
+
+/// Generate a call method for the `{Trait}Methods` trait (uses `HasContractContext`).
+fn generate_methods_trait_call(
+    method: &MethodInfo,
+    contract_format: SerializationFormat,
+) -> TokenStream2 {
+    let method_name = &method.name;
+    let method_name_str = method_name.to_string();
+    let format = method.format_override.unwrap_or(contract_format);
+
+    if let (Some(arg_name), Some(arg_type)) = (&method.arg_name, &method.arg_type) {
+        let args_method = match format {
+            SerializationFormat::Json => quote! { .args(#arg_name) },
+            SerializationFormat::Borsh => quote! { .args_borsh(#arg_name) },
+        };
+        quote! {
+            fn #method_name(&self, #arg_name: #arg_type) -> near_kit::CallBuilder {
+                self.near().call(self.contract_id(), #method_name_str)
+                    #args_method
+            }
+        }
+    } else {
+        match format {
+            SerializationFormat::Json => quote! {
+                fn #method_name(&self) -> near_kit::CallBuilder {
+                    self.near().call(self.contract_id(), #method_name_str)
+                        .args(serde_json::json!({}))
+                }
+            },
+            SerializationFormat::Borsh => quote! {
+                fn #method_name(&self) -> near_kit::CallBuilder {
+                    self.near().call(self.contract_id(), #method_name_str)
+                }
+            },
+        }
+    }
+}
+
+/// Generate a call method for the `{Trait}TxMethods` trait (uses `ContractTxBuilder`).
+fn generate_tx_method(method: &MethodInfo, contract_format: SerializationFormat) -> TokenStream2 {
+    let method_name = &method.name;
+    let method_name_str = method_name.to_string();
+    let format = method.format_override.unwrap_or(contract_format);
+
+    if let (Some(arg_name), Some(arg_type)) = (&method.arg_name, &method.arg_type) {
+        let args_method = match format {
+            SerializationFormat::Json => quote! { .args(#arg_name) },
+            SerializationFormat::Borsh => quote! { .args_borsh(#arg_name) },
+        };
+        quote! {
+            fn #method_name(self, #arg_name: #arg_type) -> near_kit::CallBuilder {
+                self.into_builder().call(#method_name_str)
+                    #args_method
+            }
+        }
+    } else {
+        match format {
+            SerializationFormat::Json => quote! {
+                fn #method_name(self) -> near_kit::CallBuilder {
+                    self.into_builder().call(#method_name_str)
+                        .args(serde_json::json!({}))
+                }
+            },
+            SerializationFormat::Borsh => quote! {
+                fn #method_name(self) -> near_kit::CallBuilder {
+                    self.into_builder().call(#method_name_str)
+                }
+            },
+        }
+    }
+}
+
 /// Strip internal attributes from a method for the output trait.
 fn strip_internal_attrs(method: &TraitItemFn) -> TraitItemFn {
     let mut method = method.clone();
@@ -375,6 +501,11 @@ pub fn contract(attr: TokenStream, item: TokenStream) -> TokenStream {
 fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStream2> {
     let trait_name = &input.ident;
     let client_name = format_ident!("{}Client", trait_name);
+    let methods_trait_name = format_ident!("{}Methods", trait_name);
+    let marker_trait_name = format_ident!("Implements{}", trait_name);
+    let tx_builder_name = format_ident!("{}TxBuilder", trait_name);
+    let tx_methods_trait_name = format_ident!("{}TxMethods", trait_name);
+    let tx_marker_trait_name = format_ident!("Implements{}Tx", trait_name);
     let vis = &input.vis;
 
     // Parse all methods
@@ -385,7 +516,7 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
         }
     }
 
-    // Generate client methods
+    // Generate client methods (inherent impls, for backwards compat)
     let client_methods: Vec<TokenStream2> = methods
         .iter()
         .map(|m| {
@@ -393,6 +524,49 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
                 generate_view_method(m, args.format)
             } else {
                 generate_call_method(m, args.format)
+            }
+        })
+        .collect();
+
+    // Generate Methods trait methods (view + call, using HasContractContext)
+    let methods_trait_methods: Vec<TokenStream2> = methods
+        .iter()
+        .map(|m| {
+            if m.is_view {
+                generate_methods_trait_view(m, args.format)
+            } else {
+                generate_methods_trait_call(m, args.format)
+            }
+        })
+        .collect();
+
+    // Generate TxMethods trait methods (call-only, using ContractTxBuilder)
+    let tx_methods: Vec<TokenStream2> = methods
+        .iter()
+        .filter(|m| !m.is_view)
+        .map(|m| generate_tx_method(m, args.format))
+        .collect();
+
+    // Collect supertrait names for generating marker trait impls
+    let supertrait_markers: Vec<TokenStream2> = input
+        .supertraits
+        .iter()
+        .filter_map(|bound| {
+            if let syn::TypeParamBound::Trait(trait_bound) = bound {
+                let path = &trait_bound.path;
+                // Generate marker trait names from supertrait paths
+                if let Some(last_seg) = path.segments.last() {
+                    let marker = format_ident!("Implements{}", last_seg.ident);
+                    let tx_marker = format_ident!("Implements{}Tx", last_seg.ident);
+                    Some(quote! {
+                        impl #marker for #client_name {}
+                        impl #tx_marker for #tx_builder_name {}
+                    })
+                } else {
+                    None
+                }
+            } else {
+                None
             }
         })
         .collect();
@@ -417,15 +591,30 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
     // Build the output
     let expanded = quote! {
         // Original trait (with internal attrs stripped for cleaner output)
-        // The trait is used for defining the interface, but the generated client
-        // struct is what's actually used - so suppress dead_code warnings.
         #[allow(dead_code)]
         #(#trait_attrs)*
         #vis trait #trait_name #trait_generics : #trait_supertraits {
             #(#cleaned_items)*
         }
 
-        // Generated client struct
+        // ── Methods trait (composable via blanket impl) ──────────────────
+
+        /// Trait providing typed methods for this contract standard.
+        ///
+        /// Automatically implemented for any type that implements
+        /// [`HasContractContext`] + [`#marker_trait_name`].
+        #vis trait #methods_trait_name: near_kit::HasContractContext {
+            #(#methods_trait_methods)*
+        }
+
+        /// Marker trait indicating a type supports this contract standard.
+        #vis trait #marker_trait_name {}
+
+        /// Blanket impl: any type with contract context + marker gets the methods.
+        impl<T: near_kit::HasContractContext + #marker_trait_name> #methods_trait_name for T {}
+
+        // ── Client struct (for simple standalone calls) ──────────────────
+
         #vis struct #client_name {
             near: near_kit::Near,
             contract_id: near_kit::AccountId,
@@ -453,16 +642,57 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
             #(#client_methods)*
         }
 
-        // Implement ContractClient trait for construction via near.contract::<T>()
+        impl near_kit::HasContractContext for #client_name {
+            fn near(&self) -> &near_kit::Near { &self.near }
+            fn contract_id(&self) -> &near_kit::AccountId { &self.contract_id }
+        }
+
+        impl #marker_trait_name for #client_name {}
+
         impl near_kit::contract::ContractClient for #client_name {
             fn new(near: near_kit::Near, contract_id: near_kit::AccountId) -> Self {
                 Self::new(near, contract_id)
             }
         }
 
-        // Implement Contract marker trait
+        // ── TxBuilder (for typed transaction composition) ────────────────
+
+        /// Builder returned by `.typed_call::<dyn #trait_name>()` on a transaction.
+        #vis struct #tx_builder_name {
+            builder: near_kit::TransactionBuilder,
+        }
+
+        impl near_kit::ContractTxBuilder for #tx_builder_name {
+            fn from_builder(builder: near_kit::TransactionBuilder) -> Self {
+                Self { builder }
+            }
+            fn into_builder(self) -> near_kit::TransactionBuilder {
+                self.builder
+            }
+        }
+
+        /// Trait providing typed transaction methods for this contract standard.
+        #vis trait #tx_methods_trait_name: near_kit::ContractTxBuilder {
+            #(#tx_methods)*
+        }
+
+        /// Marker trait for TxBuilder composition.
+        #vis trait #tx_marker_trait_name {}
+
+        /// Blanket impl: any TxBuilder with the marker gets the methods.
+        impl<T: near_kit::ContractTxBuilder + #tx_marker_trait_name> #tx_methods_trait_name for T {}
+
+        impl #tx_marker_trait_name for #tx_builder_name {}
+
+        // ── Supertrait marker impls (for trait inheritance) ──────────────
+
+        #(#supertrait_markers)*
+
+        // ── Contract marker trait ────────────────────────────────────────
+
         impl near_kit::Contract for dyn #trait_name {
             type Client = #client_name;
+            type TxBuilder = #tx_builder_name;
         }
     };
 

--- a/crates/near-kit-macros/tests/compile-pass/contract_composition.rs
+++ b/crates/near-kit-macros/tests/compile-pass/contract_composition.rs
@@ -1,0 +1,140 @@
+//! Test that contract composition via trait inheritance works.
+//!
+//! This tests the ergonomics of:
+//! - Standard traits generating Methods + TxMethods traits
+//! - Composite traits inheriting methods from supertraits
+//! - `.typed_call::<dyn T>()` on TransactionBuilder
+//! - Blanket impls providing methods automatically
+
+use near_kit::*;
+use serde::Serialize;
+
+// ── Define two "standards" ───────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub struct StorageDepositArgs {
+    pub account_id: Option<String>,
+}
+
+#[near_kit::contract]
+pub trait StorageManagement {
+    #[call]
+    fn storage_deposit(&mut self, args: StorageDepositArgs);
+}
+
+#[derive(Serialize)]
+pub struct FtTransferArgs {
+    pub receiver_id: String,
+    pub amount: String,
+}
+
+#[near_kit::contract]
+pub trait FungibleToken {
+    fn ft_balance_of(&self) -> String;
+
+    #[call]
+    fn ft_transfer(&mut self, args: FtTransferArgs);
+}
+
+// ── Define a composite contract ──────────────────────────────────────────
+
+#[derive(Serialize)]
+pub struct MintArgs {
+    pub amount: String,
+}
+
+#[near_kit::contract]
+pub trait MyToken: FungibleToken + StorageManagement {
+    #[call]
+    fn mint(&mut self, args: MintArgs);
+}
+
+fn main() {
+    let near = Near::testnet().build();
+
+    // ── 1. Per-trait client still works ───────────────────────────────
+    let ft_client = FungibleTokenClient::new(near.clone(), "token.near".parse().unwrap());
+    let _view: ViewCall<String> = ft_client.ft_balance_of();
+    let _call: CallBuilder = ft_client.ft_transfer(FtTransferArgs {
+        receiver_id: "bob.near".to_string(),
+        amount: "100".to_string(),
+    });
+
+    // ── 2. Composite client has its OWN methods ──────────────────────
+    let token = MyTokenClient::new(near.clone(), "token.near".parse().unwrap());
+    let _call: CallBuilder = token.mint(MintArgs {
+        amount: "1000".to_string(),
+    });
+
+    // ── 3. Composite client gets supertrait methods via blanket impls ─
+    // FungibleToken methods (via ImplementsFungibleToken marker)
+    let _view: ViewCall<String> = token.ft_balance_of();
+    let _call: CallBuilder = token.ft_transfer(FtTransferArgs {
+        receiver_id: "bob.near".to_string(),
+        amount: "100".to_string(),
+    });
+
+    // StorageManagement methods (via ImplementsStorageManagement marker)
+    let _call: CallBuilder = token.storage_deposit(StorageDepositArgs {
+        account_id: Some("bob.near".to_string()),
+    });
+
+    // ── 4. .typed_call::<dyn T>() on TransactionBuilder ──────────────
+    // Per-standard TxBuilder
+    let _: FungibleTokenTxBuilder = near
+        .transaction("token.near")
+        .typed_call::<dyn FungibleToken>();
+
+    // Composite TxBuilder
+    let _: MyTokenTxBuilder = near
+        .transaction("token.near")
+        .typed_call::<dyn MyToken>();
+
+    // ── 5. Typed call methods on TxBuilder ───────────────────────────
+    // Direct standard methods
+    let _: CallBuilder = near
+        .transaction("token.near")
+        .typed_call::<dyn FungibleToken>()
+        .ft_transfer(FtTransferArgs {
+            receiver_id: "bob.near".to_string(),
+            amount: "100".to_string(),
+        });
+
+    // Composite TxBuilder gets own methods
+    let _: CallBuilder = near
+        .transaction("token.near")
+        .typed_call::<dyn MyToken>()
+        .mint(MintArgs {
+            amount: "1000".to_string(),
+        });
+
+    // Composite TxBuilder gets supertrait methods via blanket impls
+    let _: CallBuilder = near
+        .transaction("token.near")
+        .typed_call::<dyn MyToken>()
+        .ft_transfer(FtTransferArgs {
+            receiver_id: "bob.near".to_string(),
+            amount: "100".to_string(),
+        });
+
+    let _: CallBuilder = near
+        .transaction("token.near")
+        .typed_call::<dyn MyToken>()
+        .storage_deposit(StorageDepositArgs {
+            account_id: Some("bob.near".to_string()),
+        });
+
+    // ── 6. Chaining typed calls across standards ─────────────────────
+    // This is the key ergonomic win: fluent cross-standard composition
+    let _: CallBuilder = near
+        .transaction("token.near")
+        .typed_call::<dyn MyToken>()
+        .storage_deposit(StorageDepositArgs {
+            account_id: Some("bob.near".to_string()),
+        })
+        .typed_call::<dyn MyToken>()
+        .ft_transfer(FtTransferArgs {
+            receiver_id: "bob.near".to_string(),
+            amount: "100".to_string(),
+        });
+}

--- a/crates/near-kit/examples/typed_contracts.rs
+++ b/crates/near-kit/examples/typed_contracts.rs
@@ -1,0 +1,227 @@
+//! Typed Contracts - Compile-time safe contract interactions
+//!
+//! Shows how to define typed contract interfaces, compose standards via
+//! trait inheritance, and build multi-action transactions with typed methods.
+//!
+//! Run: cargo run --example typed_contracts
+//!
+//! Set environment variables for write operations:
+//!   NEAR_ACCOUNT_ID=your-account.testnet
+//!   NEAR_PRIVATE_KEY=ed25519:...
+
+use near_kit::*;
+use serde::{Deserialize, Serialize};
+
+// ============================================================================
+// 1. Define contract standards
+// ============================================================================
+//
+// Standards like NEP-141 (fungible token) and NEP-145 (storage management)
+// are reusable trait definitions. Define them once, reuse everywhere.
+
+#[derive(Serialize)]
+pub struct StorageDepositArgs {
+    pub account_id: Option<String>,
+    pub registration_only: Option<bool>,
+}
+
+/// NEP-145: Storage Management standard
+#[near_kit::contract]
+pub trait StorageManagement {
+    #[call(payable)]
+    fn storage_deposit(&mut self, args: StorageDepositArgs);
+}
+
+#[derive(Serialize)]
+pub struct FtTransferArgs {
+    pub receiver_id: String,
+    pub amount: String,
+    pub memo: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FtMetadataView {
+    pub name: String,
+    pub symbol: String,
+    pub decimals: u8,
+}
+
+/// NEP-141: Fungible Token standard
+#[near_kit::contract]
+pub trait Ft {
+    fn ft_metadata(&self) -> FtMetadataView;
+
+    #[call]
+    fn ft_transfer(&mut self, args: FtTransferArgs);
+}
+
+// ============================================================================
+// 2. Compose standards into a concrete contract
+// ============================================================================
+//
+// Your contract implements multiple standards. Declare this with trait
+// inheritance — the generated client automatically gets ALL methods.
+
+#[derive(Serialize)]
+pub struct MintArgs {
+    pub account_id: String,
+    pub amount: String,
+}
+
+/// A token contract that implements FT + storage management + custom methods
+#[near_kit::contract]
+pub trait MyToken: Ft + StorageManagement {
+    #[call]
+    fn mint(&mut self, args: MintArgs);
+}
+
+// ============================================================================
+// 3. Simple contract calls (per-trait client)
+// ============================================================================
+
+async fn simple_calls(near: &Near) -> Result<(), Error> {
+    println!("=== Simple Typed Calls ===\n");
+
+    // Create a typed client — one object with ALL methods from ALL standards
+    let token = near.contract::<dyn MyToken>("wrap.testnet");
+
+    // View methods (from Ft standard)
+    let metadata = token.ft_metadata().await?;
+    println!("Token: {} ({})", metadata.name, metadata.symbol);
+
+    // Change methods (from Ft standard)
+    token
+        .ft_transfer(FtTransferArgs {
+            receiver_id: "bob.testnet".to_string(),
+            amount: "1000000".to_string(),
+            memo: Some("payment".to_string()),
+        })
+        .gas(Gas::from_tgas(30))
+        .deposit(NearToken::from_yoctonear(1))
+        .await?;
+
+    // Change methods (from StorageManagement standard)
+    token
+        .storage_deposit(StorageDepositArgs {
+            account_id: Some("bob.testnet".to_string()),
+            registration_only: Some(true),
+        })
+        .deposit(NearToken::from_millinear(100))
+        .await?;
+
+    // Custom methods (from MyToken itself)
+    token
+        .mint(MintArgs {
+            account_id: "alice.testnet".to_string(),
+            amount: "5000000".to_string(),
+        })
+        .await?;
+
+    Ok(())
+}
+
+// ============================================================================
+// 4. Typed transaction composition
+// ============================================================================
+//
+// Use `.typed_call::<dyn T>()` to compose multiple typed actions in a single
+// atomic transaction. Mix with raw actions like state_init or transfer.
+
+async fn composed_transaction(near: &Near) -> Result<(), Error> {
+    println!("=== Composed Transaction ===\n");
+
+    // Register storage + transfer tokens in a single atomic transaction
+    let outcome = near
+        .transaction("wrap.testnet")
+        // First action: register storage for bob (typed, from StorageManagement)
+        .typed_call::<dyn MyToken>()
+        .storage_deposit(StorageDepositArgs {
+            account_id: Some("bob.testnet".to_string()),
+            registration_only: Some(true),
+        })
+        .deposit(NearToken::from_millinear(100))
+        // Second action: transfer tokens to bob (typed, from Ft)
+        .typed_call::<dyn MyToken>()
+        .ft_transfer(FtTransferArgs {
+            receiver_id: "bob.testnet".to_string(),
+            amount: "1000000".to_string(),
+            memo: None,
+        })
+        .deposit(NearToken::from_yoctonear(1))
+        // Send as one atomic transaction
+        .send()
+        .await?;
+
+    println!("Composed tx: {:?}", outcome.transaction_hash());
+    println!("Gas used: {}", outcome.total_gas_used());
+
+    Ok(())
+}
+
+// ============================================================================
+// 5. Mix typed calls with raw actions
+// ============================================================================
+
+async fn mixed_transaction(near: &Near) -> Result<(), Error> {
+    println!("=== Mixed Raw + Typed Transaction ===\n");
+
+    let outcome = near
+        .transaction("wrap.testnet")
+        // Raw action: transfer NEAR
+        .transfer(NearToken::from_millinear(10))
+        // Typed action: register storage
+        .typed_call::<dyn StorageManagement>()
+        .storage_deposit(StorageDepositArgs {
+            account_id: None,
+            registration_only: None,
+        })
+        .deposit(NearToken::from_millinear(100))
+        // Raw action via FunctionCall
+        .add_action(
+            FunctionCall::new("custom_method")
+                .args(serde_json::json!({"key": "value"}))
+                .gas(Gas::from_tgas(10)),
+        )
+        .send()
+        .await?;
+
+    println!("Mixed tx: {:?}", outcome.transaction_hash());
+
+    Ok(())
+}
+
+// ============================================================================
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    // Read-only operations work without credentials
+    let near = Near::testnet().build();
+    let token = near.contract::<dyn MyToken>("wrap.testnet");
+
+    // View calls work without a signer
+    match token.ft_metadata().await {
+        Ok(meta) => println!(
+            "Token: {} ({}), decimals: {}",
+            meta.name, meta.symbol, meta.decimals
+        ),
+        Err(e) => println!("View call failed (expected on testnet): {e}"),
+    }
+
+    // Write operations need credentials
+    let account_id = std::env::var("NEAR_ACCOUNT_ID").ok();
+    let private_key = std::env::var("NEAR_PRIVATE_KEY").ok();
+
+    match (account_id, private_key) {
+        (Some(account), Some(key)) => {
+            let near = Near::testnet().credentials(&key, &account)?.build();
+            simple_calls(&near).await?;
+            composed_transaction(&near).await?;
+            mixed_transaction(&near).await?;
+        }
+        _ => {
+            println!("\nSet NEAR_ACCOUNT_ID and NEAR_PRIVATE_KEY for write operations.");
+        }
+    }
+
+    Ok(())
+}

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -274,6 +274,31 @@ impl TransactionBuilder {
         CallBuilder::new(self, method.to_string())
     }
 
+    /// Switch to a typed contract scope for composing typed function calls.
+    ///
+    /// Returns a trait-specific builder whose methods append typed
+    /// `FunctionCall` actions. Each method returns a [`CallBuilder`] for
+    /// further chaining (setting gas/deposit, or calling
+    /// `.typed_call::<AnotherTrait>()` for the next scope).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use near_kit::StorageManagementTx;
+    /// use near_kit::FungibleTokenTx;
+    ///
+    /// near.transaction("token.near")
+    ///     .typed_call::<dyn StorageManagement>()
+    ///     .storage_deposit(args)
+    ///     .typed_call::<dyn FungibleToken>()
+    ///     .ft_transfer_call(args)
+    ///     .send()
+    ///     .await?;
+    /// ```
+    pub fn typed_call<T: crate::contract::Contract + ?Sized>(self) -> T::TxBuilder {
+        crate::contract::ContractTxBuilder::from_builder(self)
+    }
+
     /// Add a full access key to the account.
     pub fn add_full_access_key(mut self, public_key: PublicKey) -> Self {
         self.actions.push(Action::add_full_access_key(public_key));
@@ -1137,6 +1162,13 @@ impl CallBuilder {
     /// Add another function call.
     pub fn call(self, method: &str) -> CallBuilder {
         self.finish().call(method)
+    }
+
+    /// Switch to a typed contract scope.
+    ///
+    /// See [`TransactionBuilder::typed_call`] for details.
+    pub fn typed_call<T: crate::contract::Contract + ?Sized>(self) -> T::TxBuilder {
+        self.finish().typed_call::<T>()
     }
 
     /// Add a create account action.

--- a/crates/near-kit/src/contract.rs
+++ b/crates/near-kit/src/contract.rs
@@ -89,7 +89,7 @@
 //! }
 //! ```
 
-use crate::client::Near;
+use crate::client::{Near, TransactionBuilder};
 use crate::types::AccountId;
 
 /// Marker trait for typed contract interfaces.
@@ -105,11 +105,15 @@ use crate::types::AccountId;
 /// ```ignore
 /// impl Contract for dyn MyContract {
 ///     type Client = MyContractClient;
+///     type TxBuilder = MyContractTxBuilder;
 /// }
 /// ```
 pub trait Contract {
     /// The generated client type for this contract interface.
     type Client: ContractClient;
+
+    /// The generated transaction builder for composing typed calls.
+    type TxBuilder: ContractTxBuilder;
 }
 
 /// Trait for contract client constructors.
@@ -119,4 +123,27 @@ pub trait Contract {
 pub trait ContractClient: Sized {
     /// Create a new contract client.
     fn new(near: Near, contract_id: AccountId) -> Self;
+}
+
+/// Provides access to the underlying `Near` client and contract ID.
+///
+/// Implemented by generated client structs. Standard method traits use this
+/// to access the RPC client and contract address without knowing the concrete type.
+pub trait HasContractContext {
+    /// Get a reference to the `Near` client.
+    fn near(&self) -> &Near;
+    /// Get the contract account ID.
+    fn contract_id(&self) -> &AccountId;
+}
+
+/// Trait for contract transaction builders.
+///
+/// Implemented by generated `{Trait}TxBuilder` structs returned from
+/// [`TransactionBuilder::call`] and [`CallBuilder::call`].
+pub trait ContractTxBuilder: Sized {
+    /// Create a new transaction builder wrapper from a `TransactionBuilder`.
+    fn from_builder(builder: TransactionBuilder) -> Self;
+
+    /// Consume this wrapper and return the inner `TransactionBuilder`.
+    fn into_builder(self) -> TransactionBuilder;
 }

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -402,7 +402,7 @@ pub use types::nep413;
 pub use types::*;
 
 // Re-export contract types
-pub use contract::{Contract, ContractClient};
+pub use contract::{Contract, ContractClient, ContractTxBuilder, HasContractContext};
 
 // Re-export client types
 pub use client::{


### PR DESCRIPTION
## Summary

- `#[near_kit::contract]` macro now generates composable method traits alongside the existing client, using blanket impls + marker traits
- Contracts can inherit standards via trait inheritance: `trait MyToken: FungibleToken + StorageManagement` — the generated client automatically gets methods from all supertraits
- New `.typed_call::<dyn T>()` method on `TransactionBuilder`/`CallBuilder` for fluent typed transaction composition across standards

### Composing standards via trait inheritance

```rust
#[near_kit::contract]
pub trait StorageManagement {
    #[call(payable)]
    fn storage_deposit(&mut self, args: StorageDepositArgs);
}

#[near_kit::contract]
pub trait FungibleToken {
    fn ft_metadata(&self) -> FtMetadataView;
    #[call]
    fn ft_transfer(&mut self, args: FtTransferArgs);
}

// Compose standards — client gets ALL methods
#[near_kit::contract]
pub trait MyToken: FungibleToken + StorageManagement {
    #[call]
    fn mint(&mut self, args: MintArgs);
}

let token = near.contract::<dyn MyToken>("token.near");
token.ft_transfer(args).await?;       // from FungibleToken
token.storage_deposit(args).await?;   // from StorageManagement
token.mint(args).await?;              // from MyToken
```

### Typed transaction composition

```rust
near.transaction("token.near")
    .typed_call::<dyn MyToken>()
    .storage_deposit(args)
    .deposit("0.1 NEAR")
    .typed_call::<dyn MyToken>()
    .ft_transfer(args)
    .deposit(NearToken::from_yoctonear(1))
    .send().await?;
```

### How it works

The proc macro challenge: when processing `MyToken: FungibleToken + StorageManagement`, the macro can't look up supertrait method definitions. Solved via blanket impls + marker traits — each standard generates a methods trait with default impls, and the composite type just implements marker traits. Rust's trait system does the rest.

Addresses #92

## Test plan

- [x] 380 unit tests pass
- [x] All existing trybuild compile-pass/compile-fail tests pass
- [x] New `contract_composition.rs` trybuild test validates full ergonomic flow
- [x] New `typed_contracts.rs` example demonstrates end-to-end usage
- [x] Clippy clean