### PR TITLE
feat!: composable typed contract calls via FunctionCall constructors

### DIFF
--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -419,6 +419,12 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
             "#[near_kit::contract] does not support generic parameters",
         ));
     }
+    if let Some(where_clause) = &input.generics.where_clause {
+        return Err(syn::Error::new(
+            where_clause.span(),
+            "#[near_kit::contract] does not support where clauses",
+        ));
+    }
     if !input.supertraits.is_empty() {
         return Err(syn::Error::new(
             input.supertraits.span(),

--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -349,15 +349,50 @@ fn generate_call_method(method: &MethodInfo, contract_format: SerializationForma
     }
 }
 
-/// Strip internal attributes from a method for the output trait.
-fn strip_internal_attrs(method: &TraitItemFn) -> TraitItemFn {
-    let mut method = method.clone();
-    method.attrs.retain(|attr| {
-        !attr.path().is_ident("call")
-            && !attr.path().is_ident("json")
-            && !attr.path().is_ident("borsh")
-    });
-    method
+/// Generate a static associated function on the contract struct that returns `FunctionCall`.
+///
+/// Only generated for call methods (not view methods). This enables composable
+/// transactions where typed contract calls can be mixed with other actions.
+fn generate_function_call_method(
+    method: &MethodInfo,
+    contract_format: SerializationFormat,
+) -> TokenStream2 {
+    let method_name = &method.name;
+    let method_name_str = method_name.to_string();
+
+    let format = method.format_override.unwrap_or(contract_format);
+
+    if let (Some(arg_name), Some(arg_type)) = (&method.arg_name, &method.arg_type) {
+        let args_method = match format {
+            SerializationFormat::Json => quote! { .args(#arg_name) },
+            SerializationFormat::Borsh => quote! { .args_borsh(#arg_name) },
+        };
+
+        quote! {
+            pub fn #method_name(#arg_name: #arg_type) -> near_kit::FunctionCall {
+                near_kit::FunctionCall::new(#method_name_str)
+                    #args_method
+            }
+        }
+    } else {
+        match format {
+            SerializationFormat::Json => {
+                quote! {
+                    pub fn #method_name() -> near_kit::FunctionCall {
+                        near_kit::FunctionCall::new(#method_name_str)
+                            .args(serde_json::json!({}))
+                    }
+                }
+            }
+            SerializationFormat::Borsh => {
+                quote! {
+                    pub fn #method_name() -> near_kit::FunctionCall {
+                        near_kit::FunctionCall::new(#method_name_str)
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// The main contract macro implementation.
@@ -385,7 +420,7 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
         }
     }
 
-    // Generate client methods
+    // Generate client methods (view → ViewCall, call → CallBuilder)
     let client_methods: Vec<TokenStream2> = methods
         .iter()
         .map(|m| {
@@ -397,35 +432,26 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
         })
         .collect();
 
-    // Generate the cleaned trait (without internal attributes)
-    let cleaned_items: Vec<TraitItem> = input
-        .items
+    // Generate FunctionCall constructors for call methods only
+    let function_call_methods: Vec<TokenStream2> = methods
         .iter()
-        .map(|item| {
-            if let TraitItem::Fn(method) = item {
-                TraitItem::Fn(strip_internal_attrs(method))
-            } else {
-                item.clone()
-            }
-        })
+        .filter(|m| !m.is_view)
+        .map(|m| generate_function_call_method(m, args.format))
         .collect();
-
-    let trait_attrs = &input.attrs;
-    let trait_supertraits = &input.supertraits;
-    let trait_generics = &input.generics;
 
     // Build the output
     let expanded = quote! {
-        // Original trait (with internal attrs stripped for cleaner output)
-        // The trait is used for defining the interface, but the generated client
-        // struct is what's actually used - so suppress dead_code warnings.
-        #[allow(dead_code)]
-        #(#trait_attrs)*
-        #vis trait #trait_name #trait_generics : #trait_supertraits {
-            #(#cleaned_items)*
+        // Unit struct for composable FunctionCall constructors.
+        //
+        // Use the associated functions to create typed `FunctionCall` values
+        // that can be added to any transaction via `TransactionBuilder::add_action()`.
+        #vis struct #trait_name;
+
+        impl #trait_name {
+            #(#function_call_methods)*
         }
 
-        // Generated client struct
+        // Generated client struct for the simple (non-composed) case.
         #vis struct #client_name {
             near: near_kit::Near,
             contract_id: near_kit::AccountId,
@@ -461,7 +487,7 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
         }
 
         // Implement Contract marker trait
-        impl near_kit::Contract for dyn #trait_name {
+        impl near_kit::Contract for #trait_name {
             type Client = #client_name;
         }
     };

--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -412,11 +412,33 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
     let client_name = format_ident!("{}Client", trait_name);
     let vis = &input.vis;
 
-    // Parse all methods
+    // Reject unsupported trait features
+    if !input.generics.params.is_empty() {
+        return Err(syn::Error::new(
+            input.generics.span(),
+            "#[near_kit::contract] does not support generic parameters",
+        ));
+    }
+    if !input.supertraits.is_empty() {
+        return Err(syn::Error::new(
+            input.supertraits.span(),
+            "#[near_kit::contract] does not support supertraits",
+        ));
+    }
+
+    // Parse all methods, reject non-method items
     let mut methods = Vec::new();
     for item in &input.items {
-        if let TraitItem::Fn(method) = item {
-            methods.push(parse_method(method)?);
+        match item {
+            TraitItem::Fn(method) => {
+                methods.push(parse_method(method)?);
+            }
+            other => {
+                return Err(syn::Error::new(
+                    other.span(),
+                    "#[near_kit::contract] only supports methods, not associated types or constants",
+                ));
+            }
         }
     }
 
@@ -439,12 +461,12 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
         .map(|m| generate_function_call_method(m, args.format))
         .collect();
 
+    // Propagate trait-level attributes (doc comments, #[cfg], etc.) to the struct
+    let trait_attrs = &input.attrs;
+
     // Build the output
     let expanded = quote! {
-        // Unit struct for composable FunctionCall constructors.
-        //
-        // Use the associated functions to create typed `FunctionCall` values
-        // that can be added to any transaction via `TransactionBuilder::add_action()`.
+        #(#trait_attrs)*
         #vis struct #trait_name;
 
         impl #trait_name {

--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -377,10 +377,11 @@ fn generate_function_call_method(
     } else {
         match format {
             SerializationFormat::Json => {
+                // Use args_raw to avoid depending on serde_json in expanded code
                 quote! {
                     pub fn #method_name() -> near_kit::FunctionCall {
                         near_kit::FunctionCall::new(#method_name_str)
-                            .args(serde_json::json!({}))
+                            .args_raw(b"{}".to_vec())
                     }
                 }
             }
@@ -449,6 +450,12 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
     for item in &input.items {
         match item {
             TraitItem::Fn(method) => {
+                if method.default.is_some() {
+                    return Err(syn::Error::new(
+                        method.sig.span(),
+                        "#[near_kit::contract] does not support default method implementations",
+                    ));
+                }
                 methods.push(parse_method(method)?);
             }
             other => {

--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -413,6 +413,18 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
     let vis = &input.vis;
 
     // Reject unsupported trait features
+    if let Some(unsafety) = input.unsafety {
+        return Err(syn::Error::new(
+            unsafety.span(),
+            "#[near_kit::contract] does not support unsafe traits",
+        ));
+    }
+    if let Some(auto_token) = input.auto_token {
+        return Err(syn::Error::new(
+            auto_token.span(),
+            "#[near_kit::contract] does not support auto traits",
+        ));
+    }
     if !input.generics.params.is_empty() {
         return Err(syn::Error::new(
             input.generics.span(),

--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -461,7 +461,7 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
             other => {
                 return Err(syn::Error::new(
                     other.span(),
-                    "#[near_kit::contract] only supports methods, not associated types or constants",
+                    "#[near_kit::contract] only supports methods in traits",
                 ));
             }
         }

--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -290,7 +290,7 @@ fn generate_view_method(method: &MethodInfo, contract_format: SerializationForma
                 quote! {
                     pub fn #method_name(&self) -> #view_return_type {
                         self.near.view::<#return_type>(&self.contract_id, #method_name_str)
-                            .args(serde_json::json!({}))
+                            .args_raw(b"{}".to_vec())
                     }
                 }
             }
@@ -334,7 +334,7 @@ fn generate_call_method(method: &MethodInfo, contract_format: SerializationForma
                 quote! {
                     pub fn #method_name(&self) -> near_kit::CallBuilder {
                         self.near.call(&self.contract_id, #method_name_str)
-                            .args(serde_json::json!({}))
+                            .args_raw(b"{}".to_vec())
                     }
                 }
             }

--- a/crates/near-kit-macros/tests/compile-pass/json_contract.rs
+++ b/crates/near-kit-macros/tests/compile-pass/json_contract.rs
@@ -42,4 +42,19 @@ fn main() {
     )
     .unwrap();
     let _client2: JsonGuestbookClient = client.with_signer(signer);
+
+    // Verify static FunctionCall constructors on the unit struct
+    let _fc: FunctionCall = JsonGuestbook::add_message(AddMessageArgs {
+        text: "composable".to_string(),
+    });
+
+    // Verify FunctionCall can be composed into a transaction via add_action
+    let _tx = near
+        .transaction("guestbook.testnet")
+        .add_action(
+            JsonGuestbook::add_message(AddMessageArgs {
+                text: "composed".to_string(),
+            })
+            .gas(Gas::from_tgas(50)),
+        );
 }

--- a/crates/near-kit-macros/tests/compile-pass/mixed_format_contract.rs
+++ b/crates/near-kit-macros/tests/compile-pass/mixed_format_contract.rs
@@ -73,4 +73,10 @@ fn main() {
         let _: ViewCall<u64> = client.get_json_value();
         let _: CallBuilder = client.set_json_value();
     }
+
+    // Verify static FunctionCall constructors (call methods only, not view)
+    let _: FunctionCall = MixedContract::set_json_value();
+    let _: FunctionCall = MixedContract::set_borsh_value();
+    let _: FunctionCall = MixedContractBorshDefault::set_borsh_value();
+    let _: FunctionCall = MixedContractBorshDefault::set_json_value();
 }

--- a/crates/near-kit/examples/quickstart.rs
+++ b/crates/near-kit/examples/quickstart.rs
@@ -135,7 +135,7 @@ pub struct Message {
 async fn typed_contract_example(near: &Near) -> Result<(), Error> {
     println!("\n=== Typed Contract Example ===\n");
 
-    let guestbook = near.contract::<dyn Guestbook>("guestbook.near-examples.testnet");
+    let guestbook = near.contract::<Guestbook>("guestbook.near-examples.testnet");
 
     // View call with full type safety
     let total = guestbook.total_messages().await?;

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -819,10 +819,7 @@ impl Near {
     ///     Ok(())
     /// }
     /// ```
-    pub fn contract<T: crate::Contract + ?Sized>(
-        &self,
-        contract_id: impl TryIntoAccountId,
-    ) -> T::Client {
+    pub fn contract<T: crate::Contract>(&self, contract_id: impl TryIntoAccountId) -> T::Client {
         let contract_id = contract_id
             .try_into_account_id()
             .expect("invalid account ID");

--- a/crates/near-kit/src/contract.rs
+++ b/crates/near-kit/src/contract.rs
@@ -95,15 +95,28 @@ use crate::types::AccountId;
 /// Marker trait for typed contract interfaces.
 ///
 /// This trait is automatically implemented by the `#[near_kit::contract]` macro
-/// for each contract trait you define. It provides the associated `Client` type
+/// for each contract interface you define. It provides the associated `Client` type
 /// that is used by [`Near::contract`](crate::Near::contract).
 ///
 /// # Example
 ///
-/// The macro generates an implementation like this:
+/// Given a contract definition:
 ///
 /// ```ignore
-/// impl Contract for dyn MyContract {
+/// #[near_kit::contract]
+/// pub trait MyContract {
+///     fn get_value(&self) -> u64;
+///     #[call]
+///     fn set_value(&mut self, args: SetArgs);
+/// }
+/// ```
+///
+/// The macro generates a unit struct `MyContract` with composable
+/// `FunctionCall` constructors, a `MyContractClient` for the simple case,
+/// and this implementation:
+///
+/// ```ignore
+/// impl Contract for MyContract {
 ///     type Client = MyContractClient;
 /// }
 /// ```

--- a/crates/near-kit/src/contract.rs
+++ b/crates/near-kit/src/contract.rs
@@ -78,14 +78,60 @@
 //! }
 //! ```
 //!
-//! # Serialization Formats
+//! # Composing Typed Calls in Transactions
 //!
-//! By default, arguments are serialized as JSON. For Borsh serialization:
+//! The macro also generates static `FunctionCall` constructors on the struct,
+//! so typed calls can be mixed with other actions in a single transaction:
 //!
 //! ```ignore
+//! // Compose state_init + typed call in one transaction
+//! near.transaction(contract_id)
+//!     .state_init(state_init, NearToken::ZERO)
+//!     .add_action(Counter::increment())
+//!     .send().await?;
+//!
+//! // Compose calls from multiple contract standards
+//! near.transaction("token.near")
+//!     .add_action(StorageManagement::storage_deposit(deposit_args))
+//!     .add_action(FungibleToken::ft_transfer_call(transfer_args))
+//!     .send().await?;
+//! ```
+//!
+//! # Serialization Formats
+//!
+//! By default, arguments are serialized as JSON. Use `#[near_kit::contract(borsh)]`
+//! if the on-chain contract expects Borsh-encoded input:
+//!
+//! ```ignore
+//! use borsh::BorshSerialize;
+//!
+//! #[derive(BorshSerialize)]
+//! pub struct UploadArgs {
+//!     pub data: Vec<u8>,
+//! }
+//!
 //! #[near_kit::contract(borsh)]
-//! pub trait MyContract {
-//!     fn my_method(&self, args: MyArgs) -> u64;
+//! pub trait DataStore {
+//!     fn get_size(&self) -> u64;
+//!
+//!     #[call]
+//!     fn upload(&mut self, args: UploadArgs);
+//! }
+//! ```
+//!
+//! You can also override the format per-method with `#[borsh]` or `#[json]`:
+//!
+//! ```ignore
+//! #[near_kit::contract]  // default: JSON
+//! pub trait MixedContract {
+//!     fn get_status(&self) -> String;       // JSON (default)
+//!
+//!     #[call]
+//!     fn set_config(&mut self, args: Config);  // JSON (default)
+//!
+//!     #[call]
+//!     #[borsh]
+//!     fn upload_data(&mut self, args: Data);   // Borsh (override)
 //! }
 //! ```
 

--- a/crates/near-kit/src/contract.rs
+++ b/crates/near-kit/src/contract.rs
@@ -99,8 +99,10 @@
 //!
 //! # Serialization Formats
 //!
-//! By default, arguments are serialized as JSON. Use `#[near_kit::contract(borsh)]`
-//! if the on-chain contract expects Borsh-encoded input:
+//! By default, arguments are serialized as JSON and view responses are
+//! deserialized from JSON. Use `#[near_kit::contract(borsh)]` to switch
+//! both directions to Borsh (call args are Borsh-encoded, view responses
+//! are Borsh-decoded):
 //!
 //! ```ignore
 //! use borsh::BorshSerialize;

--- a/crates/near-kit/tests/integration/typed_contract_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_error_integration.rs
@@ -60,7 +60,7 @@ async fn test_typed_contract_view_on_nonexistent_account() {
     let near = sandbox.client();
 
     // Try to call view method on non-existent contract
-    let guestbook = near.contract::<dyn Guestbook>("nonexistent-contract.sandbox");
+    let guestbook = near.contract::<Guestbook>("nonexistent-contract.sandbox");
     let result = guestbook.total_messages().await;
 
     assert!(result.is_err(), "Should error for non-existent account");
@@ -97,7 +97,7 @@ async fn test_typed_contract_view_on_account_without_contract() {
         .unwrap();
 
     // Try to call view method on account without contract
-    let guestbook = near.contract::<dyn Guestbook>(&account_id);
+    let guestbook = near.contract::<Guestbook>(&account_id);
     let result = guestbook.total_messages().await;
 
     assert!(result.is_err(), "Should error for account without contract");
@@ -134,7 +134,7 @@ async fn test_typed_contract_call_without_signer() {
 
     // Create client WITHOUT a signer
     let no_signer_near = Near::custom(sandbox.rpc_url()).build();
-    let guestbook = no_signer_near.contract::<dyn Guestbook>(&contract_id);
+    let guestbook = no_signer_near.contract::<Guestbook>(&contract_id);
 
     // Try to call a mutating method without signer
     let result = guestbook
@@ -173,7 +173,7 @@ async fn test_typed_contract_view_on_wrong_contract_type() {
         .unwrap();
 
     // Try to use guestbook interface on FT contract
-    let guestbook = near.contract::<dyn Guestbook>(&contract_id);
+    let guestbook = near.contract::<Guestbook>(&contract_id);
     let result = guestbook.total_messages().await;
 
     assert!(result.is_err(), "Should error for wrong contract type");
@@ -209,7 +209,7 @@ async fn test_typed_contract_call_with_insufficient_gas() {
         .await
         .unwrap();
 
-    let guestbook = near.contract::<dyn Guestbook>(&contract_id);
+    let guestbook = near.contract::<Guestbook>(&contract_id);
 
     // Try to call with extremely low gas
     let result = guestbook
@@ -263,7 +263,7 @@ async fn test_typed_contract_view_returns_wrong_type() {
         fn total_messages(&self) -> String;
     }
 
-    let wrong_guestbook = near.contract::<dyn WrongGuestbook>(&contract_id);
+    let wrong_guestbook = near.contract::<WrongGuestbook>(&contract_id);
     let result = wrong_guestbook.total_messages().await;
 
     // The result could succeed (if deserialization happens to work) or fail
@@ -302,7 +302,7 @@ async fn test_typed_contract_query_at_invalid_block() {
         .await
         .unwrap();
 
-    let guestbook = near.contract::<dyn Guestbook>(&contract_id);
+    let guestbook = near.contract::<Guestbook>(&contract_id);
 
     // Query at a non-existent block height
     let result: Result<u32, _> = guestbook.total_messages().at_block(999_999_999_u64).await;
@@ -345,7 +345,7 @@ async fn test_typed_contract_view_methods_still_work_without_signer() {
 
     // Create client WITHOUT a signer
     let no_signer_near = Near::custom(sandbox.rpc_url()).build();
-    let guestbook = no_signer_near.contract::<dyn Guestbook>(&contract_id);
+    let guestbook = no_signer_near.contract::<Guestbook>(&contract_id);
 
     // View methods should still work without a signer
     let result = guestbook.total_messages().await;

--- a/crates/near-kit/tests/integration/typed_contract_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_integration.rs
@@ -99,7 +99,7 @@ async fn test_typed_contract_view_methods() {
         .expect("Failed to deploy guestbook");
 
     // Create typed contract client
-    let guestbook = near.contract::<dyn Guestbook>(&contract_id);
+    let guestbook = near.contract::<Guestbook>(&contract_id);
 
     // Test view method - total_messages
     let count = guestbook
@@ -131,7 +131,7 @@ async fn test_typed_contract_call_methods() {
         .expect("Failed to deploy guestbook");
 
     // Create typed contract client
-    let guestbook = near.contract::<dyn Guestbook>(&contract_id);
+    let guestbook = near.contract::<Guestbook>(&contract_id);
 
     // Add a message using typed call method
     guestbook
@@ -174,7 +174,7 @@ async fn test_typed_contract_multiple_messages() {
         .expect("Failed to deploy guestbook");
 
     // Create typed contract client
-    let guestbook = near.contract::<dyn Guestbook>(&contract_id);
+    let guestbook = near.contract::<Guestbook>(&contract_id);
 
     // Add multiple messages
     let test_messages = vec!["First message", "Second message", "Third message"];
@@ -223,7 +223,7 @@ async fn test_typed_contract_with_custom_gas() {
         .expect("Failed to deploy guestbook");
 
     // Create typed contract client
-    let guestbook = near.contract::<dyn Guestbook>(&contract_id);
+    let guestbook = near.contract::<Guestbook>(&contract_id);
 
     // Add message with custom gas
     guestbook
@@ -258,7 +258,7 @@ async fn test_typed_contract_block_reference() {
         .expect("Failed to deploy guestbook");
 
     // Create typed contract client
-    let guestbook = near.contract::<dyn Guestbook>(&contract_id);
+    let guestbook = near.contract::<Guestbook>(&contract_id);
 
     // Add a message
     guestbook
@@ -294,7 +294,7 @@ async fn test_typed_contract_payable_method() {
         .expect("Failed to deploy guestbook");
 
     // Create typed contract client with payable interface
-    let guestbook = near.contract::<dyn GuestbookPayable>(&contract_id);
+    let guestbook = near.contract::<GuestbookPayable>(&contract_id);
 
     // Add a message WITHOUT deposit - should be non-premium
     guestbook
@@ -353,7 +353,7 @@ async fn test_typed_contract_no_args_view() {
         .expect("Failed to deploy guestbook");
 
     // Create typed contract client using the no-args interface
-    let guestbook = near.contract::<dyn GuestbookNoArgs>(&contract_id);
+    let guestbook = near.contract::<GuestbookNoArgs>(&contract_id);
 
     // Test view method without arguments - total_messages
     let count = guestbook
@@ -370,7 +370,7 @@ async fn test_typed_contract_no_args_view() {
     assert!(messages.is_empty(), "Initial messages should be empty");
 
     // Now add a message using the main interface
-    let main_guestbook = near.contract::<dyn Guestbook>(&contract_id);
+    let main_guestbook = near.contract::<Guestbook>(&contract_id);
     main_guestbook
         .add_message(AddMessageArgs {
             text: "Test message".to_string(),


### PR DESCRIPTION
## Summary

- The `#[near_kit::contract]` macro now generates a **unit struct** (replacing the unused trait) with static associated functions that return `FunctionCall`
- This enables typed contract calls to be composed with other actions in a single transaction via `TransactionBuilder::add_action()`
- The `Client` struct is unchanged for the simple case

### Before (forced to use raw JSON for composed transactions)
```rust
near.transaction(contract_id)
    .state_init(state_init, NearToken::ZERO)
    .call("w_execute_signed")
    .args(json!({"msg": msg, "proof": proof}))  // no type safety
    .gas(Gas::from_tgas(300))
    .finish()
    .send().await?;
```

### After (typed and composable)
```rust
near.transaction(contract_id)
    .state_init(state_init, NearToken::ZERO)
    .add_action(WalletContract::w_execute_signed(args).gas(Gas::from_tgas(300)))
    .send().await?;
```

### Multi-standard composition also works
```rust
near.transaction("token.near")
    .add_action(StorageManagement::storage_deposit(args))
    .add_action(FungibleToken::ft_transfer_call(args))
    .send().await?;
```

## Breaking changes

- `near.contract::<dyn MyTrait>()` → `near.contract::<MyTrait>()`
- `impl Contract for dyn MyTrait` → `impl Contract for MyTrait`

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo test -p near-kit-macros` — all compile-pass/compile-fail tests pass
- [x] `cargo test -p near-kit --lib` — all 378 unit tests pass
- [x] `cargo check --examples` — examples compile
- [ ] `cargo test --features sandbox` — integration tests (requires sandbox)

Closes #99
Supersedes #96