### PR TITLE
fix: prevent overflow in nonce retry loop

### DIFF
--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1332,7 +1332,7 @@ impl IntoFuture for TransactionSend {
             let mut last_error: Option<Error> = None;
             let mut last_ak_nonce: Option<u64> = None;
 
-            for attempt in 0..max_nonce_retries + 1 {
+            for attempt in 0..=max_nonce_retries {
                 // Get a signing key atomically for this attempt
                 let key = signer.key();
                 let public_key = key.public_key().clone();


### PR DESCRIPTION
## Summary

- Use inclusive range `0..=max_nonce_retries` instead of `0..max_nonce_retries + 1` to prevent u32 overflow when `max_nonce_retries == u32::MAX` (which is suggested in #129's usage examples)
- In debug builds, the overflow panics; in release it wraps to 0 and the loop doesn't run

Follow-up to #129.

## Test plan

- [x] No behavioral change for any value except `u32::MAX`
- [x] `0..=n` produces identical iterations to `0..n+1` without computing the addition