### PR TITLE
feat: add wasm32 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,21 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info
 
+  wasm:
+    name: WASM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: "true"
+      - run: cargo check --target wasm32-unknown-unknown --no-default-features -p near-kit
+
   msrv:
     name: MSRV (1.86)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,3 +63,18 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: "true"
       - run: cargo check --workspace --all-targets
+
+  wasm:
+    name: WASM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: wasm
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-on-failure: "true"
+      - run: cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1709,7 +1721,10 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "futures",
+ "getrandom 0.2.17",
+ "gloo-timers",
  "hex",
+ "js-sys",
  "k256",
  "keyring",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1078,11 +1078,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1090,6 +1092,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "group"
@@ -1840,8 +1854,12 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "futures",
+ "getrandom 0.2.17",
+ "getrandom 0.4.2",
+ "gloo-timers",
  "hex",
  "hmac 0.13.0",
+ "js-sys",
  "k256",
  "keyring",
  "libc",

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -18,8 +18,8 @@ near-account-id.workspace = true
 near-token.workspace = true
 near-gas.workspace = true
 
-# Async runtime
-tokio.workspace = true
+# Async runtime — only pull in `sync`; `time` is added for non-wasm below
+tokio = { version = "1", features = ["sync"] }
 futures.workspace = true
 
 # HTTP client
@@ -44,8 +44,8 @@ k256.workspace = true
 bs58.workspace = true
 hex.workspace = true
 
-# Filesystem
-dirs.workspace = true
+# Filesystem (optional, not available on wasm)
+dirs = { workspace = true, optional = true }
 
 # System keyring (optional)
 keyring = { workspace = true, optional = true }
@@ -64,12 +64,24 @@ testcontainers = { workspace = true, optional = true, features = ["watchdog"] }
 libc = { version = "0.2", optional = true }
 serde_with = { version = "3.17.0", features = ["hex", "base64"] }
 
+# Native-only: tokio timer support for retry backoff
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["sync", "time"] }
+
+# WASM-only: browser-compatible timer, entropy, and time APIs
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-timers = { version = "0.3", features = ["futures"] }
+getrandom = { version = "0.2", features = ["js"] }
+js-sys = "0.3"
+
 [features]
-default = ["keyring"]
+default = ["keyring", "file-signer"]
 sandbox = ["dep:testcontainers", "dep:libc"]
 keyring = ["dep:keyring"]
+file-signer = ["dep:dirs"]
 
 [dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-test.workspace = true
 tempfile.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -76,7 +76,7 @@ js-sys = "0.3"
 
 [features]
 default = ["keyring", "file-signer"]
-sandbox = ["dep:testcontainers", "dep:libc"]
+sandbox = ["dep:testcontainers", "dep:libc", "tokio/rt"]
 keyring = ["dep:keyring"]
 file-signer = ["dep:dirs"]
 

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -81,7 +81,10 @@ keyring = ["dep:keyring"]
 file-signer = ["dep:dirs"]
 
 [dev-dependencies]
-tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 tokio-test.workspace = true
 tempfile.workspace = true
 tracing-subscriber.workspace = true
+wasm-bindgen-test = "0.3"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -17,8 +17,8 @@ near-token.workspace = true
 near-gas.workspace = true
 near-global-contracts.workspace = true
 
-# Async runtime — only pull in `sync` here; `time` is added for native
-# (non-wasm) below, and `rt` is added for native by the `sandbox` feature.
+# Async runtime — only pull in `sync` here; `time` is added below for every
+# target except JS-host wasm, and `rt` is added by the `sandbox` feature.
 tokio = { version = "1", features = ["sync"] }
 futures.workspace = true
 
@@ -45,7 +45,7 @@ k256.workspace = true
 bs58.workspace = true
 hex.workspace = true
 
-# Filesystem (optional; not available on wasm, gated by `file-signer`)
+# Filesystem (optional; gated by `file-signer` — no filesystem on JS-host wasm)
 dirs = { workspace = true, optional = true }
 
 # System keyring (optional)
@@ -65,15 +65,17 @@ testcontainers = { workspace = true, optional = true, features = ["watchdog"] }
 libc = { version = "0.2", optional = true }
 serde_with = { version = "3.20", features = ["hex", "base64"] }
 
-# Native-only: tokio timer support for the RPC retry backoff
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# All targets except JS-host wasm (this includes WASI, which has real OS
+# timers): tokio timer support for the RPC retry backoff.
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
 tokio = { version = "1", features = ["sync", "time"] }
 
-# WASM-only: browser-compatible timer and time APIs. `getrandom`/`getrandom_v04`
-# are entropy backends for the transitive `rand`/`ml-dsa` dependency graphs; their
+# JS-host wasm only (`wasm32-unknown-unknown`, i.e. browsers/Node/Deno — NOT
+# WASI): JS-backed timer and time APIs. `getrandom`/`getrandom_v04` are entropy
+# backends for the transitive `rand`/`ml-dsa` dependency graphs; their
 # `js`/`wasm_js` features are opt-in via the crate's `js` feature (see below) so
-# non-browser wasm runtimes can choose their own backend instead.
-[target.'cfg(target_arch = "wasm32")'.dependencies]
+# non-JS wasm embedders can choose their own backend instead.
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 gloo-timers = { version = "0.3", features = ["futures"] }
 js-sys = "0.3"
 getrandom = { version = "0.2", default-features = false }
@@ -84,11 +86,12 @@ default = ["keyring", "file-signer"]
 sandbox = ["dep:testcontainers", "dep:libc", "tokio/rt"]
 keyring = ["dep:keyring"]
 file-signer = ["dep:dirs"]
-# Browser entropy backend for wasm32 targets. Enables `getrandom`'s `js` feature
-# (used transitively by `rand`/`ed25519-dalek`/`k256`) and `getrandom` 0.4's
-# `wasm_js` feature (used transitively by `ml-dsa`/`sha2`/`hmac` via `digest`).
-# Leave this off if you're targeting a non-browser wasm runtime and want to
-# register your own `getrandom` backend instead.
+# JS-host entropy backend for `wasm32-unknown-unknown`. Enables `getrandom`'s
+# `js` feature (used transitively by `rand`/`ed25519-dalek`/`k256`) and
+# `getrandom` 0.4's `wasm_js` feature (used transitively by
+# `ml-dsa`/`sha2`/`hmac` via `digest`). Leave this off on non-JS wasm embedders
+# (register your own `getrandom` backend) and on WASI targets (which `getrandom`
+# supports natively).
 js = ["getrandom/js", "getrandom_v04/wasm_js"]
 # Enables `interactive-clap` derives on re-exported `NearToken` and `Gas` types.
 # Useful for CLI tools using `interactive-clap` for argument parsing.
@@ -99,7 +102,7 @@ tokio-test.workspace = true
 tempfile.workspace = true
 tracing-subscriber.workspace = true
 
-# Native-only: full tokio runtime for tests and doctests (unified with the
-# minimal `sync`/`time` features from the regular dependency above).
-[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# All targets except JS-host wasm: full tokio runtime for tests and doctests
+# (unified with the minimal `sync`/`time` features from the dependency above).
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -17,8 +17,9 @@ near-token.workspace = true
 near-gas.workspace = true
 near-global-contracts.workspace = true
 
-# Async runtime
-tokio.workspace = true
+# Async runtime — only pull in `sync` here; `time` is added for native
+# (non-wasm) below, and `rt` is added for native by the `sandbox` feature.
+tokio = { version = "1", features = ["sync"] }
 futures.workspace = true
 
 # HTTP client
@@ -44,8 +45,8 @@ k256.workspace = true
 bs58.workspace = true
 hex.workspace = true
 
-# Filesystem
-dirs.workspace = true
+# Filesystem (optional; not available on wasm, gated by `file-signer`)
+dirs = { workspace = true, optional = true }
 
 # System keyring (optional)
 keyring = { workspace = true, optional = true }
@@ -64,10 +65,31 @@ testcontainers = { workspace = true, optional = true, features = ["watchdog"] }
 libc = { version = "0.2", optional = true }
 serde_with = { version = "3.20", features = ["hex", "base64"] }
 
+# Native-only: tokio timer support for the RPC retry backoff
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1", features = ["sync", "time"] }
+
+# WASM-only: browser-compatible timer and time APIs. `getrandom`/`getrandom_v04`
+# are entropy backends for the transitive `rand`/`ml-dsa` dependency graphs; their
+# `js`/`wasm_js` features are opt-in via the crate's `js` feature (see below) so
+# non-browser wasm runtimes can choose their own backend instead.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+gloo-timers = { version = "0.3", features = ["futures"] }
+js-sys = "0.3"
+getrandom = { version = "0.2", default-features = false }
+getrandom_v04 = { package = "getrandom", version = "0.4", default-features = false }
+
 [features]
-default = ["keyring"]
-sandbox = ["dep:testcontainers", "dep:libc"]
+default = ["keyring", "file-signer"]
+sandbox = ["dep:testcontainers", "dep:libc", "tokio/rt"]
 keyring = ["dep:keyring"]
+file-signer = ["dep:dirs"]
+# Browser entropy backend for wasm32 targets. Enables `getrandom`'s `js` feature
+# (used transitively by `rand`/`ed25519-dalek`/`k256`) and `getrandom` 0.4's
+# `wasm_js` feature (used transitively by `ml-dsa`/`sha2`/`hmac` via `digest`).
+# Leave this off if you're targeting a non-browser wasm runtime and want to
+# register your own `getrandom` backend instead.
+js = ["getrandom/js", "getrandom_v04/wasm_js"]
 # Enables `interactive-clap` derives on re-exported `NearToken` and `Gas` types.
 # Useful for CLI tools using `interactive-clap` for argument parsing.
 interactive-clap = ["near-token/interactive-clap", "near-gas/interactive-clap"]
@@ -76,3 +98,8 @@ interactive-clap = ["near-token/interactive-clap", "near-gas/interactive-clap"]
 tokio-test.workspace = true
 tempfile.workspace = true
 tracing-subscriber.workspace = true
+
+# Native-only: full tokio runtime for tests and doctests (unified with the
+# minimal `sync`/`time` features from the regular dependency above).
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/crates/near-kit/src/client/mod.rs
+++ b/crates/near-kit/src/client/mod.rs
@@ -50,7 +50,9 @@ pub use query::{
     AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, ViewCall, ViewCallBorsh,
 };
 pub use rpc::{RetryConfig, RpcClient};
-pub use signer::{EnvSigner, FileSigner, InMemorySigner, RotatingSigner, Signer, SigningKey};
+#[cfg(feature = "file-signer")]
+pub use signer::FileSigner;
+pub use signer::{EnvSigner, InMemorySigner, RotatingSigner, Signer, SigningKey};
 pub use transaction::{
     CallBuilder, DelegateOptions, DelegateResult, FunctionCall, TransactionBuilder, TransactionSend,
 };

--- a/crates/near-kit/src/client/query.rs
+++ b/crates/near-kit/src/client/query.rs
@@ -2,9 +2,8 @@
 //!
 //! All query builders implement `IntoFuture` so they can be `.await`ed directly.
 
-use std::future::{Future, IntoFuture};
+use std::future::IntoFuture;
 use std::marker::PhantomData;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use serde::de::DeserializeOwned;
@@ -80,7 +79,7 @@ impl BalanceQuery {
 
 impl IntoFuture for BalanceQuery {
     type Output = Result<AccountBalance, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -147,7 +146,7 @@ impl AccountQuery {
 
 impl IntoFuture for AccountQuery {
     type Output = Result<AccountView, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -215,7 +214,7 @@ impl AccountExistsQuery {
 
 impl IntoFuture for AccountExistsQuery {
     type Output = Result<bool, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -288,7 +287,7 @@ impl AccessKeysQuery {
 
 impl IntoFuture for AccessKeysQuery {
     type Output = Result<AccessKeyListView, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -427,7 +426,7 @@ impl<T> ViewCall<T> {
 
 impl<T: DeserializeOwned + Send + 'static> IntoFuture for ViewCall<T> {
     type Output = Result<T, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -489,7 +488,7 @@ pub struct ViewCallBorsh<T> {
 
 impl<T: borsh::BorshDeserialize + Send + 'static> IntoFuture for ViewCallBorsh<T> {
     type Output = Result<T, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -3,6 +3,15 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
+/// Platform-appropriate async sleep.
+async fn async_sleep(duration: Duration) {
+    #[cfg(not(target_arch = "wasm32"))]
+    tokio::time::sleep(duration).await;
+
+    #[cfg(target_arch = "wasm32")]
+    gloo_timers::future::sleep(duration).await;
+}
+
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
@@ -184,7 +193,7 @@ impl RpcClient {
                         error = %e,
                         "RPC request failed, retrying"
                     );
-                    tokio::time::sleep(Duration::from_millis(delay)).await;
+                    async_sleep(Duration::from_millis(delay)).await;
                     continue;
                 }
                 Err(e) => {
@@ -676,7 +685,7 @@ impl RpcClient {
             .await?;
 
         // Small delay to allow state to propagate - sandbox patch_state has race conditions
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        async_sleep(std::time::Duration::from_millis(100)).await;
 
         Ok(())
     }

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -15,6 +15,23 @@ use crate::types::{
     ViewFunctionResult, ViewStateResult,
 };
 
+/// Platform-appropriate async sleep, used for retry backoff.
+///
+/// Dispatches to `tokio::time::sleep` on native and `gloo-timers` on wasm32,
+/// since wasm32 has no OS timer APIs and the crate's minimal wasm tokio
+/// feature set doesn't include `time`.
+async fn async_sleep(duration: Duration) {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        tokio::time::sleep(duration).await;
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        gloo_timers::future::sleep(duration).await;
+    }
+}
+
 /// Network configuration presets.
 pub struct NetworkConfig {
     /// The RPC URL for this network.
@@ -184,7 +201,7 @@ impl RpcClient {
                         error = %e,
                         "RPC request failed, retrying"
                     );
-                    tokio::time::sleep(Duration::from_millis(delay)).await;
+                    async_sleep(Duration::from_millis(delay)).await;
                     continue;
                 }
                 Err(e) => {
@@ -888,7 +905,7 @@ impl RpcClient {
             .await?;
 
         // Small delay to allow state to propagate - sandbox patch_state has race conditions
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        async_sleep(std::time::Duration::from_millis(100)).await;
 
         Ok(())
     }

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -17,16 +17,16 @@ use crate::types::{
 
 /// Platform-appropriate async sleep, used for retry backoff.
 ///
-/// Dispatches to `tokio::time::sleep` on native and `gloo-timers` on wasm32,
-/// since wasm32 has no OS timer APIs and the crate's minimal wasm tokio
-/// feature set doesn't include `time`.
+/// Dispatches to `tokio::time::sleep` everywhere except `wasm32-unknown-unknown`,
+/// which has no OS timer APIs and uses the JS host's timers via `gloo-timers`
+/// instead. WASI targets take the tokio path.
 async fn async_sleep(duration: Duration) {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
         tokio::time::sleep(duration).await;
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         gloo_timers::future::sleep(duration).await;
     }

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -31,9 +31,8 @@
 //! # }
 //! ```
 
-use std::future::Future;
+#[cfg(feature = "file-signer")]
 use std::path::Path;
-use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -232,11 +231,11 @@ impl std::fmt::Debug for SigningKey {
 ///
 /// This allows different implementations (in-memory, hardware wallet, KMS)
 /// to provide signing capability.
-trait SigningBackend: Send + Sync {
+trait SigningBackend: crate::platform::MaybeSend + crate::platform::MaybeSync {
     fn sign(
         &self,
         message: &[u8],
-    ) -> Pin<Box<dyn Future<Output = Result<Signature, SignerError>> + Send + '_>>;
+    ) -> crate::platform::BoxFuture<'_, Result<Signature, SignerError>>;
 }
 
 /// In-memory signing backend using a secret key.
@@ -248,7 +247,7 @@ impl SigningBackend for SecretKeyBackend {
     fn sign(
         &self,
         message: &[u8],
-    ) -> Pin<Box<dyn Future<Output = Result<Signature, SignerError>> + Send + '_>> {
+    ) -> crate::platform::BoxFuture<'_, Result<Signature, SignerError>> {
         let sig = self.secret_key.sign(message);
         Box::pin(async move { Ok(sig) })
     }
@@ -461,6 +460,8 @@ impl Signer for InMemorySigner {
 ///
 /// Compatible with credentials created by near-cli and near-cli-rs.
 ///
+/// Requires the `file-signer` feature (enabled by default, not available on wasm).
+///
 /// # Example
 ///
 /// ```rust,no_run
@@ -469,18 +470,21 @@ impl Signer for InMemorySigner {
 /// // Load from ~/.near-credentials/testnet/alice.testnet.json
 /// let signer = FileSigner::new("testnet", "alice.testnet").unwrap();
 /// ```
+#[cfg(feature = "file-signer")]
 #[derive(Clone)]
 pub struct FileSigner {
     inner: InMemorySigner,
 }
 
 /// Credential file format compatible with near-cli.
+#[cfg(feature = "file-signer")]
 #[derive(serde::Deserialize)]
 struct CredentialFile {
     #[serde(alias = "secret_key")]
     private_key: String,
 }
 
+#[cfg(feature = "file-signer")]
 impl FileSigner {
     /// Load credentials for an account from the standard NEAR credentials directory.
     ///
@@ -554,6 +558,7 @@ impl FileSigner {
     }
 }
 
+#[cfg(feature = "file-signer")]
 impl std::fmt::Debug for FileSigner {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FileSigner")
@@ -563,6 +568,7 @@ impl std::fmt::Debug for FileSigner {
     }
 }
 
+#[cfg(feature = "file-signer")]
 impl Signer for FileSigner {
     fn account_id(&self) -> &AccountId {
         self.inner.account_id()

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -899,7 +899,7 @@ impl Signer for RotatingSigner {
 // Tests
 // ============================================================================
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use crate::types::{Action, CryptoHash, NearToken, Transaction};

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -460,7 +460,8 @@ impl Signer for InMemorySigner {
 ///
 /// Compatible with credentials created by near-cli and near-cli-rs.
 ///
-/// Requires the `file-signer` feature (enabled by default, not available on wasm).
+/// Requires the `file-signer` feature (enabled by default; not usable on
+/// `wasm32-unknown-unknown`, which has no filesystem).
 ///
 /// # Example
 ///

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -29,8 +29,7 @@
 //! ```
 
 use std::fmt;
-use std::future::{Future, IntoFuture};
-use std::pin::Pin;
+use std::future::IntoFuture;
 use std::sync::{Arc, OnceLock};
 
 use tracing::Instrument;
@@ -1234,7 +1233,7 @@ impl CallBuilder {
 
 impl IntoFuture for CallBuilder {
     type Output = Result<FinalExecutionOutcome, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         self.send().into_future()
@@ -1267,7 +1266,7 @@ impl TransactionSend {
 
 impl IntoFuture for TransactionSend {
     type Output = Result<FinalExecutionOutcome, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -1425,7 +1424,7 @@ impl IntoFuture for TransactionSend {
 
 impl IntoFuture for TransactionBuilder {
     type Output = Result<FinalExecutionOutcome, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         self.send().into_future()

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -29,8 +29,7 @@
 //! ```
 
 use std::fmt;
-use std::future::{Future, IntoFuture};
-use std::pin::Pin;
+use std::future::IntoFuture;
 use std::sync::{Arc, OnceLock};
 
 use tracing::Instrument;
@@ -1463,7 +1462,7 @@ impl CallBuilder {
 
 impl IntoFuture for CallBuilder {
     type Output = Result<FinalExecutionOutcome, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         self.send().into_future()
@@ -1525,7 +1524,7 @@ impl<W: WaitLevel> TransactionSend<W> {
 
 impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
     type Output = Result<W::Response, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         Box::pin(async move {
@@ -1676,7 +1675,7 @@ impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
 
 impl IntoFuture for TransactionBuilder {
     type Output = Result<FinalExecutionOutcome, Error>;
-    type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
 
     fn into_future(self) -> Self::IntoFuture {
         self.send().into_future()

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -294,7 +294,18 @@ impl RpcError {
     /// Check if this error is retryable.
     pub fn is_retryable(&self) -> bool {
         match self {
-            RpcError::Http(e) => e.is_timeout() || e.is_connect(),
+            RpcError::Http(e) => {
+                e.is_timeout() || {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        e.is_connect()
+                    }
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        false
+                    }
+                }
+            }
             RpcError::Timeout(_) => true,
             RpcError::Network { retryable, .. } => *retryable,
             RpcError::ShardUnavailable(_) => true,

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -295,6 +295,8 @@ impl RpcError {
     pub fn is_retryable(&self) -> bool {
         match self {
             RpcError::Http(e) => {
+                // is_connect() is unavailable on wasm (no hyper backend);
+                // is_request() covers transport-level failures on both platforms
                 e.is_timeout() || {
                     #[cfg(not(target_arch = "wasm32"))]
                     {
@@ -302,7 +304,7 @@ impl RpcError {
                     }
                     #[cfg(target_arch = "wasm32")]
                     {
-                        false
+                        e.is_request()
                     }
                 }
             }

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -294,7 +294,21 @@ impl RpcError {
     /// Check if this error is retryable.
     pub fn is_retryable(&self) -> bool {
         match self {
-            RpcError::Http(e) => e.is_timeout() || e.is_connect(),
+            RpcError::Http(e) => {
+                // `is_connect()` is unavailable on the wasm fetch backend (no hyper
+                // connector); `is_request()` covers transport-level failures there
+                // (e.g. offline, DNS, connection reset) so retries still work.
+                e.is_timeout() || {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    {
+                        e.is_connect()
+                    }
+                    #[cfg(target_arch = "wasm32")]
+                    {
+                        e.is_request()
+                    }
+                }
+            }
             RpcError::Timeout(_) => true,
             RpcError::Network { retryable, .. } => *retryable,
             RpcError::ShardUnavailable(_) => true,

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -295,15 +295,16 @@ impl RpcError {
     pub fn is_retryable(&self) -> bool {
         match self {
             RpcError::Http(e) => {
-                // `is_connect()` is unavailable on the wasm fetch backend (no hyper
-                // connector); `is_request()` covers transport-level failures there
-                // (e.g. offline, DNS, connection reset) so retries still work.
+                // `is_connect()` doesn't exist on reqwest's JS fetch backend
+                // (`wasm32-unknown-unknown` — no hyper connector); `is_request()`
+                // covers transport-level failures there (e.g. offline, DNS,
+                // connection reset) so retries still work.
                 e.is_timeout() || {
-                    #[cfg(not(target_arch = "wasm32"))]
+                    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
                     {
                         e.is_connect()
                     }
-                    #[cfg(target_arch = "wasm32")]
+                    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
                     {
                         e.is_request()
                     }

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -359,10 +359,13 @@
 //!
 //! ## Feature Flags
 //!
-//! | Feature | Description |
-//! |---------|-------------|
-//! | `sandbox` | Integration with `near-sandbox` for local testing |
-//! | `keyring` | System keyring signer (macOS Keychain, Windows Credential Manager, etc.) |
+//! | Feature | Default | Description |
+//! |---------|---------|-------------|
+//! | `file-signer` | Yes | [`FileSigner`] for loading keys from `~/.near-credentials` |
+//! | `keyring` | Yes | System keyring signer (macOS Keychain, Windows Credential Manager, etc.) |
+//! | `sandbox` | No | Integration with `near-sandbox` for local testing |
+//!
+//! For `wasm32` targets, use `default-features = false` to disable `file-signer` and `keyring`.
 //!
 //! ## Error Handling
 //!

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -389,6 +389,7 @@
 pub mod client;
 pub mod contract;
 pub mod error;
+mod platform;
 pub mod tokens;
 pub mod types;
 
@@ -407,10 +408,13 @@ pub use contract::{Contract, ContractClient};
 // Re-export client types
 pub use client::{
     AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, CallBuilder, DelegateOptions,
-    DelegateResult, EnvSigner, FileSigner, FunctionCall, InMemorySigner, Near, NearBuilder,
-    RetryConfig, RotatingSigner, RpcClient, SandboxNetwork, Signer, SigningKey, TransactionBuilder,
+    DelegateResult, EnvSigner, FunctionCall, InMemorySigner, Near, NearBuilder, RetryConfig,
+    RotatingSigner, RpcClient, SandboxNetwork, Signer, SigningKey, TransactionBuilder,
     TransactionSend, ViewCall, ViewCallBorsh,
 };
+
+#[cfg(feature = "file-signer")]
+pub use client::FileSigner;
 
 #[cfg(feature = "keyring")]
 pub use client::KeyringSigner;

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -375,10 +375,31 @@
 //! ```
 //!
 //! If you're running `wasm32-unknown-unknown` outside a JS host, leave `js` off and
-//! register your own `getrandom` backend following the
-//! [`getrandom` docs](https://docs.rs/getrandom) instead — forcing the browser backend
-//! would break your runtime. (WASI targets like `wasm32-wasip1` don't need any of
-//! this: `getrandom` supports them natively, so leave `js` off there too.)
+//! register your own `getrandom` backend instead (see below) — forcing the browser
+//! backend would break your runtime. (WASI targets like `wasm32-wasip1` don't need any
+//! of this: `getrandom` supports them natively, so leave `js` off there too.)
+//!
+//! ### Custom entropy backends
+//!
+//! Non-JS `wasm32-unknown-unknown` embedders must provide entropy for both `getrandom`
+//! major versions in near-kit's dependency graph: 0.2 (via `rand`/`ed25519-dalek`/`k256`)
+//! and 0.4 (via `ml-dsa`/`sha2`/`hmac`).
+//!
+//! ```toml
+//! [dependencies]
+//! near-kit = { version = "0.12", default-features = false }
+//! getrandom = { version = "0.2", features = ["custom"] }
+//! ```
+//!
+//! For getrandom 0.2, the `custom` feature suppresses its wasm compile error; register
+//! your entropy function with its `register_custom_getrandom!` macro. For getrandom 0.4,
+//! build with `RUSTFLAGS='--cfg getrandom_backend="custom"'` and export an `extern
+//! "Rust"` fn named `__getrandom_v03_custom` returning `Result<(), getrandom::Error>` —
+//! note the `v03`: getrandom 0.4 kept the 0.3 symbol name, so `_v04_` won't link. See
+//! the [`getrandom` docs](https://docs.rs/getrandom) for the exact signature. If your
+//! application never generates keys or nonces, `--cfg getrandom_backend="unsupported"`
+//! also works for 0.4: it compiles everywhere and errors at runtime if entropy is ever
+//! requested.
 //!
 //! ## Feature Flags
 //!

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -364,19 +364,21 @@
 //! APIs unavailable in the browser); use [`InMemorySigner`] or [`EnvSigner`] instead.
 //!
 //! `near-kit` relies on `getrandom` (via `rand`, `ed25519-dalek`, `k256`, and `ml-dsa`)
-//! for key generation and nonce randomness. On `wasm32`, `getrandom` requires the
-//! embedder to pick an entropy backend. If your wasm target runs in a browser, enable
-//! the `js` feature to use the browser's `crypto.getRandomValues`:
+//! for key generation and nonce randomness. On `wasm32-unknown-unknown`, `getrandom`
+//! requires the embedder to pick an entropy backend. If your wasm target runs in a
+//! browser (or another JS host like Node or Deno), enable the `js` feature to use the
+//! host's `crypto.getRandomValues`:
 //!
 //! ```toml
 //! [dependencies]
 //! near-kit = { version = "0.12", default-features = false, features = ["js"] }
 //! ```
 //!
-//! If you're targeting a non-browser wasm runtime (e.g. a custom host, or
-//! `wasm32-wasip1`), leave `js` off and register your own `getrandom` backend
-//! following the [`getrandom` docs](https://docs.rs/getrandom) instead — forcing the
-//! browser backend would break your runtime.
+//! If you're running `wasm32-unknown-unknown` outside a JS host, leave `js` off and
+//! register your own `getrandom` backend following the
+//! [`getrandom` docs](https://docs.rs/getrandom) instead — forcing the browser backend
+//! would break your runtime. (WASI targets like `wasm32-wasip1` don't need any of
+//! this: `getrandom` supports them natively, so leave `js` off there too.)
 //!
 //! ## Feature Flags
 //!
@@ -385,7 +387,7 @@
 //! | `keyring` | Yes | System keyring signer (macOS Keychain, Windows Credential Manager, etc.) |
 //! | `file-signer` | Yes | [`FileSigner`] for loading keys from `~/.near-credentials` |
 //! | `sandbox` | No | Integration with `near-sandbox` for local testing |
-//! | `js` | No | Browser entropy backend (`getrandom`'s `js`/`wasm_js`) for `wasm32` targets |
+//! | `js` | No | JS-host entropy backend (`getrandom`'s `js`/`wasm_js`) for `wasm32-unknown-unknown` |
 //!
 //! ## Error Handling
 //!

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -357,12 +357,35 @@
 //! }
 //! ```
 //!
+//! ## WebAssembly support
+//!
+//! `near-kit` compiles for `wasm32-unknown-unknown` (Dioxus, Leptos, Yew, etc.) with
+//! `default-features = false`. This disables `keyring` and `file-signer` (both use OS
+//! APIs unavailable in the browser); use [`InMemorySigner`] or [`EnvSigner`] instead.
+//!
+//! `near-kit` relies on `getrandom` (via `rand`, `ed25519-dalek`, `k256`, and `ml-dsa`)
+//! for key generation and nonce randomness. On `wasm32`, `getrandom` requires the
+//! embedder to pick an entropy backend. If your wasm target runs in a browser, enable
+//! the `js` feature to use the browser's `crypto.getRandomValues`:
+//!
+//! ```toml
+//! [dependencies]
+//! near-kit = { version = "0.12", default-features = false, features = ["js"] }
+//! ```
+//!
+//! If you're targeting a non-browser wasm runtime (e.g. a custom host, or
+//! `wasm32-wasip1`), leave `js` off and register your own `getrandom` backend
+//! following the [`getrandom` docs](https://docs.rs/getrandom) instead — forcing the
+//! browser backend would break your runtime.
+//!
 //! ## Feature Flags
 //!
-//! | Feature | Description |
-//! |---------|-------------|
-//! | `sandbox` | Integration with `near-sandbox` for local testing |
-//! | `keyring` | System keyring signer (macOS Keychain, Windows Credential Manager, etc.) |
+//! | Feature | Default | Description |
+//! |---------|---------|-------------|
+//! | `keyring` | Yes | System keyring signer (macOS Keychain, Windows Credential Manager, etc.) |
+//! | `file-signer` | Yes | [`FileSigner`] for loading keys from `~/.near-credentials` |
+//! | `sandbox` | No | Integration with `near-sandbox` for local testing |
+//! | `js` | No | Browser entropy backend (`getrandom`'s `js`/`wasm_js`) for `wasm32` targets |
 //!
 //! ## Error Handling
 //!
@@ -389,6 +412,7 @@
 pub mod client;
 pub mod contract;
 pub mod error;
+mod platform;
 pub mod tokens;
 pub mod types;
 
@@ -407,10 +431,13 @@ pub use contract::{Contract, ContractClient};
 // Re-export client types
 pub use client::{
     AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, CallBuilder, DelegateOptions,
-    DelegateResult, EnvSigner, FileSigner, FunctionCall, InMemorySigner, Near, NearBuilder,
-    RetryConfig, RotatingSigner, RpcClient, SandboxNetwork, Signer, SigningKey, TransactionBuilder,
+    DelegateResult, EnvSigner, FunctionCall, InMemorySigner, Near, NearBuilder, RetryConfig,
+    RotatingSigner, RpcClient, SandboxNetwork, Signer, SigningKey, TransactionBuilder,
     TransactionSend, ViewCall, ViewCallBorsh,
 };
+
+#[cfg(feature = "file-signer")]
+pub use client::FileSigner;
 
 #[cfg(feature = "keyring")]
 pub use client::KeyringSigner;

--- a/crates/near-kit/src/platform.rs
+++ b/crates/near-kit/src/platform.rs
@@ -1,0 +1,37 @@
+//! Platform-conditional trait bounds for wasm32 compatibility.
+//!
+//! On native targets, futures must be `Send` and trait objects must be `Send + Sync`.
+//! On wasm32, there are no threads, so these bounds are unnecessary (and often
+//! impossible to satisfy with browser APIs).
+
+use std::future::Future;
+use std::pin::Pin;
+
+/// A boxed future that is `Send` on native and `!Send` on wasm32.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+/// Trait alias: `Send` on native, unconditional on wasm32.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) trait MaybeSend: Send {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send> MaybeSend for T {}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) trait MaybeSend {}
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSend for T {}
+
+/// Trait alias: `Sync` on native, unconditional on wasm32.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) trait MaybeSync: Sync {}
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Sync> MaybeSync for T {}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) trait MaybeSync {}
+#[cfg(target_arch = "wasm32")]
+impl<T> MaybeSync for T {}

--- a/crates/near-kit/src/platform.rs
+++ b/crates/near-kit/src/platform.rs
@@ -1,37 +1,40 @@
-//! Platform-conditional trait bounds for wasm32 compatibility.
+//! Platform-conditional trait bounds for JS-host wasm compatibility.
 //!
-//! On native targets, futures must be `Send` and trait objects must be `Send + Sync`.
-//! On wasm32, there are no threads, so these bounds are unnecessary (and often
-//! impossible to satisfy with browser APIs).
+//! On most targets, futures must be `Send` and trait objects must be `Send + Sync`.
+//! On `wasm32-unknown-unknown` (browsers and other JS hosts), there are no threads,
+//! so these bounds are unnecessary (and often impossible to satisfy with browser
+//! APIs). WASI targets (`wasm32-wasip1`/`p2`) keep the regular bounds.
 
 use std::future::Future;
 use std::pin::Pin;
 
-/// A boxed future that is `Send` on native and `!Send` on wasm32.
-#[cfg(not(target_arch = "wasm32"))]
+/// A boxed future that is `Send` everywhere except `wasm32-unknown-unknown`.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
-/// Trait alias: `Send` on native, unconditional on wasm32.
-#[cfg(not(target_arch = "wasm32"))]
+/// Trait alias: `Send` everywhere except `wasm32-unknown-unknown`, where it's
+/// unconditional.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub(crate) trait MaybeSend: Send {}
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 impl<T: Send> MaybeSend for T {}
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) trait MaybeSend {}
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl<T> MaybeSend for T {}
 
-/// Trait alias: `Sync` on native, unconditional on wasm32.
-#[cfg(not(target_arch = "wasm32"))]
+/// Trait alias: `Sync` everywhere except `wasm32-unknown-unknown`, where it's
+/// unconditional.
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 pub(crate) trait MaybeSync: Sync {}
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 impl<T: Sync> MaybeSync for T {}
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 pub(crate) trait MaybeSync {}
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl<T> MaybeSync for T {}

--- a/crates/near-kit/src/types/nep413.rs
+++ b/crates/near-kit/src/types/nep413.rs
@@ -251,10 +251,15 @@ pub fn generate_nonce() -> [u8; 32] {
     let mut nonce = [0u8; 32];
 
     // First 8 bytes: timestamp (ms since epoch) as big-endian u64
+    #[cfg(not(target_arch = "wasm32"))]
     let timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("Time went backwards")
         .as_millis() as u64;
+
+    #[cfg(target_arch = "wasm32")]
+    let timestamp = js_sys::Date::now() as u64;
+
     nonce[..8].copy_from_slice(&timestamp.to_be_bytes());
 
     // Remaining 24 bytes: random data

--- a/crates/near-kit/src/types/nep413.rs
+++ b/crates/near-kit/src/types/nep413.rs
@@ -302,9 +302,10 @@ impl Default for VerifyOptions {
 /// Current time in milliseconds since the Unix epoch.
 ///
 /// `std::time::SystemTime::now()` panics on `wasm32-unknown-unknown` (there's no OS
-/// clock without a JS shim), so wasm32 uses `js_sys::Date::now()` instead.
+/// clock without a JS shim), so that target uses `js_sys::Date::now()` instead.
+/// WASI targets have a real clock and take the `SystemTime` path.
 fn now_millis() -> u64 {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
     {
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -312,7 +313,7 @@ fn now_millis() -> u64 {
             .as_millis() as u64
     }
 
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
     {
         js_sys::Date::now() as u64
     }

--- a/crates/near-kit/src/types/nep413.rs
+++ b/crates/near-kit/src/types/nep413.rs
@@ -299,6 +299,25 @@ impl Default for VerifyOptions {
 // Core Functions
 // ============================================================================
 
+/// Current time in milliseconds since the Unix epoch.
+///
+/// `std::time::SystemTime::now()` panics on `wasm32-unknown-unknown` (there's no OS
+/// clock without a JS shim), so wasm32 uses `js_sys::Date::now()` instead.
+fn now_millis() -> u64 {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_millis() as u64
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        js_sys::Date::now() as u64
+    }
+}
+
 /// Generate a 32-byte nonce with an embedded timestamp for expiration checking.
 ///
 /// The nonce structure:
@@ -322,10 +341,7 @@ pub fn generate_nonce() -> [u8; 32] {
     let mut nonce = [0u8; 32];
 
     // First 8 bytes: timestamp (ms since epoch) as big-endian u64
-    let timestamp = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .expect("Time went backwards")
-        .as_millis() as u64;
+    let timestamp = now_millis();
     nonce[..8].copy_from_slice(&timestamp.to_be_bytes());
 
     // Remaining 24 bytes: random data
@@ -426,10 +442,7 @@ pub fn verify_signature(
     // Check timestamp expiration if the nonce follows the near-kit timestamp convention
     if let NonceValidation::Timestamp { max_age } = nonce_validation.into() {
         let timestamp_ms = extract_timestamp_from_nonce(&params.nonce);
-        let now_ms = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("Time went backwards")
-            .as_millis() as u64;
+        let now_ms = now_millis();
 
         let age_ms = now_ms.saturating_sub(timestamp_ms);
 

--- a/crates/near-kit/tests/wasm.rs
+++ b/crates/near-kit/tests/wasm.rs
@@ -1,0 +1,56 @@
+//! WASM integration tests — run with:
+//!
+//! ```sh
+//! wasm-pack test --headless --chrome --no-default-features -p near-kit
+//! ```
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+use near_kit::{Near, NearToken};
+
+#[wasm_bindgen_test]
+async fn test_view_balance() {
+    let near = Near::testnet().build();
+    let balance = near.balance("near.testnet").await.unwrap();
+    // near.testnet is a system account, should always have some balance
+    assert!(balance.available > NearToken::from_near(0));
+}
+
+#[wasm_bindgen_test]
+async fn test_view_call() {
+    let near = Near::testnet().build();
+    let exists = near.account_exists("near.testnet").await.unwrap();
+    assert!(exists);
+}
+
+#[wasm_bindgen_test]
+async fn test_account_not_found() {
+    let near = Near::testnet().build();
+    let exists = near
+        .account_exists("this-account-definitely-does-not-exist-12345.testnet")
+        .await
+        .unwrap();
+    assert!(!exists);
+}
+
+#[wasm_bindgen_test]
+fn test_key_generation() {
+    // Crypto operations (key gen uses OsRng → getrandom/js on wasm)
+    let key = near_kit::SecretKey::generate_ed25519();
+    let public = key.public_key();
+    assert!(public.to_string().starts_with("ed25519:"));
+}
+
+#[wasm_bindgen_test]
+fn test_nonce_generation() {
+    // Tests both js_sys::Date::now() and OsRng on wasm
+    let nonce = near_kit::nep413::generate_nonce();
+    assert_eq!(nonce.len(), 32);
+    // Timestamp portion should be non-zero
+    let ts = near_kit::nep413::extract_timestamp_from_nonce(&nonce);
+    assert!(ts > 0);
+}


### PR DESCRIPTION
## Summary

Reimplemented from scratch on top of latest `main` (the original branch was ~76 commits behind). Same goal as before — `near-kit` compiles for `wasm32-unknown-unknown` (Dioxus, Leptos, Yew, etc.) — with one design change based on review feedback.

### What changed vs. the original approach

Per @mitinarseny's feedback, the browser entropy backend is no longer force-enabled. There's now an **opt-in `js` feature** that enables `getrandom/js` and `getrandom@0.4`'s `wasm_js` (both getrandom majors are in the wasm dependency graph now — 0.2 via `rand`/`ed25519-dalek`/`k256`, 0.4 via `ml-dsa`/`sha2`/`hmac` through `crypto-common`). Browser users enable one feature; non-browser wasm runtimes leave it off and register their own getrandom backend.

### Implementation (largely as before, rebuilt against current main)

- `platform` module with conditional `BoxFuture`/`MaybeSend`/`MaybeSync` (wasm is single-threaded, so no `Send` bounds there)
- Tokio slimmed to `sync` everywhere + `time` native-only; `sandbox` feature adds `tokio/rt` (it uses `runtime::Builder`)
- `async_sleep` dispatching to `tokio::time::sleep` (native) / `gloo-timers` (wasm) — used in the RPC retry backoff and `sandbox_patch_state`
- `js_sys::Date::now()` for NEP-413 nonce timestamps on wasm (`SystemTime::now()` panics there); this now also covers the expiry check in `verify_signature()` added by #237
- `FileSigner` gated behind a new default-on `file-signer` feature (`dirs` + `std::fs` don't exist on wasm)
- `is_retryable()` uses `is_request()` on wasm instead of `is_connect()` (unavailable on the fetch backend) so transport errors still retry
- CI job: `cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js`

Dropped the old `tests/wasm.rs` — it was a `wasm-pack`/headless-Chrome suite hitting live testnet that nothing in CI ever ran.

## Usage

```toml
# Browser (Dioxus, Leptos, Yew, ...)
near-kit = { version = "0.12", default-features = false, features = ["js"] }

# Non-browser wasm runtime: leave `js` off and register your own getrandom backend
near-kit = { version = "0.12", default-features = false }
```

Native usage is unchanged — `keyring` and `file-signer` are both on by default.

## Test plan

- [x] `cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js` compiles clean
- [x] `cargo check -p near-kit` (native, defaults) and `--no-default-features` (native) compile clean
- [x] `cargo test -p near-kit` — 500 unit + 129 doctests, 0 failed
- [x] clippy (`--workspace --all-targets --all-features`, `-Dwarnings`) + rustfmt clean
- [x] MSRV: `cargo +1.88 check --workspace --all-targets` passes
- [ ] CI green including new wasm job
