### PR TITLE
Unify SharedSandbox and OwnedSandbox into a single Arc-based Sandbox type

### DIFF
--- a/crates/near-kit/examples/rotating_signer.rs
+++ b/crates/near-kit/examples/rotating_signer.rs
@@ -10,12 +10,12 @@
 use near_kit::*;
 
 #[cfg(feature = "sandbox")]
-use near_kit::sandbox::{OwnedSandbox, SandboxConfig};
+use near_kit::sandbox::{Sandbox, SandboxConfig};
 
 #[cfg(feature = "sandbox")]
 async fn high_throughput_example() -> Result<(), Error> {
     println!("Starting local sandbox...\n");
-    let sandbox: OwnedSandbox = SandboxConfig::fresh().await;
+    let sandbox: Sandbox = SandboxConfig::fresh().await;
 
     let root_near = sandbox.client();
     let root_account = root_near.account_id().unwrap().to_string();

--- a/crates/near-kit/examples/sequential_sends.rs
+++ b/crates/near-kit/examples/sequential_sends.rs
@@ -14,12 +14,12 @@
 use near_kit::*;
 
 #[cfg(feature = "sandbox")]
-use near_kit::sandbox::{OwnedSandbox, SandboxConfig};
+use near_kit::sandbox::{Sandbox, SandboxConfig};
 
 #[cfg(feature = "sandbox")]
 async fn sequential_example() -> Result<(), Error> {
     println!("Starting local sandbox...\n");
-    let sandbox: OwnedSandbox = SandboxConfig::fresh().await;
+    let sandbox: Sandbox = SandboxConfig::fresh().await;
 
     let root_near = sandbox.client();
     let root_account = root_near.account_id().unwrap().to_string();

--- a/crates/near-kit/src/sandbox.rs
+++ b/crates/near-kit/src/sandbox.rs
@@ -25,7 +25,7 @@
 //! async fn test_transfer() {
 //!     // Same pattern as production - just different network
 //!     let near = Near::sandbox(SandboxConfig::shared().await);
-//!     
+//!
 //!     // Create accounts the normal way
 //!     let alice_key = SecretKey::generate_ed25519();
 //!     near.transaction("alice.sandbox")
@@ -39,7 +39,7 @@
 //!
 //! #[tokio::test]
 //! async fn test_isolated() {
-//!     // Fresh sandbox - completely isolated, stopped on drop
+//!     // Fresh sandbox - completely isolated, stopped when last clone drops
 //!     let sandbox = SandboxConfig::fresh().await;
 //!     let near = Near::sandbox(&sandbox);
 //! }
@@ -53,8 +53,20 @@
 //!         .await;
 //!     let near = Near::sandbox(&sandbox);
 //! }
+//!
+//! #[tokio::test]
+//! async fn test_custom_root() {
+//!     // Custom root account name
+//!     let sandbox = SandboxConfig::builder()
+//!         .root_account("sb")
+//!         .fresh()
+//!         .await;
+//!     let near = Near::sandbox(&sandbox);
+//!     // Root account is now "sb" instead of "sandbox"
+//! }
 //! ```
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use tokio::sync::OnceCell;
@@ -94,55 +106,56 @@ pub use crate::client::SandboxNetwork;
 // ============================================================================
 
 /// Global shared sandbox instance.
-static SHARED_SANDBOX: OnceCell<SharedSandbox> = OnceCell::const_new();
+static SHARED_SANDBOX: OnceCell<Sandbox> = OnceCell::const_new();
 
 // ============================================================================
-// SharedSandbox
+// Sandbox
 // ============================================================================
 
-/// A shared sandbox instance that persists across tests.
+/// A sandbox instance backed by `Arc<near_sandbox::Sandbox>`.
 ///
-/// This wrapper holds a reference to a `near_sandbox::Sandbox` and implements
-/// [`SandboxNetwork`]. It is obtained via [`SandboxConfig::shared()`].
+/// Cloning a `Sandbox` shares the underlying process — the sandbox is stopped
+/// only when the last `Arc` reference is dropped.
 ///
-/// The shared sandbox persists for the entire test run. All tests in a binary
-/// share the same sandbox instance when using `cargo test`.
+/// Obtain one via [`SandboxConfig::shared()`] (global singleton) or
+/// [`SandboxConfig::fresh()`] (new isolated instance).
 ///
 /// # Note on Cleanup
 ///
-/// The sandbox process may outlive the test process since Rust doesn't run
-/// static destructors. This is a known limitation that should be fixed in
-/// `near-sandbox-rs`. For now, you may see orphaned `near-sandbox` processes
-/// after test runs.
-pub struct SharedSandbox {
-    inner: near_sandbox::Sandbox,
+/// The sandbox process is killed when the last reference drops.
+/// For the shared singleton returned by [`SandboxConfig::shared()`],
+/// the process may outlive the test process since Rust doesn't run
+/// static destructors.
+#[derive(Clone)]
+pub struct Sandbox {
+    inner: Arc<near_sandbox::Sandbox>,
+    root_account: String,
 }
 
-impl SharedSandbox {
-    async fn init() -> Self {
-        Self::init_with_version(near_sandbox::DEFAULT_NEAR_SANDBOX_VERSION).await
-    }
-
-    async fn init_with_version(version: &str) -> Self {
+impl Sandbox {
+    async fn start(version: &str, root_account: String) -> Self {
         let instance_num = SANDBOX_INSTANCE_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
         info!(
             instance = instance_num,
             version = version,
-            mode = "shared",
+            root_account = %root_account,
             "Starting sandbox"
         );
 
         let inner = near_sandbox::Sandbox::start_sandbox_with_version(version)
             .await
-            .expect("Failed to start shared sandbox");
+            .expect("Failed to start sandbox");
 
         info!(
             instance = instance_num,
             rpc_url = %inner.rpc_addr,
-            "Shared sandbox ready"
+            "Sandbox ready"
         );
 
-        Self { inner }
+        Self {
+            inner: Arc::new(inner),
+            root_account,
+        }
     }
 
     /// Get a configured `Near` client for this sandbox.
@@ -215,13 +228,13 @@ impl SharedSandbox {
     }
 }
 
-impl SandboxNetwork for SharedSandbox {
+impl SandboxNetwork for Sandbox {
     fn rpc_url(&self) -> &str {
         &self.inner.rpc_addr
     }
 
     fn root_account_id(&self) -> &str {
-        ROOT_ACCOUNT
+        &self.root_account
     }
 
     fn root_secret_key(&self) -> &str {
@@ -229,145 +242,24 @@ impl SandboxNetwork for SharedSandbox {
     }
 }
 
-// ============================================================================
-// OwnedSandbox
-// ============================================================================
-
-/// An owned sandbox instance that stops when dropped.
-///
-/// This wrapper holds a `near_sandbox::Sandbox` and implements [`SandboxNetwork`].
-/// When dropped, it will stop the sandbox process and clean up resources.
-///
-/// Use [`SandboxConfig::fresh()`] to create a fresh sandbox for tests that need
-/// completely isolated state.
-pub struct OwnedSandbox {
-    inner: Option<near_sandbox::Sandbox>,
-}
-
-impl OwnedSandbox {
-    async fn spawn() -> Self {
-        Self::spawn_with_version(near_sandbox::DEFAULT_NEAR_SANDBOX_VERSION).await
-    }
-
-    async fn spawn_with_version(version: &str) -> Self {
-        let instance_num = SANDBOX_INSTANCE_COUNT.fetch_add(1, Ordering::Relaxed) + 1;
-        info!(
-            instance = instance_num,
-            version = version,
-            mode = "fresh",
-            "Starting sandbox"
-        );
-
-        let inner = near_sandbox::Sandbox::start_sandbox_with_version(version)
-            .await
-            .expect("Failed to start sandbox");
-
-        info!(
-            instance = instance_num,
-            rpc_url = %inner.rpc_addr,
-            "Fresh sandbox ready"
-        );
-
-        Self { inner: Some(inner) }
-    }
-
-    /// Get a configured `Near` client for this sandbox.
-    ///
-    /// This is a convenience method equivalent to `Near::sandbox(self)`.
-    pub fn client(&self) -> Near {
-        Near::sandbox(self)
-    }
-
-    /// Set an account's balance in this sandbox.
-    ///
-    /// This patches the account's balance directly via the sandbox RPC,
-    /// useful for testing scenarios that require specific balances
-    /// (e.g., staking tests that need 1M+ NEAR).
-    ///
-    /// # Example
-    ///
-    /// ```rust,ignore
-    /// use near_kit::*;
-    /// use near_kit::sandbox::SandboxConfig;
-    ///
-    /// let sandbox = SandboxConfig::fresh().await;
-    ///
-    /// // Set account balance to 1M NEAR for staking test
-    /// sandbox.set_balance("validator.sandbox", NearToken::from_near(1_000_000)).await?;
-    /// ```
-    pub async fn set_balance(
-        &self,
-        account_id: impl Into<crate::AccountId>,
-        balance: crate::NearToken,
-    ) -> Result<(), crate::Error> {
-        let near = self.client();
-        let account_id: crate::AccountId = account_id.into();
-
-        // Fetch raw account data from RPC - this includes all fields the sandbox expects
-        let mut account_response: serde_json::Value = near
-            .rpc()
-            .call(
-                "query",
-                serde_json::json!({
-                    "finality": "optimistic",
-                    "request_type": "view_account",
-                    "account_id": account_id.to_string()
-                }),
-            )
-            .await
-            .map_err(crate::Error::Rpc)?;
-
-        // Modify the amount field in the response
-        if let Some(obj) = account_response.as_object_mut() {
-            obj.insert(
-                "amount".to_string(),
-                serde_json::Value::String(balance.as_yoctonear().to_string()),
-            );
-        }
-
-        let records = serde_json::json!([
-            {
-                "Account": {
-                    "account_id": account_id.to_string(),
-                    "account": account_response
-                }
-            }
-        ]);
-
-        near.rpc()
-            .sandbox_patch_state(records)
-            .await
-            .map_err(crate::Error::Rpc)
-    }
-}
-
-impl SandboxNetwork for OwnedSandbox {
-    fn rpc_url(&self) -> &str {
-        &self
-            .inner
-            .as_ref()
-            .expect("sandbox already stopped")
-            .rpc_addr
-    }
-
-    fn root_account_id(&self) -> &str {
-        ROOT_ACCOUNT
-    }
-
-    fn root_secret_key(&self) -> &str {
-        ROOT_SECRET_KEY
-    }
-}
-
-impl Drop for OwnedSandbox {
+impl Drop for Sandbox {
     fn drop(&mut self) {
-        if let Some(sandbox) = self.inner.take() {
-            debug!(rpc_url = %sandbox.rpc_addr, "Stopping fresh sandbox");
-            // The near_sandbox::Sandbox will kill the child process when dropped
-            drop(sandbox);
+        // Arc handles the actual cleanup — log when we're the last reference
+        if Arc::strong_count(&self.inner) == 1 {
+            debug!(rpc_url = %self.inner.rpc_addr, "Stopping sandbox (last reference dropped)");
         }
     }
 }
+
+// ============================================================================
+// Backward-compatible type aliases
+// ============================================================================
+
+/// Deprecated: use [`Sandbox`] instead.
+pub type SharedSandbox = Sandbox;
+
+/// Deprecated: use [`Sandbox`] instead.
+pub type OwnedSandbox = Sandbox;
 
 // ============================================================================
 // SandboxConfig
@@ -377,9 +269,9 @@ impl Drop for OwnedSandbox {
 ///
 /// Provides two main ways to get a sandbox:
 /// - [`SandboxConfig::shared()`] - Returns a reference to a global singleton sandbox
-/// - [`SandboxConfig::fresh()`] - Spawns a new sandbox that is stopped on drop
+/// - [`SandboxConfig::fresh()`] - Spawns a new sandbox that is stopped when the last clone drops
 ///
-/// For custom configuration (e.g., specific version), use [`SandboxConfig::builder()`].
+/// For custom configuration (e.g., specific version or root account), use [`SandboxConfig::builder()`].
 ///
 /// # Example
 ///
@@ -428,14 +320,22 @@ impl SandboxConfig {
     /// // or
     /// let near = SandboxConfig::shared().await.client();
     /// ```
-    pub async fn shared() -> &'static SharedSandbox {
-        SHARED_SANDBOX.get_or_init(SharedSandbox::init).await
+    pub async fn shared() -> &'static Sandbox {
+        SHARED_SANDBOX
+            .get_or_init(|| {
+                Sandbox::start(
+                    near_sandbox::DEFAULT_NEAR_SANDBOX_VERSION,
+                    ROOT_ACCOUNT.to_string(),
+                )
+            })
+            .await
     }
 
     /// Spawn a fresh sandbox instance.
     ///
-    /// Creates a new sandbox with clean state. The sandbox will be
-    /// stopped and cleaned up when the returned [`OwnedSandbox`] is dropped.
+    /// Creates a new sandbox with clean state. The sandbox process will be
+    /// stopped and cleaned up when the last clone of the returned [`Sandbox`]
+    /// is dropped.
     ///
     /// Use this for tests that need guaranteed isolation from other tests.
     ///
@@ -446,22 +346,27 @@ impl SandboxConfig {
     /// let near = Near::sandbox(&sandbox);
     /// // or
     /// let near = sandbox.client();
-    /// // sandbox is stopped when it goes out of scope
+    /// // sandbox is stopped when last reference goes out of scope
     /// ```
-    pub async fn fresh() -> OwnedSandbox {
-        OwnedSandbox::spawn().await
+    pub async fn fresh() -> Sandbox {
+        Sandbox::start(
+            near_sandbox::DEFAULT_NEAR_SANDBOX_VERSION,
+            ROOT_ACCOUNT.to_string(),
+        )
+        .await
     }
 
     /// Create a builder for custom sandbox configuration.
     ///
     /// Use this when you need to specify a particular sandbox version
-    /// or other advanced options.
+    /// or custom root account name.
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// let sandbox = SandboxConfig::builder()
     ///     .version("2.10.5")
+    ///     .root_account("sb")
     ///     .fresh()
     ///     .await;
     /// ```
@@ -479,11 +384,15 @@ impl SandboxConfig {
 /// Created via [`SandboxConfig::builder()`].
 pub struct SandboxBuilder {
     version: Option<String>,
+    root_account: Option<String>,
 }
 
 impl SandboxBuilder {
     fn new() -> Self {
-        Self { version: None }
+        Self {
+            version: None,
+            root_account: None,
+        }
     }
 
     /// Set the sandbox version to use.
@@ -503,31 +412,56 @@ impl SandboxBuilder {
         self
     }
 
+    /// Set the root account name for this sandbox.
+    ///
+    /// If not specified, defaults to `"sandbox"`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let sandbox = SandboxConfig::builder()
+    ///     .root_account("sb")
+    ///     .fresh()
+    ///     .await;
+    /// // Sub-accounts will be "alice.sb" instead of "alice.sandbox"
+    /// ```
+    pub fn root_account(mut self, name: impl Into<String>) -> Self {
+        self.root_account = Some(name.into());
+        self
+    }
+
     /// Spawn a fresh sandbox with the configured options.
     ///
-    /// The sandbox will be stopped when the returned [`OwnedSandbox`] is dropped.
-    pub async fn fresh(self) -> OwnedSandbox {
+    /// The sandbox process will be stopped when the last clone of
+    /// the returned [`Sandbox`] is dropped.
+    pub async fn fresh(self) -> Sandbox {
         let version = self
             .version
             .as_deref()
             .unwrap_or(near_sandbox::DEFAULT_NEAR_SANDBOX_VERSION);
-        OwnedSandbox::spawn_with_version(version).await
+        let root_account = self
+            .root_account
+            .unwrap_or_else(|| ROOT_ACCOUNT.to_string());
+        Sandbox::start(version, root_account).await
     }
 
     /// Get or create the shared sandbox with the configured options.
     ///
-    /// **Note:** The version is only used if the shared sandbox hasn't been
-    /// initialized yet. If it's already running, the existing instance is
-    /// returned regardless of the version specified here.
-    pub async fn shared(self) -> &'static SharedSandbox {
-        // If a version is specified and sandbox isn't initialized yet,
-        // initialize with that version
-        if let Some(version) = self.version {
-            SHARED_SANDBOX
-                .get_or_init(|| SharedSandbox::init_with_version(&version))
-                .await
-        } else {
-            SHARED_SANDBOX.get_or_init(SharedSandbox::init).await
-        }
+    /// **Note:** The version and root account are only used if the shared
+    /// sandbox hasn't been initialized yet. If it's already running, the
+    /// existing instance is returned regardless of the options specified here.
+    pub async fn shared(self) -> &'static Sandbox {
+        let version = self.version;
+        let root_account = self.root_account;
+
+        SHARED_SANDBOX
+            .get_or_init(|| {
+                let v = version
+                    .as_deref()
+                    .unwrap_or(near_sandbox::DEFAULT_NEAR_SANDBOX_VERSION);
+                let r = root_account.unwrap_or_else(|| ROOT_ACCOUNT.to_string());
+                Sandbox::start(v, r)
+            })
+            .await
     }
 }

--- a/crates/near-kit/tests/integration/typed_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_error_integration.rs
@@ -20,7 +20,7 @@ fn unique_account() -> AccountId {
 
 /// Create a funded account, returning a Near client, the account ID, and the secret key.
 async fn funded_account(
-    sandbox: &near_kit::sandbox::SharedSandbox,
+    sandbox: &near_kit::sandbox::Sandbox,
     balance: NearToken,
 ) -> (Near, AccountId, SecretKey) {
     let near = sandbox.client();


### PR DESCRIPTION
## Summary

- Merges `SharedSandbox` and `OwnedSandbox` into a single `Sandbox` type that uses `Arc<near_sandbox::Sandbox>` internally. `Clone` shares the underlying process; the sandbox stops when the last `Arc` ref drops.
- Adds `SandboxBuilder::root_account("sb")` for configuring the root account name (default remains `"sandbox"`).
- `SandboxConfig::shared()` returns `&'static Sandbox`, `SandboxConfig::fresh()` returns `Sandbox`.
- Backward-compatible type aliases (`SharedSandbox`, `OwnedSandbox`) are provided so existing code continues to compile.
- Updates examples and integration tests to use the new `Sandbox` type directly.

Closes #108

## Test plan

- [x] `cargo check -p near-kit --features sandbox` passes
- [ ] Run integration tests with `cargo test --features sandbox` to verify sandbox lifecycle
- [ ] Verify `SandboxConfig::shared()` still returns a singleton across tests
- [ ] Verify `SandboxConfig::fresh()` returns independent instances
- [ ] Verify `SandboxConfig::builder().root_account("sb").fresh()` configures root correctly