### PR TITLE
feat: add tracing spans and #[instrument] throughout

### DIFF
--- a/crates/near-kit/src/client/nonce_manager.rs
+++ b/crates/near-kit/src/client/nonce_manager.rs
@@ -61,7 +61,7 @@ impl NonceManager {
         Fut: Future<Output = Result<u64, crate::Error>>,
     {
         let key = format!("{}:{}:{}", network, account_id, public_key);
-        let span = tracing::debug_span!("nonce", account_id = account_id, public_key = public_key);
+        let span = tracing::debug_span!("get_nonce", account_id, public_key);
         let _enter = span.enter();
 
         // Fast path: check if we already have a cached nonce
@@ -70,7 +70,7 @@ impl NonceManager {
             if let Some(atomic) = nonces.get(&key) {
                 // Atomically increment and return the previous value
                 let nonce = atomic.fetch_add(1, Ordering::SeqCst);
-                tracing::debug!(nonce = nonce, "Nonce from cache");
+                tracing::debug!(nonce, "Nonce from cache");
                 return Ok(nonce);
             }
         }
@@ -90,7 +90,7 @@ impl NonceManager {
             if let Some(atomic) = nonces.get(&key) {
                 // Someone else already inserted, use theirs
                 let nonce = atomic.fetch_add(1, Ordering::SeqCst);
-                tracing::debug!(nonce = nonce, "Nonce from cache (race)");
+                tracing::debug!(nonce, "Nonce from cache (race)");
                 return Ok(nonce);
             }
             // Insert with value = next_nonce + 1 (what the NEXT caller should get)

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -152,6 +152,7 @@ impl RpcClient {
     }
 
     /// Make a raw RPC call with retries.
+    #[tracing::instrument(skip(self, params), fields(rpc.method = method))]
     pub async fn call<P: Serialize, R: DeserializeOwned>(
         &self,
         method: &str,
@@ -177,7 +178,6 @@ impl RpcClient {
                         self.retry_config.max_delay_ms,
                     );
                     tracing::warn!(
-                        rpc.method = method,
                         attempt = attempt + 1,
                         max_attempts = total_attempts,
                         delay_ms = delay,
@@ -188,7 +188,7 @@ impl RpcClient {
                     continue;
                 }
                 Err(e) => {
-                    tracing::error!(rpc.method = method, error = %e, "RPC request failed");
+                    tracing::error!(error = %e, "RPC request failed");
                     return Err(e);
                 }
             }
@@ -429,12 +429,12 @@ impl RpcClient {
     // ========================================================================
 
     /// View account information.
+    #[tracing::instrument(skip(self, block), fields(%account_id))]
     pub async fn view_account(
         &self,
         account_id: &AccountId,
         block: BlockReference,
     ) -> Result<AccountView, RpcError> {
-        tracing::debug!(account_id = %account_id, "view_account");
         let mut params = serde_json::json!({
             "request_type": "view_account",
             "account_id": account_id.to_string(),
@@ -445,13 +445,13 @@ impl RpcClient {
     }
 
     /// View access key information.
+    #[tracing::instrument(skip(self, block), fields(%account_id, %public_key))]
     pub async fn view_access_key(
         &self,
         account_id: &AccountId,
         public_key: &PublicKey,
         block: BlockReference,
     ) -> Result<AccessKeyView, RpcError> {
-        tracing::debug!(account_id = %account_id, public_key = %public_key, "view_access_key");
         let mut params = serde_json::json!({
             "request_type": "view_access_key",
             "account_id": account_id.to_string(),
@@ -463,12 +463,12 @@ impl RpcClient {
     }
 
     /// View all access keys for an account.
+    #[tracing::instrument(skip(self, block), fields(%account_id))]
     pub async fn view_access_key_list(
         &self,
         account_id: &AccountId,
         block: BlockReference,
     ) -> Result<AccessKeyListView, RpcError> {
-        tracing::debug!(account_id = %account_id, "view_access_key_list");
         let mut params = serde_json::json!({
             "request_type": "view_access_key_list",
             "account_id": account_id.to_string(),
@@ -479,6 +479,7 @@ impl RpcClient {
     }
 
     /// Call a view function on a contract.
+    #[tracing::instrument(skip(self, args, block), fields(contract_id = %account_id, method = method_name))]
     pub async fn view_function(
         &self,
         account_id: &AccountId,
@@ -486,7 +487,6 @@ impl RpcClient {
         args: &[u8],
         block: BlockReference,
     ) -> Result<ViewFunctionResult, RpcError> {
-        tracing::debug!(contract_id = %account_id, method = method_name, "view_function");
         let mut params = serde_json::json!({
             "request_type": "call_function",
             "account_id": account_id.to_string(),
@@ -527,21 +527,21 @@ impl RpcClient {
     }
 
     /// Get block information.
+    #[tracing::instrument(skip(self, block))]
     pub async fn block(&self, block: BlockReference) -> Result<BlockView, RpcError> {
-        tracing::debug!("block");
         let params = block.to_rpc_params();
         self.call("block", params).await
     }
 
     /// Get node status.
+    #[tracing::instrument(skip(self))]
     pub async fn status(&self) -> Result<StatusResponse, RpcError> {
-        tracing::debug!("status");
         self.call("status", serde_json::json!([])).await
     }
 
     /// Get current gas price.
+    #[tracing::instrument(skip(self))]
     pub async fn gas_price(&self, block_hash: Option<&CryptoHash>) -> Result<GasPrice, RpcError> {
-        tracing::debug!("gas_price");
         let params = match block_hash {
             Some(hash) => serde_json::json!([hash.to_string()]),
             None => serde_json::json!([serde_json::Value::Null]),
@@ -550,19 +550,19 @@ impl RpcClient {
     }
 
     /// Send a signed transaction.
+    #[tracing::instrument(skip(self, signed_tx), fields(
+        tx_hash = tracing::field::Empty,
+        sender = %signed_tx.transaction.signer_id,
+        receiver = %signed_tx.transaction.receiver_id,
+        ?wait_until,
+    ))]
     pub async fn send_tx(
         &self,
         signed_tx: &SignedTransaction,
         wait_until: TxExecutionStatus,
     ) -> Result<SendTxResponse, RpcError> {
         let tx_hash = signed_tx.get_hash();
-        tracing::info!(
-            tx_hash = %tx_hash,
-            sender = %signed_tx.transaction.signer_id,
-            receiver = %signed_tx.transaction.receiver_id,
-            wait_until = ?wait_until,
-            "Sending transaction"
-        );
+        tracing::Span::current().record("tx_hash", tracing::field::display(&tx_hash));
         let params = serde_json::json!({
             "signed_tx_base64": signed_tx.to_base64(),
             "wait_until": wait_until.as_str(),
@@ -575,13 +575,13 @@ impl RpcClient {
     /// Get transaction status with full receipt details.
     ///
     /// Uses EXPERIMENTAL_tx_status which returns complete receipt information.
+    #[tracing::instrument(skip(self), fields(%tx_hash, sender = %sender_id, ?wait_until))]
     pub async fn tx_status(
         &self,
         tx_hash: &CryptoHash,
         sender_id: &AccountId,
         wait_until: TxExecutionStatus,
     ) -> Result<SendTxWithReceiptsResponse, RpcError> {
-        tracing::debug!(tx_hash = %tx_hash, sender = %sender_id, "tx_status");
         let params = serde_json::json!({
             "tx_hash": tx_hash.to_string(),
             "sender_account_id": sender_id.to_string(),

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -33,6 +33,8 @@ use std::future::{Future, IntoFuture};
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 
+use tracing::Instrument;
+
 use crate::error::{Error, RpcError};
 use crate::types::{
     AccountId, Action, BlockReference, CryptoHash, DelegateAction, DeterministicAccountStateInit,
@@ -699,68 +701,68 @@ impl TransactionBuilder {
         let signer_id = signer.account_id().clone();
         let action_count = self.actions.len();
 
-        tracing::info!(
+        let span = tracing::info_span!(
+            "sign_transaction",
             sender = %signer_id,
             receiver = %self.receiver_id,
-            action_count = action_count,
-            "Signing transaction"
+            action_count,
         );
 
-        // Get a signing key atomically. For RotatingSigner, this claims the next
-        // key in rotation. The key contains both the public key and signing capability.
-        let key = signer.key();
-        let public_key = key.public_key().clone();
-        let public_key_str = public_key.to_string();
+        async move {
+            // Get a signing key atomically. For RotatingSigner, this claims the next
+            // key in rotation. The key contains both the public key and signing capability.
+            let key = signer.key();
+            let public_key = key.public_key().clone();
+            let public_key_str = public_key.to_string();
 
-        // Get nonce for the key
-        let rpc = self.rpc.clone();
-        let network = rpc.url().to_string();
-        let signer_id_clone = signer_id.clone();
-        let public_key_clone = public_key.clone();
+            // Get nonce for the key
+            let rpc = self.rpc.clone();
+            let network = rpc.url().to_string();
+            let signer_id_clone = signer_id.clone();
+            let public_key_clone = public_key.clone();
 
-        let nonce = nonce_manager()
-            .get_next_nonce(&network, signer_id.as_ref(), &public_key_str, || async {
-                let access_key = rpc
-                    .view_access_key(
-                        &signer_id_clone,
-                        &public_key_clone,
-                        BlockReference::Finality(Finality::Optimistic),
-                    )
-                    .await?;
-                Ok(access_key.nonce)
+            let nonce = nonce_manager()
+                .get_next_nonce(&network, signer_id.as_ref(), &public_key_str, || async {
+                    let access_key = rpc
+                        .view_access_key(
+                            &signer_id_clone,
+                            &public_key_clone,
+                            BlockReference::Finality(Finality::Optimistic),
+                        )
+                        .await?;
+                    Ok(access_key.nonce)
+                })
+                .await?;
+
+            // Get recent block hash
+            let block = self
+                .rpc
+                .block(BlockReference::Finality(Finality::Final))
+                .await?;
+
+            // Build transaction
+            let tx = Transaction::new(
+                signer_id,
+                public_key,
+                nonce,
+                self.receiver_id,
+                block.header.hash,
+                self.actions,
+            );
+
+            // Sign with the key
+            let tx_hash = tx.get_hash();
+            let signature = key.sign(tx_hash.as_bytes()).await?;
+
+            tracing::debug!(tx_hash = %tx_hash, nonce, "Transaction signed");
+
+            Ok(SignedTransaction {
+                transaction: tx,
+                signature,
             })
-            .await?;
-
-        // Get recent block hash
-        let block = self
-            .rpc
-            .block(BlockReference::Finality(Finality::Final))
-            .await?;
-
-        // Build transaction
-        let tx = Transaction::new(
-            signer_id,
-            public_key,
-            nonce,
-            self.receiver_id,
-            block.header.hash,
-            self.actions,
-        );
-
-        // Sign with the key
-        let tx_hash = tx.get_hash();
-        let signature = key.sign(tx_hash.as_bytes()).await?;
-
-        tracing::info!(
-            tx_hash = %tx_hash,
-            nonce = nonce,
-            "Transaction signed"
-        );
-
-        Ok(SignedTransaction {
-            transaction: tx,
-            signature,
-        })
+        }
+        .instrument(span)
+        .await
     }
 
     /// Sign the transaction offline without network access.
@@ -1319,141 +1321,153 @@ impl IntoFuture for TransactionSend {
 
             let signer_id = signer.account_id().clone();
 
-            tracing::info!(
+            let span = tracing::info_span!(
+                "send_transaction",
                 sender = %signer_id,
                 receiver = %builder.receiver_id,
                 action_count = builder.actions.len(),
-                "Sending transaction"
             );
 
-            // Retry loop for transient InvalidTxErrors (nonce conflicts, expired block hash)
-            let max_nonce_retries = builder.max_nonce_retries;
-            let network = builder.rpc.url().to_string();
-            let mut last_error: Option<Error> = None;
-            let mut last_ak_nonce: Option<u64> = None;
+            async move {
+                // Retry loop for transient InvalidTxErrors (nonce conflicts, expired block hash)
+                let max_nonce_retries = builder.max_nonce_retries;
+                let network = builder.rpc.url().to_string();
+                let mut last_error: Option<Error> = None;
+                let mut last_ak_nonce: Option<u64> = None;
 
-            for attempt in 0..=max_nonce_retries {
-                // Get a signing key atomically for this attempt
-                let key = signer.key();
-                let public_key = key.public_key().clone();
-                let public_key_str = public_key.to_string();
+                for attempt in 0..=max_nonce_retries {
+                    // Get a signing key atomically for this attempt
+                    let key = signer.key();
+                    let public_key = key.public_key().clone();
+                    let public_key_str = public_key.to_string();
 
-                // Single view_access_key call provides both nonce and block_hash.
-                // Uses Finality::Final for block hash stability.
-                let access_key = builder
-                    .rpc
-                    .view_access_key(
-                        &signer_id,
-                        &public_key,
-                        BlockReference::Finality(Finality::Final),
-                    )
-                    .await?;
-                let block_hash = access_key.block_hash;
+                    // Single view_access_key call provides both nonce and block_hash.
+                    // Uses Finality::Final for block hash stability.
+                    let access_key = builder
+                        .rpc
+                        .view_access_key(
+                            &signer_id,
+                            &public_key,
+                            BlockReference::Finality(Finality::Final),
+                        )
+                        .await?;
+                    let block_hash = access_key.block_hash;
 
-                // Resolve nonce: use ak_nonce from InvalidNonce error if
-                // available, otherwise use the nonce manager (which caches
-                // locally after the first fetch).
-                let nonce = if let Some(ak_nonce) = last_ak_nonce.take() {
-                    nonce_manager().update_and_get_next(
-                        &network,
-                        signer_id.as_ref(),
-                        &public_key_str,
-                        ak_nonce,
-                    )
-                } else {
-                    nonce_manager()
-                        .get_next_nonce(&network, signer_id.as_ref(), &public_key_str, || async {
-                            Ok(access_key.nonce)
-                        })
-                        .await?
-                };
+                    // Resolve nonce: use ak_nonce from InvalidNonce error if
+                    // available, otherwise use the nonce manager (which caches
+                    // locally after the first fetch).
+                    let nonce = if let Some(ak_nonce) = last_ak_nonce.take() {
+                        nonce_manager().update_and_get_next(
+                            &network,
+                            signer_id.as_ref(),
+                            &public_key_str,
+                            ak_nonce,
+                        )
+                    } else {
+                        nonce_manager()
+                            .get_next_nonce(
+                                &network,
+                                signer_id.as_ref(),
+                                &public_key_str,
+                                || async { Ok(access_key.nonce) },
+                            )
+                            .await?
+                    };
 
-                // Build transaction
-                let tx = Transaction::new(
-                    signer_id.clone(),
-                    public_key.clone(),
-                    nonce,
-                    builder.receiver_id.clone(),
-                    block_hash,
-                    builder.actions.clone(),
-                );
+                    // Build transaction
+                    let tx = Transaction::new(
+                        signer_id.clone(),
+                        public_key.clone(),
+                        nonce,
+                        builder.receiver_id.clone(),
+                        block_hash,
+                        builder.actions.clone(),
+                    );
 
-                // Sign with the key
-                let signature = match key.sign(tx.get_hash().as_bytes()).await {
-                    Ok(sig) => sig,
-                    Err(e) => return Err(Error::Signing(e)),
-                };
-                let signed_tx = crate::types::SignedTransaction {
-                    transaction: tx,
-                    signature,
-                };
+                    // Sign with the key
+                    let signature = match key.sign(tx.get_hash().as_bytes()).await {
+                        Ok(sig) => sig,
+                        Err(e) => return Err(Error::Signing(e)),
+                    };
+                    let signed_tx = crate::types::SignedTransaction {
+                        transaction: tx,
+                        signature,
+                    };
 
-                // Send
-                match builder.rpc.send_tx(&signed_tx, builder.wait_until).await {
-                    Ok(response) => {
-                        let outcome = response.outcome.ok_or_else(|| {
-                            Error::InvalidTransaction(format!(
-                                "Transaction {} submitted with wait_until={:?} but no execution \
-                                 outcome was returned. Use rpc().send_tx() for fire-and-forget \
-                                 submission.",
-                                response.transaction_hash, builder.wait_until,
-                            ))
-                        })?;
+                    // Send
+                    match builder.rpc.send_tx(&signed_tx, builder.wait_until).await {
+                        Ok(response) => {
+                            let outcome = response.outcome.ok_or_else(|| {
+                                Error::InvalidTransaction(format!(
+                                    "Transaction {} submitted with wait_until={:?} but no execution \
+                                     outcome was returned. Use rpc().send_tx() for fire-and-forget \
+                                     submission.",
+                                    response.transaction_hash, builder.wait_until,
+                                ))
+                            })?;
 
-                        // Inspect outcome status — only InvalidTxError becomes Err.
-                        // ActionError means the tx executed (nonce incremented, gas consumed),
-                        // so we return Ok(outcome) and let the caller inspect is_failure().
-                        use crate::types::{FinalExecutionStatus, TxExecutionError};
-                        match outcome.status {
-                            FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(e)) => {
-                                return Err(Error::InvalidTx(Box::new(e)));
+                            // Inspect outcome status — only InvalidTxError becomes Err.
+                            // ActionError means the tx executed (nonce incremented, gas consumed),
+                            // so we return Ok(outcome) and let the caller inspect is_failure().
+                            use crate::types::{FinalExecutionStatus, TxExecutionError};
+                            match outcome.status {
+                                FinalExecutionStatus::Failure(
+                                    TxExecutionError::InvalidTxError(e),
+                                ) => {
+                                    return Err(Error::InvalidTx(Box::new(e)));
+                                }
+                                _ => return Ok(outcome),
                             }
-                            _ => return Ok(outcome),
+                        }
+                        Err(RpcError::InvalidTx(
+                            crate::types::InvalidTxError::InvalidNonce { tx_nonce, ak_nonce },
+                        )) if attempt < max_nonce_retries => {
+                            tracing::warn!(
+                                tx_nonce = tx_nonce,
+                                ak_nonce = ak_nonce,
+                                attempt = attempt + 1,
+                                "Invalid nonce, retrying"
+                            );
+                            // Store ak_nonce for next iteration to avoid refetching
+                            last_ak_nonce = Some(ak_nonce);
+                            last_error = Some(Error::InvalidTx(Box::new(
+                                crate::types::InvalidTxError::InvalidNonce { tx_nonce, ak_nonce },
+                            )));
+                            continue;
+                        }
+                        Err(RpcError::InvalidTx(crate::types::InvalidTxError::Expired))
+                            if attempt + 1 < max_nonce_retries =>
+                        {
+                            tracing::warn!(
+                                attempt = attempt + 1,
+                                "Transaction expired (stale block hash), retrying with fresh block hash"
+                            );
+                            // Expired tx was rejected before nonce consumption.
+                            // Invalidate the nonce cache so the next iteration re-fetches
+                            // via view_access_key, which gives both a fresh nonce and block_hash.
+                            nonce_manager().invalidate(
+                                &network,
+                                signer_id.as_ref(),
+                                &public_key_str,
+                            );
+                            last_error = Some(Error::InvalidTx(Box::new(
+                                crate::types::InvalidTxError::Expired,
+                            )));
+                            continue;
+                        }
+                        Err(e) => {
+                            tracing::error!(error = %e, "Transaction send failed");
+                            return Err(e.into());
                         }
                     }
-                    Err(RpcError::InvalidTx(crate::types::InvalidTxError::InvalidNonce {
-                        tx_nonce,
-                        ak_nonce,
-                    })) if attempt < max_nonce_retries => {
-                        tracing::warn!(
-                            tx_nonce = tx_nonce,
-                            ak_nonce = ak_nonce,
-                            attempt = attempt + 1,
-                            "Invalid nonce, retrying"
-                        );
-                        // Store ak_nonce for next iteration to avoid refetching
-                        last_ak_nonce = Some(ak_nonce);
-                        last_error = Some(Error::InvalidTx(Box::new(
-                            crate::types::InvalidTxError::InvalidNonce { tx_nonce, ak_nonce },
-                        )));
-                        continue;
-                    }
-                    Err(RpcError::InvalidTx(crate::types::InvalidTxError::Expired))
-                        if attempt + 1 < max_nonce_retries =>
-                    {
-                        tracing::warn!(
-                            attempt = attempt + 1,
-                            "Transaction expired (stale block hash), retrying with fresh block hash"
-                        );
-                        // Expired tx was rejected before nonce consumption.
-                        // Invalidate the nonce cache so the next iteration re-fetches
-                        // via view_access_key, which gives both a fresh nonce and block_hash.
-                        nonce_manager().invalidate(&network, signer_id.as_ref(), &public_key_str);
-                        last_error = Some(Error::InvalidTx(Box::new(
-                            crate::types::InvalidTxError::Expired,
-                        )));
-                        continue;
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, "Transaction send failed");
-                        return Err(e.into());
-                    }
                 }
-            }
 
-            Err(last_error.unwrap_or_else(|| {
-                Error::InvalidTransaction("Unknown error during transaction send".to_string())
-            }))
+                Err(last_error.unwrap_or_else(|| {
+                    Error::InvalidTransaction("Unknown error during transaction send".to_string())
+                }))
+            }
+            .instrument(span)
+            .await
         })
     }
 }

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use serde::Serialize;
 use tokio::sync::OnceCell;
+use tracing::Instrument;
 
 use crate::client::{CallBuilder, RpcClient, Signer, TransactionBuilder};
 use crate::error::Error;
@@ -161,37 +162,42 @@ impl FungibleToken {
     /// ```
     pub async fn balance_of(&self, account_id: impl TryIntoAccountId) -> Result<FtAmount, Error> {
         let account_id: AccountId = account_id.try_into_account_id()?;
-        tracing::debug!(contract = %self.contract_id, account = %account_id, "Querying FT balance");
-        let metadata = self.metadata().await?;
+        let span = tracing::debug_span!("ft_balance_of", contract = %self.contract_id, %account_id);
 
-        #[derive(Serialize)]
-        struct Args<'a> {
-            account_id: &'a str,
+        async {
+            let metadata = self.metadata().await?;
+
+            #[derive(Serialize)]
+            struct Args<'a> {
+                account_id: &'a str,
+            }
+
+            let args = serde_json::to_vec(&Args {
+                account_id: account_id.as_str(),
+            })?;
+
+            let result = self
+                .rpc
+                .view_function(
+                    &self.contract_id,
+                    "ft_balance_of",
+                    &args,
+                    BlockReference::Finality(Finality::Optimistic),
+                )
+                .await?;
+
+            let balance_str: String = result.json().map_err(Error::from)?;
+            let raw: u128 = balance_str.parse().map_err(|_| {
+                Error::Rpc(Box::new(crate::error::RpcError::InvalidResponse(format!(
+                    "Invalid balance format: {}",
+                    balance_str
+                ))))
+            })?;
+
+            Ok(FtAmount::from_metadata(raw, metadata))
         }
-
-        let args = serde_json::to_vec(&Args {
-            account_id: account_id.as_str(),
-        })?;
-
-        let result = self
-            .rpc
-            .view_function(
-                &self.contract_id,
-                "ft_balance_of",
-                &args,
-                BlockReference::Finality(Finality::Optimistic),
-            )
-            .await?;
-
-        let balance_str: String = result.json().map_err(Error::from)?;
-        let raw: u128 = balance_str.parse().map_err(|_| {
-            Error::Rpc(Box::new(crate::error::RpcError::InvalidResponse(format!(
-                "Invalid balance format: {}",
-                balance_str
-            ))))
-        })?;
-
-        Ok(FtAmount::from_metadata(raw, metadata))
+        .instrument(span)
+        .await
     }
 
     /// Get total token supply (ft_total_supply).

--- a/crates/near-kit/src/tokens/nft.rs
+++ b/crates/near-kit/src/tokens/nft.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use serde::Serialize;
 use tokio::sync::OnceCell;
+use tracing::Instrument;
 
 use crate::client::{CallBuilder, RpcClient, Signer, TransactionBuilder};
 use crate::error::Error;
@@ -146,27 +147,31 @@ impl NonFungibleToken {
     /// # }
     /// ```
     pub async fn token(&self, token_id: impl AsRef<str>) -> Result<Option<NftToken>, Error> {
-        tracing::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), "Querying NFT token");
-        #[derive(Serialize)]
-        struct Args<'a> {
-            token_id: &'a str,
+        let token_id = token_id.as_ref();
+        let span = tracing::debug_span!("nft_token", contract = %self.contract_id, token_id);
+
+        async {
+            #[derive(Serialize)]
+            struct Args<'a> {
+                token_id: &'a str,
+            }
+
+            let args = serde_json::to_vec(&Args { token_id })?;
+
+            let result = self
+                .rpc
+                .view_function(
+                    &self.contract_id,
+                    "nft_token",
+                    &args,
+                    BlockReference::Finality(Finality::Optimistic),
+                )
+                .await?;
+
+            result.json().map_err(Error::from)
         }
-
-        let args = serde_json::to_vec(&Args {
-            token_id: token_id.as_ref(),
-        })?;
-
-        let result = self
-            .rpc
-            .view_function(
-                &self.contract_id,
-                "nft_token",
-                &args,
-                BlockReference::Finality(Finality::Optimistic),
-            )
-            .await?;
-
-        result.json().map_err(Error::from)
+        .instrument(span)
+        .await
     }
 
     /// Get tokens owned by an account (nft_tokens_for_owner).
@@ -199,34 +204,39 @@ impl NonFungibleToken {
         limit: Option<u64>,
     ) -> Result<Vec<NftToken>, Error> {
         let account_id: AccountId = account_id.try_into_account_id()?;
-        tracing::debug!(contract = %self.contract_id, account = %account_id, "Querying NFT tokens for owner");
+        let span =
+            tracing::debug_span!("nft_tokens_for_owner", contract = %self.contract_id, %account_id);
 
-        #[derive(Serialize)]
-        struct Args<'a> {
-            account_id: &'a str,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            from_index: Option<String>,
-            #[serde(skip_serializing_if = "Option::is_none")]
-            limit: Option<u64>,
+        async {
+            #[derive(Serialize)]
+            struct Args<'a> {
+                account_id: &'a str,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                from_index: Option<String>,
+                #[serde(skip_serializing_if = "Option::is_none")]
+                limit: Option<u64>,
+            }
+
+            let args = serde_json::to_vec(&Args {
+                account_id: account_id.as_str(),
+                from_index: from_index.map(|i| i.to_string()),
+                limit,
+            })?;
+
+            let result = self
+                .rpc
+                .view_function(
+                    &self.contract_id,
+                    "nft_tokens_for_owner",
+                    &args,
+                    BlockReference::Finality(Finality::Optimistic),
+                )
+                .await?;
+
+            result.json().map_err(Error::from)
         }
-
-        let args = serde_json::to_vec(&Args {
-            account_id: account_id.as_str(),
-            from_index: from_index.map(|i| i.to_string()),
-            limit,
-        })?;
-
-        let result = self
-            .rpc
-            .view_function(
-                &self.contract_id,
-                "nft_tokens_for_owner",
-                &args,
-                BlockReference::Finality(Finality::Optimistic),
-            )
-            .await?;
-
-        result.json().map_err(Error::from)
+        .instrument(span)
+        .await
     }
 
     /// Get total supply of tokens (nft_total_supply).
@@ -317,7 +327,7 @@ impl NonFungibleToken {
         let receiver_id: AccountId = receiver_id
             .try_into_account_id()
             .expect("invalid account ID");
-        tracing::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), "nft_transfer");
+        tracing::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), receiver = %receiver_id, "nft_transfer");
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -420,7 +430,7 @@ impl NonFungibleToken {
         let receiver_id: AccountId = receiver_id
             .try_into_account_id()
             .expect("invalid account ID");
-        tracing::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), "nft_transfer_call");
+        tracing::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), receiver = %receiver_id, "nft_transfer_call");
         #[derive(Serialize)]
         struct TransferCallArgs {
             receiver_id: String,

--- a/crates/near-kit/tests/integration/main.rs
+++ b/crates/near-kit/tests/integration/main.rs
@@ -18,6 +18,7 @@ mod sandbox_integration;
 mod signer_edge_cases_integration;
 mod token_error_integration;
 mod token_integration;
+mod tracing_integration;
 mod transaction_failure_integration;
 mod transaction_outcome_integration;
 mod typed_contract_error_integration;

--- a/crates/near-kit/tests/integration/tracing_integration.rs
+++ b/crates/near-kit/tests/integration/tracing_integration.rs
@@ -1,0 +1,282 @@
+//! Integration tests verifying tracing span hierarchy.
+//!
+//! These tests install a capturing tracing subscriber, run real sandbox
+//! operations, then assert that spans are nested correctly — i.e. that
+//! child RPC/nonce spans appear inside the expected parent spans.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use near_kit::sandbox::{SANDBOX_ROOT_ACCOUNT, SandboxConfig};
+use near_kit::*;
+use tracing::span::Id;
+use tracing_subscriber::layer::SubscriberExt;
+
+/// Counter for generating unique subaccount names
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_account() -> AccountId {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("trace{}.{}", n, SANDBOX_ROOT_ACCOUNT)
+        .parse()
+        .unwrap()
+}
+
+// =============================================================================
+// Capturing Layer
+// =============================================================================
+
+/// A recorded span creation event.
+#[derive(Clone, Debug)]
+struct SpanRecord {
+    name: &'static str,
+    parent_id: Option<Id>,
+}
+
+/// Shared state for the capturing layer.
+#[derive(Default, Clone, Debug)]
+struct CapturedSpans {
+    /// span id -> record
+    spans: Arc<Mutex<HashMap<u64, SpanRecord>>>,
+}
+
+impl CapturedSpans {
+    /// Return all recorded span names that are direct children of a span with
+    /// the given `parent_name`.
+    fn children_of(&self, parent_name: &str) -> Vec<&'static str> {
+        let spans = self.spans.lock().unwrap();
+        // Find all span IDs that have this name
+        let parent_ids: Vec<u64> = spans
+            .iter()
+            .filter(|(_, r)| r.name == parent_name)
+            .map(|(id, _)| *id)
+            .collect();
+
+        spans
+            .iter()
+            .filter(|(_, r)| {
+                r.parent_id
+                    .as_ref()
+                    .map(|pid| parent_ids.contains(&pid.into_u64()))
+                    .unwrap_or(false)
+            })
+            .map(|(_, r)| r.name)
+            .collect()
+    }
+
+    /// Check if any span with the given name was recorded.
+    fn has_span(&self, name: &str) -> bool {
+        self.spans.lock().unwrap().values().any(|r| r.name == name)
+    }
+}
+
+/// A tracing Layer that records span creation with parent info.
+struct CapturingLayer {
+    state: CapturedSpans,
+}
+
+impl<S> tracing_subscriber::Layer<S> for CapturingLayer
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn on_new_span(
+        &self,
+        _attrs: &tracing::span::Attributes<'_>,
+        id: &Id,
+        ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let span = ctx.span(id).expect("span not found");
+        let parent_id = span.parent().map(|p| p.id());
+        let name = span.name();
+        self.state
+            .spans
+            .lock()
+            .unwrap()
+            .insert(id.into_u64(), SpanRecord { name, parent_id });
+    }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_send_transaction_span_hierarchy() {
+    let captured = CapturedSpans::default();
+    let layer = CapturingLayer {
+        state: captured.clone(),
+    };
+
+    // Install our capturing subscriber for this test
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+
+    // Create a test account — this exercises send_transaction + RPC spans
+    let account_key = SecretKey::generate_ed25519();
+    let account_id = unique_account();
+
+    root_near
+        .transaction(&account_id)
+        .create_account()
+        .transfer(NearToken::from_near(10))
+        .add_full_access_key(account_key.public_key())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // Verify send_transaction span was created
+    assert!(
+        captured.has_span("send_transaction"),
+        "expected a 'send_transaction' span"
+    );
+
+    // Verify key child spans are nested under send_transaction
+    let children = captured.children_of("send_transaction");
+    assert!(
+        children.contains(&"get_nonce"),
+        "expected 'get_nonce' as child of 'send_transaction', got: {children:?}"
+    );
+    assert!(
+        children.contains(&"send_tx"),
+        "expected 'send_tx' (RPC) as child of 'send_transaction', got: {children:?}"
+    );
+    assert!(
+        children.contains(&"view_access_key"),
+        "expected 'view_access_key' as child of 'send_transaction', got: {children:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_sign_transaction_span_hierarchy() {
+    let captured = CapturedSpans::default();
+    let layer = CapturingLayer {
+        state: captured.clone(),
+    };
+
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+
+    let account_key = SecretKey::generate_ed25519();
+    let account_id = unique_account();
+
+    // Use .sign() to exercise sign_transaction span
+    let _signed = root_near
+        .transaction(&account_id)
+        .create_account()
+        .transfer(NearToken::from_near(5))
+        .add_full_access_key(account_key.public_key())
+        .sign()
+        .await
+        .unwrap();
+
+    assert!(
+        captured.has_span("sign_transaction"),
+        "expected a 'sign_transaction' span"
+    );
+
+    let children = captured.children_of("sign_transaction");
+    assert!(
+        children.contains(&"get_nonce"),
+        "expected 'get_nonce' as child of 'sign_transaction', got: {children:?}"
+    );
+    assert!(
+        children.contains(&"block"),
+        "expected 'block' as child of 'sign_transaction', got: {children:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_ft_balance_of_span_hierarchy() {
+    let captured = CapturedSpans::default();
+    let layer = CapturingLayer {
+        state: captured.clone(),
+    };
+
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    // Deploy an FT contract
+    let ft_key = SecretKey::generate_ed25519();
+    let ft_id = unique_account();
+    let owner_id = unique_account();
+    let owner_key = SecretKey::generate_ed25519();
+
+    // Create owner account
+    root_near
+        .transaction(&owner_id)
+        .create_account()
+        .transfer(NearToken::from_near(50))
+        .add_full_access_key(owner_key.public_key())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // Deploy FT contract
+    let wasm = std::fs::read("tests/contracts/fungible_token.wasm")
+        .expect("fungible_token.wasm not found");
+
+    root_near
+        .transaction(&ft_id)
+        .create_account()
+        .transfer(NearToken::from_near(50))
+        .add_full_access_key(ft_key.public_key())
+        .deploy(wasm)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    let ft_near = Near::custom(rpc_url)
+        .credentials(ft_key.to_string(), &ft_id)
+        .unwrap()
+        .build();
+
+    ft_near
+        .call(&ft_id, "new")
+        .args(serde_json::json!({
+            "owner_id": owner_id.to_string(),
+            "total_supply": "1000000000000000000000000",
+            "metadata": {
+                "spec": "ft-1.0.0",
+                "name": "Test Token",
+                "symbol": "TEST",
+                "decimals": 18
+            }
+        }))
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // Clear spans from setup, we only care about balance_of
+    captured.spans.lock().unwrap().clear();
+
+    let ft = ft_near.ft(&ft_id).unwrap();
+    let _balance = ft.balance_of(&owner_id).await.unwrap();
+
+    // Verify ft_balance_of span was created
+    assert!(
+        captured.has_span("ft_balance_of"),
+        "expected a 'ft_balance_of' span"
+    );
+
+    // The view_function RPC call should be a child of ft_balance_of
+    let children = captured.children_of("ft_balance_of");
+    assert!(
+        children.contains(&"view_function"),
+        "expected 'view_function' as child of 'ft_balance_of', got: {children:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #121

Replace standalone log events with structured tracing spans so operations render as a hierarchical waterfall in Grafana/Jaeger instead of a flat list of logs.

- **RpcClient**: `#[instrument]` on all async methods (`call`, `view_account`, `view_access_key`, `view_function`, `send_tx`, `tx_status`, `block`, `status`, `gas_price`) — standalone `tracing::debug!`/`tracing::info!` replaced by span fields
- **TransactionBuilder**: `info_span` for `sign_transaction` and `send_transaction` lifecycle (wraps the nonce retry loop), using `tracing::Instrument` to correctly propagate across `.await` points
- **NonceManager**: renamed span from `"nonce"` to `"get_nonce"`, cleaned up field syntax
- **FungibleToken**: `debug_span` for `ft_balance_of` (instrumented with `.instrument()`); standalone `debug!` events for `ft_transfer`, `ft_transfer_call` (sync builder methods where a span would close before async execution)
- **NonFungibleToken**: `debug_span` for `nft_token`, `nft_tokens_for_owner` (instrumented with `.instrument()`); standalone `debug!` events for `nft_transfer`, `nft_transfer_call` (sync builder methods)

Child events inside spans automatically inherit parent context (receiver_id, contract_id, etc.) so they no longer need to repeat these fields.

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace --lib` — all 390 tests pass
- [ ] Manual verification with a tracing subscriber to confirm span hierarchy