### PR TITLE
fix: revert leaked tracing changes and relax testcontainers pin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ quote = "1"
 proc-macro2 = "1"
 
 # Optional: Sandbox integration (via Docker/testcontainers)
-testcontainers = "=0.25.0"
+testcontainers = "0.25"
 
 # Dev dependencies
 tokio-test = "0.4"

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -177,6 +177,7 @@ impl RpcClient {
                         self.retry_config.max_delay_ms,
                     );
                     tracing::warn!(
+                        rpc.method = method,
                         attempt = attempt + 1,
                         max_attempts = total_attempts,
                         delay_ms = delay,
@@ -187,7 +188,7 @@ impl RpcClient {
                     continue;
                 }
                 Err(e) => {
-                    tracing::error!(error = %e, "RPC request failed");
+                    tracing::error!(rpc.method = method, error = %e, "RPC request failed");
                     return Err(e);
                 }
             }
@@ -555,7 +556,6 @@ impl RpcClient {
         wait_until: TxExecutionStatus,
     ) -> Result<SendTxResponse, RpcError> {
         let tx_hash = signed_tx.get_hash();
-        tracing::Span::current().record("tx_hash", tracing::field::display(&tx_hash));
         tracing::info!(
             tx_hash = %tx_hash,
             sender = %signed_tx.transaction.signer_id,


### PR DESCRIPTION
## Summary

- Revert rpc.rs tracing span changes that leaked into #131
- Relax testcontainers pin from `=0.25.0` to `0.25` so the MSRV-aware resolver handles version selection

## Test plan

- [ ] `cargo +1.86.0 check --workspace --features sandbox` passes
- [ ] `cargo test --workspace` passes on stable