### PR TITLE
feat!: rework deploy/publish convenience API

### DIFF
--- a/crates/near-kit/examples/README.md
+++ b/crates/near-kit/examples/README.md
@@ -42,6 +42,22 @@ Requires the `sandbox` feature (starts a local NEAR node):
 cargo run --example rotating_signer --features sandbox
 ```
 
+### [`sequential_sends.rs`](./sequential_sends.rs)
+
+Per-key sequential transaction execution using `into_per_key_signers()`, preventing nonce ordering issues.
+
+```bash
+cargo run --example sequential_sends --features sandbox
+```
+
+### [`global_contracts.rs`](./global_contracts.rs)
+
+Publish contracts to the global registry and deploy them to other accounts using `deploy_from`. Demonstrates both `PublishMode::Updatable` (by publisher) and `PublishMode::Immutable` (by hash).
+
+```bash
+cargo run --example global_contracts --features sandbox
+```
+
 ## Getting Testnet Credentials
 
 1. Create an account at [testnet.mynearwallet.com](https://testnet.mynearwallet.com/)

--- a/crates/near-kit/examples/global_contracts.rs
+++ b/crates/near-kit/examples/global_contracts.rs
@@ -1,0 +1,180 @@
+//! Global Contracts: Publish and Deploy-From
+//!
+//! Demonstrates the global contract workflow:
+//! 1. Publish a contract to the global registry
+//! 2. Deploy it to another account using `deploy_from`
+//! 3. Call methods on the deployed contract
+//!
+//! Run: cargo run --example global_contracts --features sandbox
+//!
+//! This example requires the `sandbox` feature and will start a local NEAR node.
+
+use near_kit::*;
+
+#[cfg(feature = "sandbox")]
+use near_kit::sandbox::{Sandbox, SandboxConfig};
+
+#[cfg(feature = "sandbox")]
+async fn global_contracts_example() -> Result<(), Error> {
+    println!("Starting local sandbox...\n");
+    let sandbox: Sandbox = SandboxConfig::fresh().await;
+
+    let root_near = sandbox.client();
+    let root_account = root_near.account_id().to_string();
+
+    // --- Create a publisher account ---
+    let publisher_key = KeyPair::random();
+    let publisher_account = format!("publisher.{root_account}");
+
+    root_near
+        .transaction(&publisher_account)
+        .create_account()
+        .transfer(NearToken::from_near(50))
+        .add_full_access_key(publisher_key.public_key.clone())
+        .send()
+        .await?;
+
+    let publisher_near = Near::custom(sandbox.rpc_url())
+        .signer(InMemorySigner::from_secret_key(
+            publisher_account.parse()?,
+            publisher_key.secret_key,
+        ))
+        .build();
+
+    println!("Created publisher: {publisher_account}");
+
+    // --- Publish a contract (updatable mode) ---
+    let wasm_code = std::fs::read("tests/contracts/guestbook.wasm")
+        .expect("Run from the crate root: cargo run --example global_contracts --features sandbox");
+
+    publisher_near
+        .publish(wasm_code.clone(), PublishMode::Updatable)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await?;
+
+    println!("Published guestbook contract (updatable)\n");
+
+    // --- Create a user account and deploy from the publisher ---
+    let user_key = KeyPair::random();
+    let user_account = format!("app.{root_account}");
+
+    root_near
+        .transaction(&user_account)
+        .create_account()
+        .transfer(NearToken::from_near(10))
+        .add_full_access_key(user_key.public_key.clone())
+        .send()
+        .await?;
+
+    let user_near = Near::custom(sandbox.rpc_url())
+        .signer(InMemorySigner::from_secret_key(
+            user_account.parse()?,
+            user_key.secret_key,
+        ))
+        .build();
+
+    // Deploy from the publisher's global contract (type dispatches on &str)
+    user_near
+        .deploy_from(publisher_account.as_str())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await?;
+
+    println!("Deployed to {user_account} from publisher\n");
+
+    // --- Interact with the deployed contract ---
+    user_near
+        .transaction(&user_account)
+        .call("add_message")
+        .args(serde_json::json!({ "text": "Hello from a global contract!" }))
+        .gas(Gas::from_tgas(30))
+        .deposit(NearToken::ZERO)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await?;
+
+    let messages: Vec<serde_json::Value> = root_near
+        .view(&user_account, "get_messages")
+        .args(serde_json::json!({}))
+        .await?;
+
+    println!("Messages on {user_account}:");
+    for msg in &messages {
+        println!("  - {}", msg["text"]);
+    }
+
+    // --- Also demonstrate deploy_from with a CryptoHash ---
+    let code_hash = CryptoHash::hash(&wasm_code);
+    println!("\nContract code hash: {code_hash}");
+
+    // Publish the same contract immutably (by hash)
+    publisher_near
+        .publish(wasm_code, PublishMode::Immutable)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await?;
+
+    println!("Published same contract (immutable)\n");
+
+    // Deploy to a second account using the hash
+    let user2_key = KeyPair::random();
+    let user2_account = format!("app2.{root_account}");
+
+    root_near
+        .transaction(&user2_account)
+        .create_account()
+        .transfer(NearToken::from_near(10))
+        .add_full_access_key(user2_key.public_key.clone())
+        .send()
+        .await?;
+
+    let user2_near = Near::custom(sandbox.rpc_url())
+        .signer(InMemorySigner::from_secret_key(
+            user2_account.parse()?,
+            user2_key.secret_key,
+        ))
+        .build();
+
+    // Deploy from hash (type dispatches on CryptoHash)
+    user2_near
+        .deploy_from(code_hash)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await?;
+
+    println!("Deployed to {user2_account} from code hash");
+
+    // Verify it works
+    let messages: Vec<serde_json::Value> = root_near
+        .view(&user2_account, "get_messages")
+        .args(serde_json::json!({}))
+        .await?;
+
+    println!(
+        "Messages on {user2_account}: {} (empty as expected)",
+        messages.len()
+    );
+
+    println!("\nDone.");
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    println!("Global Contracts Example\n");
+    println!("Demonstrates publishing contracts to the global registry and deploying from them.\n");
+
+    #[cfg(feature = "sandbox")]
+    {
+        global_contracts_example().await?;
+    }
+
+    #[cfg(not(feature = "sandbox"))]
+    {
+        println!("This example requires the `sandbox` feature.");
+        println!("Run with: cargo run --example global_contracts --features sandbox");
+    }
+
+    Ok(())
+}

--- a/crates/near-kit/examples/global_contracts.rs
+++ b/crates/near-kit/examples/global_contracts.rs
@@ -74,9 +74,9 @@ async fn global_contracts_example() -> Result<(), Error> {
         ))
         .build();
 
-    // Deploy from the publisher's global contract (type dispatches on &str)
+    // Deploy from the publisher's global contract
     user_near
-        .deploy_from(publisher_account.as_str())
+        .deploy_from(&publisher_account)
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await?;

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -640,8 +640,7 @@ impl Near {
     /// Panics if no signer is configured.
     pub fn deploy_from(&self, contract_ref: impl GlobalContractRef) -> TransactionBuilder {
         let account_id = self.account_id().clone();
-        let identifier = contract_ref.into_identifier();
-        self.transaction(account_id).deploy_from(identifier)
+        self.transaction(account_id).deploy_from(contract_ref)
     }
 
     /// Publish a contract to the global registry.

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -7,7 +7,8 @@ use serde::de::DeserializeOwned;
 use crate::contract::ContractClient;
 use crate::error::Error;
 use crate::types::{
-    AccountId, ChainId, Gas, IntoNearToken, NearToken, PublicKey, SecretKey, TryIntoAccountId,
+    AccountId, ChainId, Gas, GlobalContractRef, IntoNearToken, NearToken, PublicKey, PublishMode,
+    SecretKey, TryIntoAccountId,
 };
 
 use super::query::{AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, ViewCall};
@@ -586,7 +587,7 @@ impl Near {
         self.transaction(contract_id).call(method)
     }
 
-    /// Deploy a contract.
+    /// Deploy WASM bytes to the signer's account.
     ///
     /// # Example
     ///
@@ -598,33 +599,98 @@ impl Near {
     ///     .build();
     ///
     /// let wasm_code = std::fs::read("contract.wasm").unwrap();
-    /// near.deploy("alice.testnet", wasm_code).await?;
+    /// near.deploy(wasm_code).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn deploy(
-        &self,
-        account_id: impl TryIntoAccountId,
-        code: impl Into<Vec<u8>>,
-    ) -> TransactionBuilder {
+    ///
+    /// # Panics
+    ///
+    /// Panics if no signer is configured.
+    pub fn deploy(&self, code: impl Into<Vec<u8>>) -> TransactionBuilder {
+        let account_id = self.account_id().clone();
         self.transaction(account_id).deploy(code)
     }
 
-    /// Add a full access key to an account.
-    pub fn add_full_access_key(
-        &self,
-        account_id: impl TryIntoAccountId,
-        public_key: PublicKey,
-    ) -> TransactionBuilder {
+    /// Deploy a contract from the global registry.
+    ///
+    /// Accepts either a `CryptoHash` (for immutable contracts identified by hash)
+    /// or an account ID string/`AccountId` (for publisher-updatable contracts).
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example(code_hash: CryptoHash) -> Result<(), near_kit::Error> {
+    /// let near = Near::testnet()
+    ///         .credentials("ed25519:...", "alice.testnet")?
+    ///     .build();
+    ///
+    /// // Deploy by publisher (updatable)
+    /// near.deploy_from("publisher.near").await?;
+    ///
+    /// // Deploy by hash (immutable)
+    /// near.deploy_from(code_hash).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if no signer is configured.
+    pub fn deploy_from(&self, contract_ref: impl GlobalContractRef) -> TransactionBuilder {
+        let account_id = self.account_id().clone();
+        let identifier = contract_ref.into_identifier();
+        self.transaction(account_id).deploy_from(identifier)
+    }
+
+    /// Publish a contract to the global registry.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example() -> Result<(), near_kit::Error> {
+    /// let near = Near::testnet()
+    ///         .credentials("ed25519:...", "alice.testnet")?
+    ///     .build();
+    ///
+    /// let wasm_code = std::fs::read("contract.wasm").unwrap();
+    ///
+    /// // Publish updatable contract (identified by your account)
+    /// near.publish(wasm_code.clone(), PublishMode::Updatable).await?;
+    ///
+    /// // Publish immutable contract (identified by its hash)
+    /// near.publish(wasm_code, PublishMode::Immutable).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if no signer is configured.
+    pub fn publish(&self, code: impl Into<Vec<u8>>, mode: PublishMode) -> TransactionBuilder {
+        let account_id = self.account_id().clone();
+        self.transaction(account_id).publish(code, mode)
+    }
+
+    /// Add a full access key to the signer's account.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no signer is configured.
+    pub fn add_full_access_key(&self, public_key: PublicKey) -> TransactionBuilder {
+        let account_id = self.account_id().clone();
         self.transaction(account_id).add_full_access_key(public_key)
     }
 
-    /// Delete an access key from an account.
-    pub fn delete_key(
-        &self,
-        account_id: impl TryIntoAccountId,
-        public_key: PublicKey,
-    ) -> TransactionBuilder {
+    /// Delete an access key from the signer's account.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no signer is configured.
+    pub fn delete_key(&self, public_key: PublicKey) -> TransactionBuilder {
+        let account_id = self.account_id().clone();
         self.transaction(account_id).delete_key(public_key)
     }
 

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -37,9 +37,8 @@ use crate::error::{Error, RpcError};
 use crate::types::{
     AccountId, Action, BlockReference, CryptoHash, DelegateAction, DeterministicAccountStateInit,
     FinalExecutionOutcome, Finality, Gas, GlobalContractIdentifier, GlobalContractRef, IntoGas,
-    IntoNearToken,
-    NearToken, NonDelegateAction, PublicKey, PublishMode, SignedDelegateAction, SignedTransaction,
-    Transaction, TryIntoAccountId, TxExecutionStatus,
+    IntoNearToken, NearToken, NonDelegateAction, PublicKey, PublishMode, SignedDelegateAction,
+    SignedTransaction, Transaction, TryIntoAccountId, TxExecutionStatus,
 };
 
 use super::nonce_manager::NonceManager;

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -484,7 +484,12 @@ impl TransactionBuilder {
     /// Publish a contract to the global registry.
     ///
     /// Global contracts are deployed once and can be referenced by multiple accounts,
-    /// saving storage costs. Two modes are available:
+    /// saving storage costs. Two modes are available via [`PublishMode`]:
+    ///
+    /// - [`PublishMode::Updatable`]: the contract is identified by the publisher's
+    ///   account and can be updated by publishing new code from the same account.
+    /// - [`PublishMode::Immutable`]: the contract is identified by its code hash and
+    ///   cannot be updated once published.
     ///
     /// # Example
     ///
@@ -514,7 +519,8 @@ impl TransactionBuilder {
 
     /// Deploy a contract from the global registry.
     ///
-    /// Accepts a [`GlobalContractIdentifier`] to reference a previously published contract.
+    /// Accepts any [`GlobalContractRef`] (such as a [`CryptoHash`] or an account ID
+    /// string/[`AccountId`]) to reference a previously published contract.
     ///
     /// # Example
     ///

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -36,9 +36,9 @@ use std::sync::{Arc, OnceLock};
 use crate::error::{Error, RpcError};
 use crate::types::{
     AccountId, Action, BlockReference, CryptoHash, DelegateAction, DeterministicAccountStateInit,
-    FinalExecutionOutcome, Finality, Gas, IntoGas, IntoNearToken, NearToken, NonDelegateAction,
-    PublicKey, SignedDelegateAction, SignedTransaction, Transaction, TryIntoAccountId,
-    TxExecutionStatus,
+    FinalExecutionOutcome, Finality, Gas, GlobalContractIdentifier, IntoGas, IntoNearToken,
+    NearToken, NonDelegateAction, PublicKey, PublishMode, SignedDelegateAction, SignedTransaction,
+    Transaction, TryIntoAccountId, TxExecutionStatus,
 };
 
 use super::nonce_manager::NonceManager;
@@ -486,13 +486,6 @@ impl TransactionBuilder {
     /// Global contracts are deployed once and can be referenced by multiple accounts,
     /// saving storage costs. Two modes are available:
     ///
-    /// - `by_hash = false` (default): Contract is identified by the signer's account ID.
-    ///   The signer can update the contract later, and all users will automatically
-    ///   use the updated version.
-    ///
-    /// - `by_hash = true`: Contract is identified by its code hash. This creates
-    ///   an immutable contract that cannot be updated.
-    ///
     /// # Example
     ///
     /// ```rust,no_run
@@ -502,27 +495,26 @@ impl TransactionBuilder {
     ///
     /// // Publish updatable contract (identified by your account)
     /// near.transaction("alice.testnet")
-    ///     .publish_contract(wasm_code.clone(), false)
+    ///     .publish(wasm_code.clone(), PublishMode::Updatable)
     ///     .send()
     ///     .await?;
     ///
     /// // Publish immutable contract (identified by its hash)
     /// near.transaction("alice.testnet")
-    ///     .publish_contract(wasm_code, true)
+    ///     .publish(wasm_code, PublishMode::Immutable)
     ///     .send()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn publish_contract(mut self, code: impl Into<Vec<u8>>, by_hash: bool) -> Self {
-        self.actions
-            .push(Action::publish_contract(code.into(), by_hash));
+    pub fn publish(mut self, code: impl Into<Vec<u8>>, mode: PublishMode) -> Self {
+        self.actions.push(Action::publish(code.into(), mode));
         self
     }
 
-    /// Deploy a contract from the global registry by code hash.
+    /// Deploy a contract from the global registry.
     ///
-    /// References a previously published immutable contract.
+    /// Accepts a [`GlobalContractIdentifier`] to reference a previously published contract.
     ///
     /// # Example
     ///
@@ -530,39 +522,17 @@ impl TransactionBuilder {
     /// # use near_kit::*;
     /// # async fn example(near: Near, code_hash: CryptoHash) -> Result<(), near_kit::Error> {
     /// near.transaction("alice.testnet")
-    ///     .deploy_from_hash(code_hash)
+    ///     .deploy_from(GlobalContractIdentifier::CodeHash(code_hash))
     ///     .send()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn deploy_from_hash(mut self, code_hash: CryptoHash) -> Self {
-        self.actions.push(Action::deploy_from_hash(code_hash));
-        self
-    }
-
-    /// Deploy a contract from the global registry by publisher account.
-    ///
-    /// References a contract published by the given account.
-    /// The contract can be updated by the publisher.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use near_kit::*;
-    /// # async fn example(near: Near) -> Result<(), near_kit::Error> {
-    /// near.transaction("alice.testnet")
-    ///     .deploy_from_publisher("contract-publisher.near")
-    ///     .send()
-    ///     .await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn deploy_from_publisher(mut self, publisher_id: impl TryIntoAccountId) -> Self {
-        let publisher_id = publisher_id
-            .try_into_account_id()
-            .expect("invalid account ID");
-        self.actions.push(Action::deploy_from_account(publisher_id));
+    pub fn deploy_from(mut self, identifier: GlobalContractIdentifier) -> Self {
+        self.actions.push(match identifier {
+            GlobalContractIdentifier::CodeHash(hash) => Action::deploy_from_hash(hash),
+            GlobalContractIdentifier::AccountId(id) => Action::deploy_from_account(id),
+        });
         self
     }
 
@@ -1187,18 +1157,13 @@ impl CallBuilder {
     }
 
     /// Publish a contract to the global registry.
-    pub fn publish_contract(self, code: impl Into<Vec<u8>>, by_hash: bool) -> TransactionBuilder {
-        self.finish().publish_contract(code, by_hash)
+    pub fn publish(self, code: impl Into<Vec<u8>>, mode: PublishMode) -> TransactionBuilder {
+        self.finish().publish(code, mode)
     }
 
-    /// Deploy a contract from the global registry by code hash.
-    pub fn deploy_from_hash(self, code_hash: CryptoHash) -> TransactionBuilder {
-        self.finish().deploy_from_hash(code_hash)
-    }
-
-    /// Deploy a contract from the global registry by publisher account.
-    pub fn deploy_from_publisher(self, publisher_id: impl TryIntoAccountId) -> TransactionBuilder {
-        self.finish().deploy_from_publisher(publisher_id)
+    /// Deploy a contract from the global registry.
+    pub fn deploy_from(self, identifier: GlobalContractIdentifier) -> TransactionBuilder {
+        self.finish().deploy_from(identifier)
     }
 
     /// Create a NEP-616 deterministic state init action.

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -36,7 +36,8 @@ use std::sync::{Arc, OnceLock};
 use crate::error::{Error, RpcError};
 use crate::types::{
     AccountId, Action, BlockReference, CryptoHash, DelegateAction, DeterministicAccountStateInit,
-    FinalExecutionOutcome, Finality, Gas, GlobalContractIdentifier, IntoGas, IntoNearToken,
+    FinalExecutionOutcome, Finality, Gas, GlobalContractIdentifier, GlobalContractRef, IntoGas,
+    IntoNearToken,
     NearToken, NonDelegateAction, PublicKey, PublishMode, SignedDelegateAction, SignedTransaction,
     Transaction, TryIntoAccountId, TxExecutionStatus,
 };
@@ -522,13 +523,14 @@ impl TransactionBuilder {
     /// # use near_kit::*;
     /// # async fn example(near: Near, code_hash: CryptoHash) -> Result<(), near_kit::Error> {
     /// near.transaction("alice.testnet")
-    ///     .deploy_from(GlobalContractIdentifier::CodeHash(code_hash))
+    ///     .deploy_from(code_hash)
     ///     .send()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn deploy_from(mut self, identifier: GlobalContractIdentifier) -> Self {
+    pub fn deploy_from(mut self, contract_ref: impl GlobalContractRef) -> Self {
+        let identifier = contract_ref.into_identifier();
         self.actions.push(match identifier {
             GlobalContractIdentifier::CodeHash(hash) => Action::deploy_from_hash(hash),
             GlobalContractIdentifier::AccountId(id) => Action::deploy_from_account(id),
@@ -1162,8 +1164,8 @@ impl CallBuilder {
     }
 
     /// Deploy a contract from the global registry.
-    pub fn deploy_from(self, identifier: GlobalContractIdentifier) -> TransactionBuilder {
-        self.finish().deploy_from(identifier)
+    pub fn deploy_from(self, contract_ref: impl GlobalContractRef) -> TransactionBuilder {
+        self.finish().deploy_from(contract_ref)
     }
 
     /// Create a NEP-616 deterministic state init action.

--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -28,6 +28,10 @@ pub enum PublishMode {
 ///
 /// This allows `deploy_from` to accept either a `CryptoHash` (for immutable
 /// contracts) or an account ID string/`AccountId` (for publisher-updatable contracts).
+///
+/// # Panics
+///
+/// The `&str` and `String` implementations panic if the string is not a valid NEAR account ID.
 pub trait GlobalContractRef {
     fn into_identifier(self) -> GlobalContractIdentifier;
 }
@@ -1064,7 +1068,7 @@ mod tests {
 
     #[test]
     fn test_action_helper_constructors() {
-        // Test publish_contract
+        // Test publish
         let code = vec![1, 2, 3];
         let action = Action::publish(code.clone(), PublishMode::Immutable);
         if let Action::DeployGlobalContract(inner) = action {

--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -31,7 +31,8 @@ pub enum PublishMode {
 ///
 /// # Panics
 ///
-/// The `&str` and `String` implementations panic if the string is not a valid NEAR account ID.
+/// String-based implementations (`&str`, `String`, `&String`) panic if the string is not a
+/// valid NEAR account ID.
 pub trait GlobalContractRef {
     fn into_identifier(self) -> GlobalContractIdentifier;
 }

--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -9,7 +9,54 @@ use serde_with::base64::Base64;
 use serde_with::serde_as;
 use sha3::{Digest, Keccak256};
 
-use super::{AccountId, CryptoHash, Gas, NearToken, PublicKey, Signature};
+use super::{AccountId, CryptoHash, Gas, NearToken, PublicKey, Signature, TryIntoAccountId};
+
+/// Publish mode for global contracts.
+///
+/// Determines how a published contract will be identified in the global registry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PublishMode {
+    /// Contract is identified by the signer's account ID.
+    /// The signer can update the contract later.
+    Updatable,
+    /// Contract is identified by its code hash.
+    /// The contract cannot be updated after publishing.
+    Immutable,
+}
+
+/// Trait for types that can identify a global contract.
+///
+/// This allows `deploy_from` to accept either a `CryptoHash` (for immutable
+/// contracts) or an account ID string/`AccountId` (for publisher-updatable contracts).
+pub trait GlobalContractRef {
+    fn into_identifier(self) -> GlobalContractIdentifier;
+}
+
+impl GlobalContractRef for CryptoHash {
+    fn into_identifier(self) -> GlobalContractIdentifier {
+        GlobalContractIdentifier::CodeHash(self)
+    }
+}
+
+impl GlobalContractRef for AccountId {
+    fn into_identifier(self) -> GlobalContractIdentifier {
+        GlobalContractIdentifier::AccountId(self)
+    }
+}
+
+impl GlobalContractRef for &str {
+    fn into_identifier(self) -> GlobalContractIdentifier {
+        let account_id: AccountId = self.try_into_account_id().expect("invalid account ID");
+        GlobalContractIdentifier::AccountId(account_id)
+    }
+}
+
+impl GlobalContractRef for String {
+    fn into_identifier(self) -> GlobalContractIdentifier {
+        let account_id: AccountId = self.try_into_account_id().expect("invalid account ID");
+        GlobalContractIdentifier::AccountId(account_id)
+    }
+}
 
 /// NEP-461 prefix for delegate actions (meta-transactions).
 /// Value: 2^30 + 366 = 1073742190
@@ -511,31 +558,29 @@ impl Action {
     /// # Arguments
     ///
     /// * `code` - The WASM code to publish
-    /// * `by_hash` - If true, contract is identified by its code hash (immutable).
-    ///   If false (default), contract is identified by the signer's account ID (updatable).
+    /// * `mode` - Whether the contract is updatable (by publisher) or immutable (by hash)
     ///
     /// # Example
     ///
     /// ```rust,ignore
     /// // Publish updatable contract (identified by your account)
     /// near.transaction("alice.near")
-    ///     .publish_contract(wasm_code, false)
+    ///     .publish(wasm_code, PublishMode::Updatable)
     ///     .send()
     ///     .await?;
     ///
     /// // Publish immutable contract (identified by its hash)
     /// near.transaction("alice.near")
-    ///     .publish_contract(wasm_code, true)
+    ///     .publish(wasm_code, PublishMode::Immutable)
     ///     .send()
     ///     .await?;
     /// ```
-    pub fn publish_contract(code: Vec<u8>, by_hash: bool) -> Self {
+    pub fn publish(code: Vec<u8>, mode: PublishMode) -> Self {
         Self::DeployGlobalContract(DeployGlobalContractAction {
             code,
-            deploy_mode: if by_hash {
-                GlobalContractDeployMode::CodeHash
-            } else {
-                GlobalContractDeployMode::AccountId
+            deploy_mode: match mode {
+                PublishMode::Updatable => GlobalContractDeployMode::AccountId,
+                PublishMode::Immutable => GlobalContractDeployMode::CodeHash,
             },
         })
     }
@@ -881,7 +926,7 @@ mod tests {
         assert_eq!(bytes[0], 3, "Transfer should have discriminant 3");
 
         // DeployGlobalContract (discriminant = 9)
-        let publish = Action::publish_contract(vec![1, 2, 3], false);
+        let publish = Action::publish(vec![1, 2, 3], PublishMode::Updatable);
         let bytes = borsh::to_vec(&publish).unwrap();
         assert_eq!(
             bytes[0], 9,
@@ -1021,7 +1066,7 @@ mod tests {
     fn test_action_helper_constructors() {
         // Test publish_contract
         let code = vec![1, 2, 3];
-        let action = Action::publish_contract(code.clone(), true);
+        let action = Action::publish(code.clone(), PublishMode::Immutable);
         if let Action::DeployGlobalContract(inner) = action {
             assert_eq!(inner.code, code);
             assert_eq!(inner.deploy_mode, GlobalContractDeployMode::CodeHash);
@@ -1029,7 +1074,7 @@ mod tests {
             panic!("Expected DeployGlobalContract");
         }
 
-        let action = Action::publish_contract(code.clone(), false);
+        let action = Action::publish(code.clone(), PublishMode::Updatable);
         if let Action::DeployGlobalContract(inner) = action {
             assert_eq!(inner.deploy_mode, GlobalContractDeployMode::AccountId);
         } else {

--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -48,6 +48,12 @@ impl GlobalContractRef for AccountId {
     }
 }
 
+impl GlobalContractRef for &AccountId {
+    fn into_identifier(self) -> GlobalContractIdentifier {
+        GlobalContractIdentifier::AccountId(self.clone())
+    }
+}
+
 impl GlobalContractRef for &str {
     fn into_identifier(self) -> GlobalContractIdentifier {
         let account_id: AccountId = self.try_into_account_id().expect("invalid account ID");
@@ -58,6 +64,16 @@ impl GlobalContractRef for &str {
 impl GlobalContractRef for String {
     fn into_identifier(self) -> GlobalContractIdentifier {
         let account_id: AccountId = self.try_into_account_id().expect("invalid account ID");
+        GlobalContractIdentifier::AccountId(account_id)
+    }
+}
+
+impl GlobalContractRef for &String {
+    fn into_identifier(self) -> GlobalContractIdentifier {
+        let account_id: AccountId = self
+            .as_str()
+            .try_into_account_id()
+            .expect("invalid account ID");
         GlobalContractIdentifier::AccountId(account_id)
     }
 }

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -64,8 +64,9 @@ pub use action::{
     DeleteAccountAction, DeleteKeyAction, DeployContractAction, DeployGlobalContractAction,
     DeterministicAccountStateInit, DeterministicAccountStateInitV1, DeterministicStateInitAction,
     FunctionCallAction, FunctionCallPermission, GasKeyInfo, GlobalContractDeployMode,
-    GlobalContractIdentifier, NonDelegateAction, SignedDelegateAction, StakeAction, TransferAction,
-    TransferToGasKeyAction, UseGlobalContractAction, WithdrawFromGasKeyAction,
+    GlobalContractIdentifier, GlobalContractRef, NonDelegateAction, PublishMode,
+    SignedDelegateAction, StakeAction, TransferAction, TransferToGasKeyAction,
+    UseGlobalContractAction, WithdrawFromGasKeyAction,
 };
 pub use block_reference::{BlockReference, Finality, SyncCheckpoint, TxExecutionStatus};
 pub use error::{

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -60,6 +60,184 @@ async fn create_funded_account(
 // Global Contract Tests
 // =============================================================================
 
+/// Test the `near.publish()` convenience shorthand (updatable mode).
+#[tokio::test]
+async fn test_near_publish_shorthand_updatable() {
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    let (publisher_near, _, _) =
+        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+
+    let wasm_code = load_test_contract();
+
+    // Use the Near::publish() shorthand (targets the signer's own account)
+    let outcome = publisher_near
+        .publish(wasm_code, PublishMode::Updatable)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    assert!(!outcome.transaction_hash().to_string().is_empty());
+}
+
+/// Test the `near.publish()` convenience shorthand (immutable mode).
+#[tokio::test]
+async fn test_near_publish_shorthand_immutable() {
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    let (publisher_near, _, _) =
+        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+
+    let wasm_code = load_test_contract();
+
+    let outcome = publisher_near
+        .publish(wasm_code, PublishMode::Immutable)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    assert!(!outcome.transaction_hash().to_string().is_empty());
+}
+
+/// Test the `near.deploy_from()` convenience shorthand with a publisher account.
+#[tokio::test]
+async fn test_near_deploy_from_shorthand_publisher() {
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    // Publisher publishes the contract
+    let (publisher_near, publisher_id, _) =
+        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+
+    let wasm_code = load_test_contract();
+
+    publisher_near
+        .publish(wasm_code, PublishMode::Updatable)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // User deploys using the Near::deploy_from() shorthand
+    let (user_near, user_id, _) =
+        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+
+    user_near
+        .deploy_from(publisher_id.as_str())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // Verify by calling a view method on the deployed contract
+    let messages: Vec<serde_json::Value> = root_near
+        .view(&user_id, "get_messages")
+        .args(serde_json::json!({}))
+        .await
+        .unwrap();
+    assert!(messages.is_empty());
+}
+
+/// Test the `near.deploy_from()` convenience shorthand with a CryptoHash.
+#[tokio::test]
+async fn test_near_deploy_from_shorthand_hash() {
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    let (publisher_near, _, _) =
+        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+
+    let wasm_code = load_test_contract();
+    let code_hash = CryptoHash::hash(&wasm_code);
+
+    publisher_near
+        .publish(wasm_code, PublishMode::Immutable)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // User deploys using the Near::deploy_from() shorthand with CryptoHash
+    let (user_near, user_id, _) =
+        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+
+    user_near
+        .deploy_from(code_hash)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // Verify by calling a view method
+    let messages: Vec<serde_json::Value> = root_near
+        .view(&user_id, "get_messages")
+        .args(serde_json::json!({}))
+        .await
+        .unwrap();
+    assert!(messages.is_empty());
+}
+
+/// End-to-end test: publish → deploy_from → call the deployed contract.
+#[tokio::test]
+async fn test_publish_deploy_from_call_end_to_end() {
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    // Publisher publishes an updatable contract
+    let (publisher_near, publisher_id, _) =
+        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+
+    let wasm_code = load_test_contract();
+
+    publisher_near
+        .publish(wasm_code, PublishMode::Updatable)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // User deploys from the publisher's global contract
+    let (user_near, user_id, _) =
+        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+
+    user_near
+        .deploy_from(publisher_id.as_str())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // Call a mutating method on the deployed contract
+    user_near
+        .transaction(&user_id)
+        .call("add_message")
+        .args(serde_json::json!({ "text": "Hello from global contract!" }))
+        .gas(Gas::from_tgas(30))
+        .deposit(NearToken::ZERO)
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // Verify the message was stored
+    let messages: Vec<serde_json::Value> = root_near
+        .view(&user_id, "get_messages")
+        .args(serde_json::json!({}))
+        .await
+        .unwrap();
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["text"], "Hello from global contract!");
+}
+
 /// Test publishing a contract to the global registry by account ID (updatable).
 #[tokio::test]
 async fn test_publish_contract_by_account() {

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -130,7 +130,7 @@ async fn test_near_deploy_from_shorthand_publisher() {
         create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
 
     user_near
-        .deploy_from(publisher_id.as_str())
+        .deploy_from(publisher_id.clone())
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
@@ -320,10 +320,10 @@ async fn test_deploy_from_publisher() {
     let (user_near, user_id, _) =
         create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
 
-    // Deploy from the publisher's global contract
+    // Deploy from the publisher's global contract (passing AccountId directly)
     let outcome = user_near
         .transaction(&user_id)
-        .deploy_from(publisher_id.as_str())
+        .deploy_from(publisher_id.clone())
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -145,7 +145,7 @@ async fn test_deploy_from_publisher() {
     // Deploy from the publisher's global contract
     let outcome = user_near
         .transaction(&user_id)
-        .deploy_from(GlobalContractIdentifier::AccountId(publisher_id.clone()))
+        .deploy_from(publisher_id.as_str())
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
@@ -200,7 +200,7 @@ async fn test_deploy_from_hash() {
     // Deploy from the code hash
     let outcome = user_near
         .transaction(&user_id)
-        .deploy_from(GlobalContractIdentifier::CodeHash(code_hash))
+        .deploy_from(code_hash)
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -73,7 +73,7 @@ async fn test_publish_contract_by_account() {
 
     let wasm_code = load_test_contract();
 
-    // Publish the contract (by_hash = false means identified by account)
+    // Publish the contract in updatable mode (identified by the publisher account)
     let outcome = publisher_near
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Updatable)
@@ -101,7 +101,7 @@ async fn test_publish_contract_by_hash() {
 
     let wasm_code = load_test_contract();
 
-    // Publish the contract (by_hash = true means identified by code hash, immutable)
+    // Publish the contract using PublishMode::Immutable (identified by code hash, immutable)
     let outcome = publisher_near
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Immutable)

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -76,7 +76,7 @@ async fn test_publish_contract_by_account() {
     // Publish the contract (by_hash = false means identified by account)
     let outcome = publisher_near
         .transaction(&publisher_id)
-        .publish_contract(wasm_code, false)
+        .publish(wasm_code, PublishMode::Updatable)
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
@@ -104,7 +104,7 @@ async fn test_publish_contract_by_hash() {
     // Publish the contract (by_hash = true means identified by code hash, immutable)
     let outcome = publisher_near
         .transaction(&publisher_id)
-        .publish_contract(wasm_code, true)
+        .publish(wasm_code, PublishMode::Immutable)
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
@@ -132,7 +132,7 @@ async fn test_deploy_from_publisher() {
     // First, publish the contract
     publisher_near
         .transaction(&publisher_id)
-        .publish_contract(wasm_code, false)
+        .publish(wasm_code, PublishMode::Updatable)
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
@@ -145,7 +145,7 @@ async fn test_deploy_from_publisher() {
     // Deploy from the publisher's global contract
     let outcome = user_near
         .transaction(&user_id)
-        .deploy_from_publisher(&publisher_id)
+        .deploy_from(GlobalContractIdentifier::AccountId(publisher_id.clone()))
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
@@ -187,7 +187,7 @@ async fn test_deploy_from_hash() {
     // Publish the contract by hash (immutable)
     publisher_near
         .transaction(&publisher_id)
-        .publish_contract(wasm_code, true)
+        .publish(wasm_code, PublishMode::Immutable)
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
@@ -200,7 +200,7 @@ async fn test_deploy_from_hash() {
     // Deploy from the code hash
     let outcome = user_near
         .transaction(&user_id)
-        .deploy_from_hash(code_hash)
+        .deploy_from(GlobalContractIdentifier::CodeHash(code_hash))
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
@@ -239,7 +239,7 @@ async fn test_state_init_by_hash() {
     // First, publish the contract by hash
     publisher_near
         .transaction(&publisher_id)
-        .publish_contract(wasm_code, true)
+        .publish(wasm_code, PublishMode::Immutable)
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
@@ -279,7 +279,7 @@ async fn test_state_init_by_publisher() {
     // First, publish the contract by account
     publisher_near
         .transaction(&publisher_id)
-        .publish_contract(wasm_code, false)
+        .publish(wasm_code, PublishMode::Updatable)
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await

--- a/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
+++ b/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
@@ -358,7 +358,7 @@ async fn test_deleted_key_fails() {
         .build();
 
     near2
-        .delete_key(&account_id, key1.public_key())
+        .delete_key(key1.public_key())
         .wait_until(TxExecutionStatus::Final)
         .await
         .unwrap();

--- a/crates/near-kit/tests/integration/transaction_failure_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_failure_integration.rs
@@ -101,7 +101,9 @@ async fn test_add_key_to_nonexistent_account() {
 
     // Try to add a key to a non-existent account — action error returns Ok(outcome)
     let outcome = near
-        .add_full_access_key(&nonexistent, key.public_key())
+        .transaction(&nonexistent)
+        .add_full_access_key(key.public_key())
+        .send()
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -137,7 +139,7 @@ async fn test_add_duplicate_key() {
 
     // Try to add the same key again — action error returns Ok(outcome)
     let outcome = account_near
-        .add_full_access_key(&account_id, key.public_key())
+        .add_full_access_key(key.public_key())
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -172,7 +174,7 @@ async fn test_delete_last_full_access_key() {
 
     // Delete the only key - this should succeed but leave the account inaccessible
     // Note: NEAR protocol allows this
-    let result = account_near.delete_key(&account_id, key.public_key()).await;
+    let result = account_near.delete_key(key.public_key()).await;
 
     // This may succeed - depends on protocol rules about last key
     println!("Delete last key result: {:?}", result);

--- a/crates/near-kit/tests/integration/transaction_failure_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_failure_integration.rs
@@ -49,7 +49,7 @@ async fn test_deploy_invalid_wasm() {
     // Try to deploy invalid WASM (random bytes)
     let invalid_wasm = vec![0u8; 100]; // Not valid WASM
 
-    let result = account_near.deploy(&account_id, invalid_wasm).await;
+    let result = account_near.deploy(invalid_wasm).await;
 
     // Note: NEAR allows deploying any bytes, but calling methods will fail
     // The deploy itself may succeed
@@ -81,7 +81,7 @@ async fn test_deploy_empty_wasm() {
     // Try to deploy empty WASM
     let empty_wasm: Vec<u8> = vec![];
 
-    let result = account_near.deploy(&account_id, empty_wasm).await;
+    let result = account_near.deploy(empty_wasm).await;
 
     // Empty deploys may succeed (effectively removes contract)
     println!("Empty WASM deploy result: {:?}", result);

--- a/crates/near-kit/tests/integration/typed_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_error_integration.rs
@@ -201,7 +201,7 @@ async fn test_call_nonexistent_method_deserializes_as_typed_error() {
 
     // Deploy a contract first
     let wasm = std::fs::read("tests/contracts/guestbook.wasm").unwrap();
-    near.deploy(&id, wasm).await.unwrap();
+    near.deploy(wasm).await.unwrap();
 
     // Call a method that doesn't exist
     let outcome = send_raw_tx(


### PR DESCRIPTION
## Summary

Reworks the deploy/publish convenience API on `Near` based on feedback from @mitinarseny:

- **Remove redundant `account_id` param** from `near.deploy()`, `near.add_full_access_key()`, and `near.delete_key()` — these always target the signer's own account
- **Add `near.deploy_from()`** with a `GlobalContractRef` trait that dispatches based on type — pass a `CryptoHash` for immutable contracts or an account ID string for publisher-updatable contracts
- **Add `near.publish()`** convenience method for publishing contracts to the global registry
- **Replace `publish_contract(code, by_hash: bool)`** with `publish(code, PublishMode)` using a clear `PublishMode::Updatable` / `PublishMode::Immutable` enum instead of an opaque bool
- **Replace `deploy_from_hash()` / `deploy_from_publisher()`** with a unified `deploy_from()` on `TransactionBuilder` and `CallBuilder`

### Before
```rust
near.deploy("alice.testnet", wasm_code).await?;
near.transaction("alice.testnet").publish_contract(code, true).send().await?;
near.transaction("alice.testnet").deploy_from_hash(hash).send().await?;
```

### After
```rust
near.deploy(wasm_code).await?;
near.publish(code, PublishMode::Immutable).await?;
near.deploy_from(hash).await?;        // by hash (immutable)
near.deploy_from("publisher.near").await?;  // by publisher (updatable)
```

## Test plan

- [x] `cargo check --workspace` passes
- [x] `cargo test --workspace` passes (390 unit tests + 5 ignored integration tests)
- [ ] Integration tests with sandbox (require Docker)

Closes #117