### PR TITLE
feat: enable testcontainers watchdog for container cleanup on Ctrl+C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,6 +405,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "conquer-once"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d008a441c0f269f36ca13712528069a86a3e60dffee1d98b976eb3b0b2160b4"
+dependencies = [
+ "conquer-util",
+]
+
+[[package]]
+name = "conquer-util"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e763eef8846b13b380f37dfecda401770b0ca4e56e95170237bd7c25c7db3582"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,6 +2691,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2869,6 +2904,7 @@ dependencies = [
  "bollard",
  "bollard-stubs",
  "bytes",
+ "conquer-once",
  "docker_credential",
  "either",
  "etcetera",
@@ -2880,6 +2916,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "signal-hook",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -60,7 +60,7 @@ tracing.workspace = true
 near-kit-macros.workspace = true
 
 # Optional: Sandbox integration (via Docker/testcontainers)
-testcontainers = { workspace = true, optional = true }
+testcontainers = { workspace = true, optional = true, features = ["watchdog"] }
 libc = { version = "0.2", optional = true }
 serde_with = { version = "3.17.0", features = ["hex", "base64"] }
 

--- a/crates/near-kit/src/sandbox.rs
+++ b/crates/near-kit/src/sandbox.rs
@@ -207,13 +207,12 @@ static SHARED_SANDBOX: OnceCell<Sandbox> = OnceCell::const_new();
 
 /// Stop the shared sandbox container on process exit.
 ///
-/// Tokio's thread-local storage is already destroyed on the main thread by
-/// the time `atexit` fires, so `Runtime::block_on` panics there. We work
-/// around this by spawning a new thread (which gets fresh TLS) and calling
-/// `stop_with_timeout` via a temporary tokio runtime.
+/// Statics are never dropped in Rust, so the watchdog (which handles signals)
+/// won't cover normal process exit. This `atexit` handler ensures the container
+/// is cleaned up on clean termination.
 ///
-/// The container is stopped via the testcontainers API on a spawned thread
-/// (to avoid tokio TLS destruction).
+/// Tokio's thread-local storage is already destroyed on the main thread by
+/// the time `atexit` fires, so we spawn a new thread with fresh TLS.
 extern "C" fn cleanup_shared_sandbox() {
     let handle = std::thread::spawn(|| {
         if let Some(sandbox) = SHARED_SANDBOX.get() {
@@ -249,9 +248,9 @@ fn register_shared_cleanup() {
 ///
 /// # Cleanup
 ///
-/// For fresh sandboxes, testcontainers' `Drop` handles stopping.
-/// For the shared sandbox, an `atexit` handler stops the container via the
-/// testcontainers API on a spawned thread (to avoid tokio TLS destruction).
+/// - **Fresh sandboxes**: cleaned up via testcontainers' `Drop` impl.
+/// - **Shared sandbox**: cleaned up via an `atexit` handler (normal exit) and
+///   the testcontainers `watchdog` (SIGINT/SIGTERM/SIGQUIT, e.g. Ctrl+C).
 #[derive(Clone)]
 pub struct Sandbox {
     #[allow(dead_code)]


### PR DESCRIPTION
## Summary

- Enable the `watchdog` feature on testcontainers so containers are automatically stopped and removed on SIGINT/SIGTERM/SIGQUIT (e.g. Ctrl+C)
- Previously, Ctrl+C would leave sandbox containers running
- The `atexit` handler is kept for normal process exit since Rust statics are never dropped

## Test plan

- [x] `cargo check --features sandbox` compiles
- [x] Manually verified: run sandbox example, Ctrl+C, confirm container is removed