### PR TITLE
refactor: remove sandbox bool from Near struct

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -98,7 +98,6 @@ pub struct Near {
     signer: Option<Arc<dyn Signer>>,
     chain_id: ChainId,
     max_nonce_retries: u32,
-    sandbox: bool,
 }
 
 impl Near {
@@ -253,7 +252,6 @@ impl Near {
             signer: Some(Arc::new(signer)),
             chain_id: ChainId::new("sandbox"),
             max_nonce_retries: 3,
-            sandbox: true,
         }
     }
 
@@ -292,16 +290,6 @@ impl Near {
         &self.chain_id
     }
 
-    /// Returns true if this client was created via [`Near::sandbox()`].
-    ///
-    /// Note: sandbox nodes generate a random `chain_id` (e.g., `test-chain-aB3xQ`)
-    /// on each startup, so [`Near::chain_id()`] returns a placeholder for sandbox
-    /// clients that does not reflect the node-reported chain ID. Use this method
-    /// instead to check if the client is connected to a sandbox.
-    pub fn is_sandbox(&self) -> bool {
-        self.sandbox
-    }
-
     /// Create a new client that shares this client's transport but uses a different signer.
     ///
     /// This is the recommended way to manage multiple accounts. The RPC connection
@@ -331,7 +319,6 @@ impl Near {
             signer: Some(Arc::new(signer)),
             chain_id: self.chain_id.clone(),
             max_nonce_retries: self.max_nonce_retries,
-            sandbox: self.sandbox,
         }
     }
 
@@ -1066,7 +1053,6 @@ impl NearBuilder {
             signer: self.signer,
             chain_id: self.chain_id,
             max_nonce_retries: self.max_nonce_retries,
-            sandbox: false,
         }
     }
 }


### PR DESCRIPTION
## Summary

Removes the `sandbox: bool` field from `Near` and the `Near::is_sandbox()` method added in #101.

The field was unnecessary — the caller who creates `Near::sandbox()` already knows it's a sandbox, and nothing internal depends on the flag. No need to carry extra state.

1 file changed, 14 deletions.