### PR TITLE
feat: InMemorySigner implicit account constructors + from_secret_key ergonomics

### DIFF
--- a/crates/near-kit/examples/global_contracts.rs
+++ b/crates/near-kit/examples/global_contracts.rs
@@ -36,9 +36,9 @@ async fn global_contracts_example() -> Result<(), Error> {
 
     let publisher_near = Near::custom(sandbox.rpc_url())
         .signer(InMemorySigner::from_secret_key(
-            publisher_account.parse()?,
+            publisher_account.as_str(),
             publisher_key.secret_key,
-        ))
+        )?)
         .build();
 
     println!("Created publisher: {publisher_account}");
@@ -69,9 +69,9 @@ async fn global_contracts_example() -> Result<(), Error> {
 
     let user_near = Near::custom(sandbox.rpc_url())
         .signer(InMemorySigner::from_secret_key(
-            user_account.parse()?,
+            user_account.as_str(),
             user_key.secret_key,
-        ))
+        )?)
         .build();
 
     // Deploy from the publisher's global contract
@@ -131,9 +131,9 @@ async fn global_contracts_example() -> Result<(), Error> {
 
     let user2_near = Near::custom(sandbox.rpc_url())
         .signer(InMemorySigner::from_secret_key(
-            user2_account.parse()?,
+            user2_account.as_str(),
             user2_key.secret_key,
-        ))
+        )?)
         .build();
 
     // Deploy from hash (type dispatches on CryptoHash)

--- a/crates/near-kit/examples/rotating_signer.rs
+++ b/crates/near-kit/examples/rotating_signer.rs
@@ -39,9 +39,9 @@ async fn high_throughput_example() -> Result<(), Error> {
     // Add remaining keys using a loop
     let bot_near = Near::custom(sandbox.rpc_url())
         .signer(InMemorySigner::from_secret_key(
-            bot_account.parse()?,
+            bot_account.as_str(),
             keypairs[0].secret_key.clone(),
-        ))
+        )?)
         .build();
 
     println!("Adding {} more access keys...", num_keys - 1);

--- a/crates/near-kit/examples/sequential_sends.rs
+++ b/crates/near-kit/examples/sequential_sends.rs
@@ -43,9 +43,9 @@ async fn sequential_example() -> Result<(), Error> {
     // Add remaining keys
     let bot_near = Near::custom(sandbox.rpc_url())
         .signer(InMemorySigner::from_secret_key(
-            bot_account.parse()?,
+            bot_account.as_str(),
             keypairs[0].secret_key.clone(),
-        ))
+        )?)
         .build();
 
     keypairs[1..]

--- a/crates/near-kit/src/client/keyring_signer.rs
+++ b/crates/near-kit/src/client/keyring_signer.rs
@@ -140,7 +140,7 @@ impl KeyringSigner {
         let secret_key = parse_keyring_credential(&password, &account_id, &public_key)?;
 
         // Create the inner signer
-        let inner = InMemorySigner::from_secret_key(account_id, secret_key);
+        let inner = InMemorySigner::from_secret_key(account_id, secret_key)?;
 
         // Verify the public key matches
         if inner.public_key() != &public_key {

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -249,7 +249,8 @@ impl Near {
             .parse()
             .expect("sandbox should provide valid account id");
 
-        let signer = InMemorySigner::from_secret_key(account_id, secret_key);
+        let signer = InMemorySigner::from_secret_key(account_id, secret_key)
+            .expect("sandbox should provide valid account id");
 
         Near {
             rpc: Arc::new(RpcClient::new(network.rpc_url())),

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -307,6 +307,10 @@ impl InMemorySigner {
     }
 
     /// Create a signer from a SecretKey directly.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `account_id` cannot be converted to a valid [`AccountId`].
     pub fn from_secret_key(
         account_id: impl TryIntoAccountId,
         secret_key: SecretKey,
@@ -392,7 +396,6 @@ impl InMemorySigner {
         account_id: impl TryIntoAccountId,
         phrase: impl AsRef<str>,
     ) -> Result<Self, crate::error::Error> {
-        let account_id: AccountId = account_id.try_into_account_id()?;
         let secret_key = SecretKey::from_seed_phrase(phrase)?;
         Self::from_secret_key(account_id, secret_key)
     }
@@ -421,7 +424,6 @@ impl InMemorySigner {
         phrase: impl AsRef<str>,
         hd_path: impl AsRef<str>,
     ) -> Result<Self, crate::error::Error> {
-        let account_id: AccountId = account_id.try_into_account_id()?;
         let secret_key = SecretKey::from_seed_phrase_with_path(phrase, hd_path)?;
         Self::from_secret_key(account_id, secret_key)
     }

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -333,12 +333,12 @@ impl InMemorySigner {
     /// ```rust
     /// use near_kit::{InMemorySigner, Signer};
     ///
-    /// let signer = InMemorySigner::random_implicit();
+    /// let signer = InMemorySigner::generate_implicit();
     /// assert_eq!(signer.account_id().as_str().len(), 64);
     /// ```
-    pub fn random_implicit() -> Self {
+    pub fn generate_implicit() -> Self {
         let secret_key = SecretKey::generate_ed25519();
-        Self::new_implicit(secret_key)
+        Self::implicit(secret_key)
     }
 
     /// Create a signer from an existing secret key, deriving an implicit account ID.
@@ -355,10 +355,10 @@ impl InMemorySigner {
     /// use near_kit::{InMemorySigner, SecretKey, Signer};
     ///
     /// let secret_key = SecretKey::generate_ed25519();
-    /// let signer = InMemorySigner::new_implicit(secret_key);
+    /// let signer = InMemorySigner::implicit(secret_key);
     /// assert_eq!(signer.account_id().as_str().len(), 64);
     /// ```
-    pub fn new_implicit(secret_key: SecretKey) -> Self {
+    pub fn implicit(secret_key: SecretKey) -> Self {
         let public_key = secret_key.public_key();
         let pk_bytes = public_key
             .as_ed25519_bytes()
@@ -1082,8 +1082,8 @@ mod tests {
     }
 
     #[test]
-    fn test_random_implicit() {
-        let signer = InMemorySigner::random_implicit();
+    fn test_generate_implicit() {
+        let signer = InMemorySigner::generate_implicit();
         let account_id = signer.account_id().as_str();
 
         // Implicit account IDs are 64 hex characters
@@ -1096,10 +1096,10 @@ mod tests {
     }
 
     #[test]
-    fn test_new_implicit() {
+    fn test_implicit() {
         let secret_key = SecretKey::generate_ed25519();
         let expected_pk = secret_key.public_key();
-        let signer = InMemorySigner::new_implicit(secret_key);
+        let signer = InMemorySigner::implicit(secret_key);
 
         // Account ID matches hex-encoded public key
         let pk_bytes = expected_pk.as_ed25519_bytes().unwrap();
@@ -1108,9 +1108,9 @@ mod tests {
     }
 
     #[test]
-    fn test_random_implicit_unique() {
-        let signer1 = InMemorySigner::random_implicit();
-        let signer2 = InMemorySigner::random_implicit();
+    fn test_generate_implicit_unique() {
+        let signer1 = InMemorySigner::generate_implicit();
+        let signer2 = InMemorySigner::generate_implicit();
         assert_ne!(signer1.account_id(), signer2.account_id());
     }
 

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -307,8 +307,61 @@ impl InMemorySigner {
     }
 
     /// Create a signer from a SecretKey directly.
-    pub fn from_secret_key(account_id: AccountId, secret_key: SecretKey) -> Self {
+    pub fn from_secret_key(
+        account_id: impl TryIntoAccountId,
+        secret_key: SecretKey,
+    ) -> Result<Self, crate::error::Error> {
+        let account_id: AccountId = account_id.try_into_account_id()?;
         let public_key = secret_key.public_key();
+        Ok(Self {
+            account_id,
+            secret_key,
+            public_key,
+        })
+    }
+
+    /// Generate a random Ed25519 key and derive an implicit account ID.
+    ///
+    /// The account ID is the hex-encoded Ed25519 public key bytes (64 characters).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use near_kit::{InMemorySigner, Signer};
+    ///
+    /// let signer = InMemorySigner::random_implicit();
+    /// assert_eq!(signer.account_id().as_str().len(), 64);
+    /// ```
+    pub fn random_implicit() -> Self {
+        let secret_key = SecretKey::generate_ed25519();
+        Self::new_implicit(secret_key)
+    }
+
+    /// Create a signer from an existing secret key, deriving an implicit account ID.
+    ///
+    /// The account ID is the hex-encoded Ed25519 public key bytes (64 characters).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the secret key is not Ed25519.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use near_kit::{InMemorySigner, SecretKey, Signer};
+    ///
+    /// let secret_key = SecretKey::generate_ed25519();
+    /// let signer = InMemorySigner::new_implicit(secret_key);
+    /// assert_eq!(signer.account_id().as_str().len(), 64);
+    /// ```
+    pub fn new_implicit(secret_key: SecretKey) -> Self {
+        let public_key = secret_key.public_key();
+        let pk_bytes = public_key
+            .as_ed25519_bytes()
+            .expect("implicit accounts require an Ed25519 key");
+        let account_id: AccountId = hex::encode(pk_bytes)
+            .parse()
+            .expect("hex-encoded Ed25519 public key is a valid account ID");
         Self {
             account_id,
             secret_key,
@@ -341,7 +394,7 @@ impl InMemorySigner {
     ) -> Result<Self, crate::error::Error> {
         let account_id: AccountId = account_id.try_into_account_id()?;
         let secret_key = SecretKey::from_seed_phrase(phrase)?;
-        Ok(Self::from_secret_key(account_id, secret_key))
+        Self::from_secret_key(account_id, secret_key)
     }
 
     /// Create a signer from a BIP-39 seed phrase with custom HD path.
@@ -370,7 +423,7 @@ impl InMemorySigner {
     ) -> Result<Self, crate::error::Error> {
         let account_id: AccountId = account_id.try_into_account_id()?;
         let secret_key = SecretKey::from_seed_phrase_with_path(phrase, hd_path)?;
-        Ok(Self::from_secret_key(account_id, secret_key))
+        Self::from_secret_key(account_id, secret_key)
     }
 
     /// Get the public key.
@@ -798,7 +851,10 @@ impl RotatingSigner {
         let account_id = self.account_id;
         self.keys
             .into_iter()
-            .map(|sk| InMemorySigner::from_secret_key(account_id.clone(), sk))
+            .map(|sk| {
+                InMemorySigner::from_secret_key(account_id.clone(), sk)
+                    .expect("AccountId is always a valid account ID")
+            })
             .collect()
     }
 }
@@ -894,7 +950,7 @@ mod tests {
     #[tokio::test]
     async fn test_transaction_signing_with_signer_trait() {
         let secret_key = SecretKey::generate_ed25519();
-        let signer = InMemorySigner::from_secret_key("alice.testnet".parse().unwrap(), secret_key);
+        let signer = InMemorySigner::from_secret_key("alice.testnet", secret_key).unwrap();
 
         // Get a key for signing
         let key = signer.key();
@@ -1003,10 +1059,57 @@ mod tests {
         let secret = SecretKey::generate_ed25519();
         let expected_pk = secret.public_key();
 
-        let signer = InMemorySigner::from_secret_key("alice.testnet".parse().unwrap(), secret);
+        let signer = InMemorySigner::from_secret_key("alice.testnet", secret).unwrap();
 
         assert_eq!(signer.account_id().as_str(), "alice.testnet");
         assert_eq!(signer.public_key(), &expected_pk);
+    }
+
+    #[test]
+    fn test_from_secret_key_accepts_string() {
+        let secret = SecretKey::generate_ed25519();
+        let signer = InMemorySigner::from_secret_key("alice.testnet", secret);
+        assert!(signer.is_ok());
+    }
+
+    #[test]
+    fn test_from_secret_key_rejects_invalid_account() {
+        let secret = SecretKey::generate_ed25519();
+        let signer = InMemorySigner::from_secret_key("", secret);
+        assert!(signer.is_err());
+    }
+
+    #[test]
+    fn test_random_implicit() {
+        let signer = InMemorySigner::random_implicit();
+        let account_id = signer.account_id().as_str();
+
+        // Implicit account IDs are 64 hex characters
+        assert_eq!(account_id.len(), 64);
+        assert!(account_id.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // The account ID should be the hex-encoded public key bytes
+        let pk_bytes = signer.public_key().as_ed25519_bytes().unwrap();
+        assert_eq!(account_id, hex::encode(pk_bytes));
+    }
+
+    #[test]
+    fn test_new_implicit() {
+        let secret_key = SecretKey::generate_ed25519();
+        let expected_pk = secret_key.public_key();
+        let signer = InMemorySigner::new_implicit(secret_key);
+
+        // Account ID matches hex-encoded public key
+        let pk_bytes = expected_pk.as_ed25519_bytes().unwrap();
+        assert_eq!(signer.account_id().as_str(), hex::encode(pk_bytes));
+        assert_eq!(signer.public_key(), &expected_pk);
+    }
+
+    #[test]
+    fn test_random_implicit_unique() {
+        let signer1 = InMemorySigner::random_implicit();
+        let signer2 = InMemorySigner::random_implicit();
+        assert_ne!(signer1.account_id(), signer2.account_id());
     }
 
     #[test]
@@ -1060,7 +1163,7 @@ mod tests {
 
         let signers: Vec<InMemorySigner> = keys
             .into_iter()
-            .map(|sk| InMemorySigner::from_secret_key("bot.testnet".parse().unwrap(), sk))
+            .map(|sk| InMemorySigner::from_secret_key("bot.testnet", sk).unwrap())
             .collect();
 
         let rotating = RotatingSigner::from_signers(signers).unwrap();
@@ -1071,14 +1174,9 @@ mod tests {
     #[test]
     fn test_rotating_signer_from_signers_mismatched_accounts() {
         let signers = vec![
-            InMemorySigner::from_secret_key(
-                "alice.testnet".parse().unwrap(),
-                SecretKey::generate_ed25519(),
-            ),
-            InMemorySigner::from_secret_key(
-                "bob.testnet".parse().unwrap(),
-                SecretKey::generate_ed25519(),
-            ),
+            InMemorySigner::from_secret_key("alice.testnet", SecretKey::generate_ed25519())
+                .unwrap(),
+            InMemorySigner::from_secret_key("bob.testnet", SecretKey::generate_ed25519()).unwrap(),
         ];
 
         let result = RotatingSigner::from_signers(signers);

--- a/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
+++ b/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
@@ -253,7 +253,7 @@ async fn test_sign_with_override() {
         .build();
 
     // Use sign_with to send a transaction from account2
-    let signer2 = InMemorySigner::from_secret_key(account2_id.clone(), key2);
+    let signer2 = InMemorySigner::from_secret_key(account2_id.clone(), key2).unwrap();
 
     let sub_id: AccountId = format!("signwith.{}", account2_id).parse().unwrap();
     near.transaction(&sub_id)


### PR DESCRIPTION
## Summary

- Add `InMemorySigner::implicit(secret_key)` — derives implicit account ID from Ed25519 public key bytes
- Add `InMemorySigner::generate_implicit()` — generates a random Ed25519 key and derives implicit account ID
- Change `from_secret_key` to accept `impl TryIntoAccountId` (breaking: now returns `Result`)
- Consistent with `from_seed_phrase` and other constructors

## Test plan

- [x] 5 new unit tests for implicit constructors and `from_secret_key` accepting strings
- [x] All 35 signer tests pass
- [x] All call sites updated (examples, tests, internal code)

Closes #119