### PR TITLE
fix: prevent underflow in Expired retry guard

### DIFF
--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1429,7 +1429,7 @@ impl IntoFuture for TransactionSend {
                         continue;
                     }
                     Err(RpcError::InvalidTx(crate::types::InvalidTxError::Expired))
-                        if attempt < max_nonce_retries - 1 =>
+                        if attempt + 1 < max_nonce_retries =>
                     {
                         tracing::warn!(
                             attempt = attempt + 1,


### PR DESCRIPTION
## Summary

- Rewrite `attempt < max_nonce_retries - 1` as `attempt + 1 < max_nonce_retries` to avoid u32 underflow
- When `max_nonce_retries == 0`, the subtraction wraps to `u32::MAX` in release (panic in debug), incorrectly allowing Expired retries on every attempt

Follow-up to #132.

## Test plan

- [x] No behavioral change for `max_nonce_retries >= 1` (the normal case)
- [x] `attempt + 1` cannot overflow since `attempt` is bounded by `max_nonce_retries` which is `u32`