### PR TITLE
feat: derive Ord and PartialOrd for TxExecutionStatus

### DIFF
--- a/crates/near-kit/src/types/block_reference.rs
+++ b/crates/near-kit/src/types/block_reference.rs
@@ -138,7 +138,7 @@ impl Finality {
 }
 
 /// Transaction execution status for send_tx wait_until parameter.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum TxExecutionStatus {
     /// Don't wait, return immediately after RPC accepts.


### PR DESCRIPTION
## Summary

- Adds `PartialOrd` and `Ord` derives to `TxExecutionStatus`, enabling comparison of finality levels
- Variant ordering follows the natural finality progression: `None < Included < ExecutedOptimistic < IncludedFinal < Executed < Final`
- Enables ergonomic patterns like `if wait_until >= TxExecutionStatus::ExecutedOptimistic { /* inspect receipts */ }`