### PR TITLE
feat!: replace Network enum with ChainId newtype

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -119,8 +119,11 @@ impl Near {
     /// Create a configured client from environment variables.
     ///
     /// Reads the following environment variables:
-    /// - `NEAR_CHAIN_ID` or `NEAR_NETWORK` (optional): `"mainnet"`, `"testnet"`, or a custom RPC URL.
-    ///   `NEAR_CHAIN_ID` takes precedence over `NEAR_NETWORK`. Defaults to `"testnet"` if not set.
+    /// - `NEAR_NETWORK` (optional): `"mainnet"`, `"testnet"`, or a custom RPC URL.
+    ///   Defaults to `"testnet"` if not set.
+    /// - `NEAR_CHAIN_ID` (optional): Overrides the chain identifier (e.g., `"pinet"`).
+    ///   Only needed for custom networks — `"mainnet"` and `"testnet"` are inferred
+    ///   from `NEAR_NETWORK` automatically.
     /// - `NEAR_ACCOUNT_ID` (optional): Account ID for signing transactions.
     /// - `NEAR_PRIVATE_KEY` (optional): Private key for signing (e.g., `"ed25519:..."`).
     /// - `NEAR_MAX_NONCE_RETRIES` (optional): Maximum number of transaction send
@@ -133,7 +136,8 @@ impl Near {
     ///
     /// ```bash
     /// # Environment variables
-    /// export NEAR_NETWORK=testnet
+    /// export NEAR_NETWORK=https://rpc.pinet.near.org
+    /// export NEAR_CHAIN_ID=pinet
     /// export NEAR_ACCOUNT_ID=alice.testnet
     /// export NEAR_PRIVATE_KEY=ed25519:...
     /// export NEAR_MAX_NONCE_RETRIES=10
@@ -158,18 +162,22 @@ impl Near {
     /// - `NEAR_PRIVATE_KEY` contains an invalid key format
     /// - `NEAR_MAX_NONCE_RETRIES` is set but not a valid positive integer
     pub fn from_env() -> Result<Near, Error> {
-        let network = std::env::var("NEAR_CHAIN_ID")
-            .or_else(|_| std::env::var("NEAR_NETWORK"))
-            .ok();
+        let network = std::env::var("NEAR_NETWORK").ok();
+        let chain_id_override = std::env::var("NEAR_CHAIN_ID").ok();
         let account_id = std::env::var("NEAR_ACCOUNT_ID").ok();
         let private_key = std::env::var("NEAR_PRIVATE_KEY").ok();
 
-        // Determine builder based on network/chain_id
+        // Determine builder based on NEAR_NETWORK
         let mut builder = match network.as_deref() {
             Some("mainnet") => Near::mainnet(),
             Some("testnet") | None => Near::testnet(),
             Some(url) => Near::custom(url),
         };
+
+        // Override chain_id if NEAR_CHAIN_ID is set
+        if let Some(id) = chain_id_override {
+            builder = builder.chain_id(id);
+        }
 
         // Configure signer if both account and key are provided
         match (account_id, private_key) {
@@ -1450,6 +1458,33 @@ mod tests {
                 "Error should mention NEAR_MAX_NONCE_RETRIES: {}",
                 err
             );
+        }
+
+        // Scenario 10: NEAR_CHAIN_ID overrides chain_id for custom network
+        clear_env();
+        unsafe {
+            std::env::set_var("NEAR_NETWORK", "https://rpc.pinet.near.org");
+            std::env::set_var("NEAR_CHAIN_ID", "pinet");
+        }
+        {
+            let near = Near::from_env().unwrap();
+            assert_eq!(near.rpc_url(), "https://rpc.pinet.near.org");
+            assert_eq!(near.chain_id().as_str(), "pinet");
+        }
+
+        // Scenario 11: NEAR_CHAIN_ID without NEAR_NETWORK defaults to testnet RPC
+        clear_env();
+        unsafe {
+            std::env::set_var("NEAR_CHAIN_ID", "my-chain");
+        }
+        {
+            let near = Near::from_env().unwrap();
+            assert!(
+                near.rpc_url().contains("test") || near.rpc_url().contains("fastnear"),
+                "Expected testnet URL, got: {}",
+                near.rpc_url()
+            );
+            assert_eq!(near.chain_id().as_str(), "my-chain");
         }
 
         // Final cleanup

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -123,8 +123,9 @@ impl Near {
     /// - `NEAR_NETWORK` (optional): `"mainnet"`, `"testnet"`, or a custom RPC URL.
     ///   Defaults to `"testnet"` if not set.
     /// - `NEAR_CHAIN_ID` (optional): Overrides the chain identifier (e.g., `"pinet"`).
-    ///   Only needed for custom networks — `"mainnet"` and `"testnet"` are inferred
-    ///   from `NEAR_NETWORK` automatically.
+    ///   If set, always overrides the chain ID inferred from `NEAR_NETWORK`, including
+    ///   the built-in `"mainnet"` and `"testnet"` presets. Typically only needed for
+    ///   custom networks.
     /// - `NEAR_ACCOUNT_ID` (optional): Account ID for signing transactions.
     /// - `NEAR_PRIVATE_KEY` (optional): Private key for signing (e.g., `"ed25519:..."`).
     /// - `NEAR_MAX_NONCE_RETRIES` (optional): Maximum number of transaction send
@@ -294,8 +295,9 @@ impl Near {
     /// Returns true if this client was created via [`Near::sandbox()`].
     ///
     /// Note: sandbox nodes generate a random `chain_id` (e.g., `test-chain-aB3xQ`)
-    /// on each startup, so `chain_id()` won't return a predictable value for sandbox.
-    /// Use this method instead to check if the client is connected to a sandbox.
+    /// on each startup, so [`Near::chain_id()`] returns a placeholder for sandbox
+    /// clients that does not reflect the node-reported chain ID. Use this method
+    /// instead to check if the client is connected to a sandbox.
     pub fn is_sandbox(&self) -> bool {
         self.sandbox
     }

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -7,7 +7,7 @@ use serde::de::DeserializeOwned;
 use crate::contract::ContractClient;
 use crate::error::Error;
 use crate::types::{
-    AccountId, Gas, IntoNearToken, NearToken, Network, PublicKey, SecretKey, TryIntoAccountId,
+    AccountId, ChainId, Gas, IntoNearToken, NearToken, PublicKey, SecretKey, TryIntoAccountId,
 };
 
 use super::query::{AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, ViewCall};
@@ -96,31 +96,31 @@ pub trait SandboxNetwork {
 pub struct Near {
     rpc: Arc<RpcClient>,
     signer: Option<Arc<dyn Signer>>,
-    network: Network,
+    chain_id: ChainId,
     max_nonce_retries: u32,
 }
 
 impl Near {
     /// Create a builder for mainnet.
     pub fn mainnet() -> NearBuilder {
-        NearBuilder::new(MAINNET.rpc_url, Network::Mainnet)
+        NearBuilder::new(MAINNET.rpc_url, ChainId::mainnet())
     }
 
     /// Create a builder for testnet.
     pub fn testnet() -> NearBuilder {
-        NearBuilder::new(TESTNET.rpc_url, Network::Testnet)
+        NearBuilder::new(TESTNET.rpc_url, ChainId::testnet())
     }
 
     /// Create a builder with a custom RPC URL.
     pub fn custom(rpc_url: impl Into<String>) -> NearBuilder {
-        NearBuilder::new(rpc_url, Network::Custom)
+        NearBuilder::new(rpc_url, ChainId::new("custom"))
     }
 
     /// Create a configured client from environment variables.
     ///
     /// Reads the following environment variables:
-    /// - `NEAR_NETWORK` (optional): `"mainnet"`, `"testnet"`, or a custom RPC URL.
-    ///   Defaults to `"testnet"` if not set.
+    /// - `NEAR_CHAIN_ID` or `NEAR_NETWORK` (optional): `"mainnet"`, `"testnet"`, or a custom RPC URL.
+    ///   `NEAR_CHAIN_ID` takes precedence over `NEAR_NETWORK`. Defaults to `"testnet"` if not set.
     /// - `NEAR_ACCOUNT_ID` (optional): Account ID for signing transactions.
     /// - `NEAR_PRIVATE_KEY` (optional): Private key for signing (e.g., `"ed25519:..."`).
     /// - `NEAR_MAX_NONCE_RETRIES` (optional): Maximum number of transaction send
@@ -158,11 +158,13 @@ impl Near {
     /// - `NEAR_PRIVATE_KEY` contains an invalid key format
     /// - `NEAR_MAX_NONCE_RETRIES` is set but not a valid positive integer
     pub fn from_env() -> Result<Near, Error> {
-        let network = std::env::var("NEAR_NETWORK").ok();
+        let network = std::env::var("NEAR_CHAIN_ID")
+            .or_else(|_| std::env::var("NEAR_NETWORK"))
+            .ok();
         let account_id = std::env::var("NEAR_ACCOUNT_ID").ok();
         let private_key = std::env::var("NEAR_PRIVATE_KEY").ok();
 
-        // Determine builder based on network
+        // Determine builder based on network/chain_id
         let mut builder = match network.as_deref() {
             Some("mainnet") => Near::mainnet(),
             Some("testnet") | None => Near::testnet(),
@@ -239,7 +241,7 @@ impl Near {
         Near {
             rpc: Arc::new(RpcClient::new(network.rpc_url())),
             signer: Some(Arc::new(signer)),
-            network: Network::Sandbox,
+            chain_id: ChainId::sandbox(),
             max_nonce_retries: 3,
         }
     }
@@ -274,9 +276,9 @@ impl Near {
         self.signer.clone()
     }
 
-    /// Get the network this client is connected to.
-    pub fn network(&self) -> Network {
-        self.network
+    /// Get the chain ID this client is connected to.
+    pub fn chain_id(&self) -> &ChainId {
+        &self.chain_id
     }
 
     /// Create a new client that shares this client's transport but uses a different signer.
@@ -306,7 +308,7 @@ impl Near {
         Near {
             rpc: self.rpc.clone(),
             signer: Some(Arc::new(signer)),
-            network: self.network,
+            chain_id: self.chain_id.clone(),
             max_nonce_retries: self.max_nonce_retries,
         }
     }
@@ -868,7 +870,7 @@ impl Near {
         &self,
         contract: impl crate::tokens::IntoContractId,
     ) -> Result<crate::tokens::FungibleToken, Error> {
-        let contract_id = contract.into_contract_id(self.network)?;
+        let contract_id = contract.into_contract_id(&self.chain_id)?;
         Ok(crate::tokens::FungibleToken::new(
             self.rpc.clone(),
             self.signer.clone(),
@@ -906,7 +908,7 @@ impl Near {
         &self,
         contract: impl crate::tokens::IntoContractId,
     ) -> Result<crate::tokens::NonFungibleToken, Error> {
-        let contract_id = contract.into_contract_id(self.network)?;
+        let contract_id = contract.into_contract_id(&self.chain_id)?;
         Ok(crate::tokens::NonFungibleToken::new(
             self.rpc.clone(),
             self.signer.clone(),
@@ -951,18 +953,18 @@ pub struct NearBuilder {
     rpc_url: String,
     signer: Option<Arc<dyn Signer>>,
     retry_config: RetryConfig,
-    network: Network,
+    chain_id: ChainId,
     max_nonce_retries: u32,
 }
 
 impl NearBuilder {
     /// Create a new builder with the given RPC URL.
-    fn new(rpc_url: impl Into<String>, network: Network) -> Self {
+    fn new(rpc_url: impl Into<String>, chain_id: ChainId) -> Self {
         Self {
             rpc_url: rpc_url.into(),
             signer: None,
             retry_config: RetryConfig::default(),
-            network,
+            chain_id,
             max_nonce_retries: 3,
         }
     }
@@ -998,6 +1000,15 @@ impl NearBuilder {
         Ok(self)
     }
 
+    /// Set the chain ID.
+    ///
+    /// This is useful for custom networks where the default chain ID
+    /// (e.g., `"custom"`) should be overridden.
+    pub fn chain_id(mut self, chain_id: impl Into<String>) -> Self {
+        self.chain_id = ChainId::new(chain_id);
+        self
+    }
+
     /// Set the retry configuration.
     pub fn retry_config(mut self, config: RetryConfig) -> Self {
         self.retry_config = config;
@@ -1031,7 +1042,7 @@ impl NearBuilder {
                 self.retry_config,
             )),
             signer: self.signer,
-            network: self.network,
+            chain_id: self.chain_id,
             max_nonce_retries: self.max_nonce_retries,
         }
     }
@@ -1144,7 +1155,7 @@ mod tests {
 
     #[test]
     fn test_near_builder_new() {
-        let builder = NearBuilder::new("https://example.com", Network::Custom);
+        let builder = NearBuilder::new("https://example.com", ChainId::new("custom"));
         let near = builder.build();
         assert_eq!(near.rpc_url(), "https://example.com");
     }
@@ -1291,6 +1302,7 @@ mod tests {
         fn clear_env() {
             // SAFETY: This is a test and we control the execution
             unsafe {
+                std::env::remove_var("NEAR_CHAIN_ID");
                 std::env::remove_var("NEAR_NETWORK");
                 std::env::remove_var("NEAR_ACCOUNT_ID");
                 std::env::remove_var("NEAR_PRIVATE_KEY");

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -98,6 +98,7 @@ pub struct Near {
     signer: Option<Arc<dyn Signer>>,
     chain_id: ChainId,
     max_nonce_retries: u32,
+    sandbox: bool,
 }
 
 impl Near {
@@ -249,8 +250,9 @@ impl Near {
         Near {
             rpc: Arc::new(RpcClient::new(network.rpc_url())),
             signer: Some(Arc::new(signer)),
-            chain_id: ChainId::sandbox(),
+            chain_id: ChainId::new("sandbox"),
             max_nonce_retries: 3,
+            sandbox: true,
         }
     }
 
@@ -289,6 +291,15 @@ impl Near {
         &self.chain_id
     }
 
+    /// Returns true if this client was created via [`Near::sandbox()`].
+    ///
+    /// Note: sandbox nodes generate a random `chain_id` (e.g., `test-chain-aB3xQ`)
+    /// on each startup, so `chain_id()` won't return a predictable value for sandbox.
+    /// Use this method instead to check if the client is connected to a sandbox.
+    pub fn is_sandbox(&self) -> bool {
+        self.sandbox
+    }
+
     /// Create a new client that shares this client's transport but uses a different signer.
     ///
     /// This is the recommended way to manage multiple accounts. The RPC connection
@@ -318,6 +329,7 @@ impl Near {
             signer: Some(Arc::new(signer)),
             chain_id: self.chain_id.clone(),
             max_nonce_retries: self.max_nonce_retries,
+            sandbox: self.sandbox,
         }
     }
 
@@ -1052,6 +1064,7 @@ impl NearBuilder {
             signer: self.signer,
             chain_id: self.chain_id,
             max_nonce_retries: self.max_nonce_retries,
+            sandbox: false,
         }
     }
 }

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -439,8 +439,8 @@ pub enum Error {
     DelegateDecode(#[from] DelegateDecodeError),
 
     // ─── Tokens ───
-    #[error("Token {token} is not available on {network}")]
-    TokenNotAvailable { token: String, network: String },
+    #[error("Token {token} is not available on chain {chain_id}")]
+    TokenNotAvailable { token: String, chain_id: String },
 }
 
 #[cfg(test)]

--- a/crates/near-kit/src/tokens/known.rs
+++ b/crates/near-kit/src/tokens/known.rs
@@ -22,7 +22,7 @@
 //! ```
 
 use crate::error::Error;
-use crate::types::{AccountId, Network};
+use crate::types::{AccountId, ChainId};
 
 /// A known fungible token with verified addresses for different networks.
 ///
@@ -45,17 +45,17 @@ impl KnownToken {
     ///
     /// Returns an error if the token is not available on the specified network
     /// (e.g., some tokens don't have testnet deployments).
-    pub fn resolve(&self, network: Network) -> Result<AccountId, Error> {
-        let address = match network {
-            Network::Mainnet => self.mainnet,
-            Network::Testnet => self.testnet.ok_or_else(|| Error::TokenNotAvailable {
+    pub fn resolve(&self, chain_id: &ChainId) -> Result<AccountId, Error> {
+        let address = match chain_id.as_str() {
+            "mainnet" => self.mainnet,
+            "testnet" => self.testnet.ok_or_else(|| Error::TokenNotAvailable {
                 token: self.name.to_string(),
-                network: network.to_string(),
+                network: chain_id.to_string(),
             })?,
-            Network::Sandbox | Network::Custom => {
+            _ => {
                 return Err(Error::TokenNotAvailable {
                     token: self.name.to_string(),
-                    network: network.to_string(),
+                    network: chain_id.to_string(),
                 });
             }
         };
@@ -68,37 +68,37 @@ impl KnownToken {
 /// This enables the `ft()` and `nft()` methods to accept both raw addresses
 /// and [`KnownToken`] constants, resolving them based on the client's network.
 pub trait IntoContractId {
-    /// Resolve this to a contract [`AccountId`] for the given network.
-    fn into_contract_id(self, network: Network) -> Result<AccountId, Error>;
+    /// Resolve this to a contract [`AccountId`] for the given chain.
+    fn into_contract_id(self, chain_id: &ChainId) -> Result<AccountId, Error>;
 }
 
 impl IntoContractId for &str {
-    fn into_contract_id(self, _network: Network) -> Result<AccountId, Error> {
+    fn into_contract_id(self, _chain_id: &ChainId) -> Result<AccountId, Error> {
         self.parse().map_err(Into::into)
     }
 }
 
 impl IntoContractId for String {
-    fn into_contract_id(self, _network: Network) -> Result<AccountId, Error> {
+    fn into_contract_id(self, _chain_id: &ChainId) -> Result<AccountId, Error> {
         self.parse().map_err(Into::into)
     }
 }
 
 impl IntoContractId for AccountId {
-    fn into_contract_id(self, _network: Network) -> Result<AccountId, Error> {
+    fn into_contract_id(self, _chain_id: &ChainId) -> Result<AccountId, Error> {
         Ok(self)
     }
 }
 
 impl IntoContractId for &AccountId {
-    fn into_contract_id(self, _network: Network) -> Result<AccountId, Error> {
+    fn into_contract_id(self, _chain_id: &ChainId) -> Result<AccountId, Error> {
         Ok(self.clone())
     }
 }
 
 impl IntoContractId for KnownToken {
-    fn into_contract_id(self, network: Network) -> Result<AccountId, Error> {
-        self.resolve(network)
+    fn into_contract_id(self, chain_id: &ChainId) -> Result<AccountId, Error> {
+        self.resolve(chain_id)
     }
 }
 
@@ -146,7 +146,7 @@ mod tests {
 
     #[test]
     fn test_usdc_mainnet() {
-        let account = USDC.resolve(Network::Mainnet).unwrap();
+        let account = USDC.resolve(&ChainId::mainnet()).unwrap();
         assert_eq!(
             account.as_str(),
             "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1"
@@ -155,7 +155,7 @@ mod tests {
 
     #[test]
     fn test_usdc_testnet() {
-        let account = USDC.resolve(Network::Testnet).unwrap();
+        let account = USDC.resolve(&ChainId::testnet()).unwrap();
         assert_eq!(
             account.as_str(),
             "3e2210e1184b45b64c8a434c0a7e7b23cc04ea7eb7a6c3c32520d03d4afcb8af"
@@ -164,37 +164,37 @@ mod tests {
 
     #[test]
     fn test_usdt_mainnet() {
-        let account = USDT.resolve(Network::Mainnet).unwrap();
+        let account = USDT.resolve(&ChainId::mainnet()).unwrap();
         assert_eq!(account.as_str(), "usdt.tether-token.near");
     }
 
     #[test]
     fn test_usdt_testnet_not_available() {
-        let result = USDT.resolve(Network::Testnet);
+        let result = USDT.resolve(&ChainId::testnet());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_wnear_mainnet() {
-        let account = W_NEAR.resolve(Network::Mainnet).unwrap();
+        let account = W_NEAR.resolve(&ChainId::mainnet()).unwrap();
         assert_eq!(account.as_str(), "wrap.near");
     }
 
     #[test]
     fn test_wnear_testnet() {
-        let account = W_NEAR.resolve(Network::Testnet).unwrap();
+        let account = W_NEAR.resolve(&ChainId::testnet()).unwrap();
         assert_eq!(account.as_str(), "wrap.testnet");
     }
 
     #[test]
     fn test_sandbox_not_available() {
-        let result = USDC.resolve(Network::Sandbox);
+        let result = USDC.resolve(&ChainId::sandbox());
         assert!(result.is_err());
     }
 
     #[test]
     fn test_custom_not_available() {
-        let result = USDC.resolve(Network::Custom);
+        let result = USDC.resolve(&ChainId::new("custom"));
         assert!(result.is_err());
     }
 }

--- a/crates/near-kit/src/tokens/known.rs
+++ b/crates/near-kit/src/tokens/known.rs
@@ -188,7 +188,7 @@ mod tests {
 
     #[test]
     fn test_sandbox_not_available() {
-        let result = USDC.resolve(&ChainId::sandbox());
+        let result = USDC.resolve(&ChainId::new("test-chain-abc12"));
         assert!(result.is_err());
     }
 

--- a/crates/near-kit/src/tokens/known.rs
+++ b/crates/near-kit/src/tokens/known.rs
@@ -24,7 +24,7 @@
 use crate::error::Error;
 use crate::types::{AccountId, ChainId};
 
-/// A known fungible token with verified addresses for different networks.
+/// A known fungible token with verified addresses for different chains.
 ///
 /// Use the predefined constants like [`USDC`], [`USDT`], and [`W_NEAR`]
 /// for common tokens.
@@ -50,12 +50,12 @@ impl KnownToken {
             "mainnet" => self.mainnet,
             "testnet" => self.testnet.ok_or_else(|| Error::TokenNotAvailable {
                 token: self.name.to_string(),
-                network: chain_id.to_string(),
+                chain_id: chain_id.to_string(),
             })?,
             _ => {
                 return Err(Error::TokenNotAvailable {
                     token: self.name.to_string(),
-                    network: chain_id.to_string(),
+                    chain_id: chain_id.to_string(),
                 });
             }
         };

--- a/crates/near-kit/src/tokens/known.rs
+++ b/crates/near-kit/src/tokens/known.rs
@@ -39,11 +39,11 @@ pub struct KnownToken {
 }
 
 impl KnownToken {
-    /// Resolve this token to an [`AccountId`] for the given network.
+    /// Resolve this token to an [`AccountId`] for the given chain.
     ///
     /// # Errors
     ///
-    /// Returns an error if the token is not available on the specified network
+    /// Returns an error if the token is not available on the specified chain
     /// (e.g., some tokens don't have testnet deployments).
     pub fn resolve(&self, chain_id: &ChainId) -> Result<AccountId, Error> {
         let address = match chain_id.as_str() {
@@ -66,7 +66,7 @@ impl KnownToken {
 /// Trait for types that can be resolved to a contract [`AccountId`].
 ///
 /// This enables the `ft()` and `nft()` methods to accept both raw addresses
-/// and [`KnownToken`] constants, resolving them based on the client's network.
+/// and [`KnownToken`] constants, resolving them based on the client's chain ID.
 pub trait IntoContractId {
     /// Resolve this to a contract [`AccountId`] for the given chain.
     fn into_contract_id(self, chain_id: &ChainId) -> Result<AccountId, Error>;

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -79,7 +79,7 @@ pub use key::{
     DEFAULT_HD_PATH, DEFAULT_WORD_COUNT, KeyPair, KeyType, PublicKey, SecretKey, Signature,
     generate_seed_phrase,
 };
-pub use network::Network;
+pub use network::ChainId;
 pub use rpc::{
     AccessKeyDetails, AccessKeyInfoView, AccessKeyListView, AccessKeyPermissionView, AccessKeyView,
     AccountBalance, AccountView, ActionReceiptData, ActionView, BandwidthRequest,

--- a/crates/near-kit/src/types/network.rs
+++ b/crates/near-kit/src/types/network.rs
@@ -41,11 +41,6 @@ impl ChainId {
         Self("testnet".to_string())
     }
 
-    /// Local sandbox network.
-    pub fn sandbox() -> Self {
-        Self("sandbox".to_string())
-    }
-
     /// Returns true if this is mainnet.
     pub fn is_mainnet(&self) -> bool {
         self.0 == "mainnet"
@@ -54,11 +49,6 @@ impl ChainId {
     /// Returns true if this is testnet.
     pub fn is_testnet(&self) -> bool {
         self.0 == "testnet"
-    }
-
-    /// Returns true if this is a sandbox network.
-    pub fn is_sandbox(&self) -> bool {
-        self.0 == "sandbox"
     }
 
     /// Returns the chain identifier as a string slice.
@@ -93,7 +83,6 @@ mod tests {
     fn test_chain_id_display() {
         assert_eq!(ChainId::mainnet().to_string(), "mainnet");
         assert_eq!(ChainId::testnet().to_string(), "testnet");
-        assert_eq!(ChainId::sandbox().to_string(), "sandbox");
         assert_eq!(ChainId::new("custom").to_string(), "custom");
     }
 
@@ -104,8 +93,6 @@ mod tests {
 
         assert!(ChainId::testnet().is_testnet());
         assert!(!ChainId::testnet().is_mainnet());
-
-        assert!(ChainId::sandbox().is_sandbox());
     }
 
     #[test]
@@ -132,6 +119,5 @@ mod tests {
         assert_eq!(chain_id.as_str(), "my-custom-network");
         assert!(!chain_id.is_mainnet());
         assert!(!chain_id.is_testnet());
-        assert!(!chain_id.is_sandbox());
     }
 }

--- a/crates/near-kit/src/types/network.rs
+++ b/crates/near-kit/src/types/network.rs
@@ -1,54 +1,87 @@
-//! Network identification for NEAR Protocol.
+//! Chain identification for NEAR Protocol.
 
 use std::fmt;
 
-/// The NEAR network the client is connected to.
+/// Identifies the NEAR chain the client is connected to.
 ///
-/// This is used to resolve network-specific addresses for known tokens
-/// and other network-aware operations.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Default)]
-pub enum Network {
-    /// NEAR mainnet (production network).
-    #[default]
-    Mainnet,
-    /// NEAR testnet (testing network).
-    Testnet,
-    /// Local sandbox network for development.
-    Sandbox,
-    /// Custom network with unknown token mappings.
-    Custom,
-}
+/// This is a string-based newtype that replaces the former `Network` enum,
+/// allowing any chain identifier (not just the hardcoded variants).
+///
+/// Use the named constructors for well-known chains, or [`ChainId::new`]
+/// for custom ones.
+///
+/// # Examples
+///
+/// ```
+/// use near_kit::ChainId;
+///
+/// let mainnet = ChainId::mainnet();
+/// assert!(mainnet.is_mainnet());
+/// assert_eq!(mainnet.as_str(), "mainnet");
+///
+/// let custom = ChainId::new("localnet");
+/// assert_eq!(custom.as_str(), "localnet");
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct ChainId(String);
 
-impl Network {
+impl ChainId {
+    /// Create a chain ID from any string.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self(id.into())
+    }
+
+    /// NEAR mainnet.
+    pub fn mainnet() -> Self {
+        Self("mainnet".to_string())
+    }
+
+    /// NEAR testnet.
+    pub fn testnet() -> Self {
+        Self("testnet".to_string())
+    }
+
+    /// Local sandbox network.
+    pub fn sandbox() -> Self {
+        Self("sandbox".to_string())
+    }
+
     /// Returns true if this is mainnet.
     pub fn is_mainnet(&self) -> bool {
-        matches!(self, Network::Mainnet)
+        self.0 == "mainnet"
     }
 
     /// Returns true if this is testnet.
     pub fn is_testnet(&self) -> bool {
-        matches!(self, Network::Testnet)
+        self.0 == "testnet"
     }
 
     /// Returns true if this is a sandbox network.
     pub fn is_sandbox(&self) -> bool {
-        matches!(self, Network::Sandbox)
+        self.0 == "sandbox"
     }
 
-    /// Returns the network identifier string.
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            Network::Mainnet => "mainnet",
-            Network::Testnet => "testnet",
-            Network::Sandbox => "sandbox",
-            Network::Custom => "custom",
-        }
+    /// Returns the chain identifier as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
-impl fmt::Display for Network {
+impl Default for ChainId {
+    fn default() -> Self {
+        Self::mainnet()
+    }
+}
+
+impl AsRef<str> for ChainId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ChainId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
+        f.write_str(&self.0)
     }
 }
 
@@ -57,26 +90,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_network_display() {
-        assert_eq!(Network::Mainnet.to_string(), "mainnet");
-        assert_eq!(Network::Testnet.to_string(), "testnet");
-        assert_eq!(Network::Sandbox.to_string(), "sandbox");
-        assert_eq!(Network::Custom.to_string(), "custom");
+    fn test_chain_id_display() {
+        assert_eq!(ChainId::mainnet().to_string(), "mainnet");
+        assert_eq!(ChainId::testnet().to_string(), "testnet");
+        assert_eq!(ChainId::sandbox().to_string(), "sandbox");
+        assert_eq!(ChainId::new("custom").to_string(), "custom");
     }
 
     #[test]
-    fn test_network_predicates() {
-        assert!(Network::Mainnet.is_mainnet());
-        assert!(!Network::Mainnet.is_testnet());
+    fn test_chain_id_predicates() {
+        assert!(ChainId::mainnet().is_mainnet());
+        assert!(!ChainId::mainnet().is_testnet());
 
-        assert!(Network::Testnet.is_testnet());
-        assert!(!Network::Testnet.is_mainnet());
+        assert!(ChainId::testnet().is_testnet());
+        assert!(!ChainId::testnet().is_mainnet());
 
-        assert!(Network::Sandbox.is_sandbox());
+        assert!(ChainId::sandbox().is_sandbox());
     }
 
     #[test]
     fn test_default_is_mainnet() {
-        assert_eq!(Network::default(), Network::Mainnet);
+        assert_eq!(ChainId::default(), ChainId::mainnet());
+    }
+
+    #[test]
+    fn test_as_str() {
+        assert_eq!(ChainId::mainnet().as_str(), "mainnet");
+        assert_eq!(ChainId::new("localnet").as_str(), "localnet");
+    }
+
+    #[test]
+    fn test_as_ref_str() {
+        let chain_id = ChainId::mainnet();
+        let s: &str = chain_id.as_ref();
+        assert_eq!(s, "mainnet");
+    }
+
+    #[test]
+    fn test_custom_chain_id() {
+        let chain_id = ChainId::new("my-custom-network");
+        assert_eq!(chain_id.as_str(), "my-custom-network");
+        assert!(!chain_id.is_mainnet());
+        assert!(!chain_id.is_testnet());
+        assert!(!chain_id.is_sandbox());
     }
 }


### PR DESCRIPTION
## Summary

Replaces the closed `Network` enum (`Mainnet | Testnet | Sandbox | Custom`) with a `ChainId(String)` newtype, so custom/private chains carry their actual identity instead of being flattened to `Network::Custom`.

- `ChainId::new()` for arbitrary chain IDs, named constructors for `mainnet()`/`testnet()`
- `near.chain_id()` replaces `near.network()`, returns `&ChainId`
- `NearBuilder::chain_id()` lets custom networks set their chain ID
- `from_env()` checks `NEAR_CHAIN_ID` to override chain ID, `NEAR_NETWORK` for RPC selection
- `Near::is_sandbox()` as a bool flag (sandbox nodes use random chain IDs, so `ChainId` can't detect them)
- `Error::TokenNotAvailable` field renamed from `network` to `chain_id`

## Motivation

The intents wallet contract embeds `chain_id` in signed messages for replay protection. Relayers need to compare this against the chain they're connected to, but `Network::Custom` carries no identity. With NEP-638 making `chain_id` a first-class protocol concept, near-kit should align. The RPC `status` endpoint already returns `chain_id` — this is purely a client-side API improvement with no nearcore dependency.

## Example

```rust
// Custom network now carries its identity
let near = Near::custom("https://rpc.pinet.near.org")
    .chain_id("pinet")
    .build();

assert_eq!(near.chain_id().as_str(), "pinet");
```

Closes #98