### PR TITLE
fix: return Option<FinalExecutionOutcome> for non-executed wait levels

### DIFF
--- a/crates/near-kit/examples/meta_transactions.rs
+++ b/crates/near-kit/examples/meta_transactions.rs
@@ -62,7 +62,8 @@ async fn relayer_submits_delegate(
         .transaction(delegate_result.sender_id())
         .signed_delegate_action(delegate_result.signed_delegate_action)
         .send()
-        .await?;
+        .await?
+        .expect("ExecutedOptimistic guarantees an execution outcome");
 
     println!(
         "Relayer submitted transaction: {:?}",

--- a/crates/near-kit/examples/quickstart.rs
+++ b/crates/near-kit/examples/quickstart.rs
@@ -50,7 +50,8 @@ async fn call_example(near: &Near) -> Result<(), Error> {
         .call("guestbook.near-examples.testnet", "add_message")
         .args(serde_json::json!({ "text": "Hello from near-kit-rs!" }))
         .gas(Gas::from_tgas(30))
-        .await?;
+        .await?
+        .expect("default wait level guarantees an execution outcome");
 
     println!("Transaction: {:?}", outcome.transaction_hash());
 
@@ -67,7 +68,8 @@ async fn transfer_example(near: &Near) -> Result<(), Error> {
     // Transfer using typed amount
     let outcome = near
         .transfer("friend.testnet", NearToken::from_millinear(100))
-        .await?;
+        .await?
+        .expect("default wait level guarantees an execution outcome");
 
     println!("Sent 0.1 NEAR: {:?}", outcome.transaction_hash());
 
@@ -94,7 +96,8 @@ async fn transaction_example(near: &Near, new_account: &str) -> Result<(), Error
         .transfer(NearToken::from_near(1))
         .add_full_access_key(keypair.public_key)
         .send()
-        .await?;
+        .await?
+        .expect("default wait level guarantees an execution outcome");
 
     println!("Transaction: {:?}", outcome.transaction_hash());
 

--- a/crates/near-kit/examples/rotating_signer.rs
+++ b/crates/near-kit/examples/rotating_signer.rs
@@ -90,7 +90,7 @@ async fn high_throughput_example() -> Result<(), Error> {
         })
         .collect();
 
-    let results: Vec<Result<FinalExecutionOutcome, Error>> =
+    let results: Vec<Result<Option<FinalExecutionOutcome>, Error>> =
         futures::future::join_all(futures).await;
     let duration = start.elapsed();
 

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -825,31 +825,36 @@ impl Near {
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
         self.send_with_options(signed_tx, TxExecutionStatus::ExecutedOptimistic)
             .await
+            .map(|opt| opt.expect("ExecutedOptimistic guarantees an execution outcome"))
     }
 
     /// Send a pre-signed transaction with custom wait options.
+    ///
+    /// Returns `Ok(None)` when `wait_until` is a non-executed level
+    /// (`None`, `Included`, `IncludedFinal`) and the RPC does not return an
+    /// execution outcome. This is expected — the transaction was accepted but
+    /// has not yet been executed. Use [`send`](Self::send) if you always want
+    /// an outcome (it defaults to `ExecutedOptimistic`).
     pub async fn send_with_options(
         &self,
         signed_tx: &crate::types::SignedTransaction,
         wait_until: TxExecutionStatus,
-    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
+    ) -> Result<Option<crate::types::FinalExecutionOutcome>, Error> {
         let response = self.rpc.send_tx(signed_tx, wait_until).await?;
-        let outcome = response.outcome.ok_or_else(|| {
-            Error::InvalidTransaction(format!(
-                "Transaction {} submitted with wait_until={:?} but no execution outcome \
-                 was returned. Use rpc().send_tx() for fire-and-forget submission.",
-                response.transaction_hash, wait_until,
-            ))
-        })?;
 
-        // Only InvalidTxError becomes Err — action errors return Ok(outcome)
+        let outcome = match response.outcome {
+            Some(outcome) => outcome,
+            None => return Ok(None),
+        };
+
+        // Only InvalidTxError becomes Err — action errors return Ok(Some(outcome))
         // so callers can inspect the full outcome via is_failure()/failure_message().
         use crate::types::{FinalExecutionStatus, TxExecutionError};
         match outcome.status {
             FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(e)) => {
                 Err(Error::InvalidTx(Box::new(e)))
             }
-            _ => Ok(outcome),
+            _ => Ok(Some(outcome)),
         }
     }
 
@@ -877,7 +882,10 @@ impl Near {
         method: &str,
         args: &A,
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        self.call(contract_id, method).args(args).await
+        self.call(contract_id, method)
+            .args(args)
+            .await
+            .map(|opt| opt.expect("ExecutedOptimistic guarantees an execution outcome"))
     }
 
     /// Call a function with full options (convenience method).
@@ -894,6 +902,7 @@ impl Near {
             .gas(gas)
             .deposit(deposit)
             .await
+            .map(|opt| opt.expect("ExecutedOptimistic guarantees an execution outcome"))
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -844,7 +844,14 @@ impl Near {
 
         let outcome = match response.outcome {
             Some(outcome) => outcome,
-            None => return Ok(None),
+            None if !wait_until.is_executed() => return Ok(None),
+            None => {
+                return Err(Error::InvalidTransaction(format!(
+                    "Transaction {} submitted with wait_until={:?} but no execution outcome \
+                     was returned by the RPC.",
+                    response.transaction_hash, wait_until,
+                )));
+            }
         };
 
         // Only InvalidTxError becomes Err — action errors return Ok(Some(outcome))

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -14,7 +14,7 @@ use crate::types::{
 use super::query::{AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, ViewCall};
 use super::rpc::{MAINNET, RetryConfig, RpcClient, TESTNET};
 use super::signer::{InMemorySigner, Signer};
-use super::transaction::{CallBuilder, TransactionBuilder};
+use super::transaction::{CallBuilder, TransactionBuilder, process_send_response, require_outcome};
 use crate::types::TxExecutionStatus;
 
 /// Trait for sandbox network configuration.
@@ -823,15 +823,10 @@ impl Near {
         &self,
         signed_tx: &crate::types::SignedTransaction,
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        self.send_with_options(signed_tx, TxExecutionStatus::ExecutedOptimistic)
-            .await
-            .and_then(|opt| {
-                opt.ok_or_else(|| {
-                    Error::InvalidTransaction(
-                        "RPC returned no execution outcome for ExecutedOptimistic".to_string(),
-                    )
-                })
-            })
+        require_outcome(
+            self.send_with_options(signed_tx, TxExecutionStatus::ExecutedOptimistic)
+                .await,
+        )
     }
 
     /// Send a pre-signed transaction with custom wait options.
@@ -847,28 +842,7 @@ impl Near {
         wait_until: TxExecutionStatus,
     ) -> Result<Option<crate::types::FinalExecutionOutcome>, Error> {
         let response = self.rpc.send_tx(signed_tx, wait_until).await?;
-
-        let outcome = match response.outcome {
-            Some(outcome) => outcome,
-            None if !wait_until.is_executed() => return Ok(None),
-            None => {
-                return Err(Error::InvalidTransaction(format!(
-                    "Transaction {} submitted with wait_until={:?} but no execution outcome \
-                     was returned by the RPC.",
-                    response.transaction_hash, wait_until,
-                )));
-            }
-        };
-
-        // Only InvalidTxError becomes Err — action errors return Ok(Some(outcome))
-        // so callers can inspect the full outcome via is_failure()/failure_message().
-        use crate::types::{FinalExecutionStatus, TxExecutionError};
-        match outcome.status {
-            FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(e)) => {
-                Err(Error::InvalidTx(Box::new(e)))
-            }
-            _ => Ok(Some(outcome)),
-        }
+        process_send_response(response, wait_until)
     }
 
     // ========================================================================
@@ -895,16 +869,7 @@ impl Near {
         method: &str,
         args: &A,
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        self.call(contract_id, method)
-            .args(args)
-            .await
-            .and_then(|opt| {
-                opt.ok_or_else(|| {
-                    Error::InvalidTransaction(
-                        "RPC returned no execution outcome for ExecutedOptimistic".to_string(),
-                    )
-                })
-            })
+        require_outcome(self.call(contract_id, method).args(args).await)
     }
 
     /// Call a function with full options (convenience method).
@@ -916,18 +881,13 @@ impl Near {
         gas: Gas,
         deposit: NearToken,
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        self.call(contract_id, method)
-            .args(args)
-            .gas(gas)
-            .deposit(deposit)
-            .await
-            .and_then(|opt| {
-                opt.ok_or_else(|| {
-                    Error::InvalidTransaction(
-                        "RPC returned no execution outcome for ExecutedOptimistic".to_string(),
-                    )
-                })
-            })
+        require_outcome(
+            self.call(contract_id, method)
+                .args(args)
+                .gas(gas)
+                .deposit(deposit)
+                .await,
+        )
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -825,7 +825,13 @@ impl Near {
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
         self.send_with_options(signed_tx, TxExecutionStatus::ExecutedOptimistic)
             .await
-            .map(|opt| opt.expect("ExecutedOptimistic guarantees an execution outcome"))
+            .and_then(|opt| {
+                opt.ok_or_else(|| {
+                    Error::InvalidTransaction(
+                        "RPC returned no execution outcome for ExecutedOptimistic".to_string(),
+                    )
+                })
+            })
     }
 
     /// Send a pre-signed transaction with custom wait options.
@@ -892,7 +898,13 @@ impl Near {
         self.call(contract_id, method)
             .args(args)
             .await
-            .map(|opt| opt.expect("ExecutedOptimistic guarantees an execution outcome"))
+            .and_then(|opt| {
+                opt.ok_or_else(|| {
+                    Error::InvalidTransaction(
+                        "RPC returned no execution outcome for ExecutedOptimistic".to_string(),
+                    )
+                })
+            })
     }
 
     /// Call a function with full options (convenience method).
@@ -909,7 +921,13 @@ impl Near {
             .gas(gas)
             .deposit(deposit)
             .await
-            .map(|opt| opt.expect("ExecutedOptimistic guarantees an execution outcome"))
+            .and_then(|opt| {
+                opt.ok_or_else(|| {
+                    Error::InvalidTransaction(
+                        "RPC returned no execution outcome for ExecutedOptimistic".to_string(),
+                    )
+                })
+            })
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -47,6 +47,54 @@ use super::nonce_manager::NonceManager;
 use super::rpc::RpcClient;
 use super::signer::Signer;
 
+/// Extract and validate the execution outcome from a send_tx RPC response.
+///
+/// - Returns `Ok(Some(outcome))` when an outcome is present and valid.
+/// - Returns `Ok(None)` when the outcome is absent and `wait_until` is a
+///   non-executed level (`None`, `Included`, `IncludedFinal`).
+/// - Returns `Err(InvalidTx)` if the outcome contains an `InvalidTxError`.
+/// - Returns `Err(InvalidTransaction)` if the outcome is absent but `wait_until`
+///   is an executed level (malformed RPC response).
+pub(crate) fn process_send_response(
+    response: crate::types::SendTxResponse,
+    wait_until: TxExecutionStatus,
+) -> Result<Option<FinalExecutionOutcome>, Error> {
+    let outcome = match response.outcome {
+        Some(outcome) => outcome,
+        None if !wait_until.is_executed() => return Ok(None),
+        None => {
+            return Err(Error::InvalidTransaction(format!(
+                "Transaction {} submitted with wait_until={:?} but no execution outcome \
+                 was returned by the RPC.",
+                response.transaction_hash, wait_until,
+            )));
+        }
+    };
+
+    use crate::types::{FinalExecutionStatus, TxExecutionError};
+    match outcome.status {
+        FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(e)) => {
+            Err(Error::InvalidTx(Box::new(e)))
+        }
+        _ => Ok(Some(outcome)),
+    }
+}
+
+/// Unwrap an `Option<FinalExecutionOutcome>` into a `FinalExecutionOutcome`,
+/// returning an error if the outcome is absent. Used by convenience methods
+/// that always send with `ExecutedOptimistic`.
+pub(crate) fn require_outcome(
+    result: Result<Option<FinalExecutionOutcome>, Error>,
+) -> Result<FinalExecutionOutcome, Error> {
+    result.and_then(|opt| {
+        opt.ok_or_else(|| {
+            Error::InvalidTransaction(
+                "RPC returned no execution outcome for ExecutedOptimistic".to_string(),
+            )
+        })
+    })
+}
+
 /// Global nonce manager shared across all TransactionBuilder instances.
 /// This is an implementation detail - not exposed to users.
 fn nonce_manager() -> &'static NonceManager {
@@ -1352,34 +1400,7 @@ impl IntoFuture for TransactionSend {
                     // Send
                     match builder.rpc.send_tx(&signed_tx, builder.wait_until).await {
                         Ok(response) => {
-                            // When wait_until is a non-executed level (None, Included,
-                            // IncludedFinal), the outcome may legitimately be absent
-                            // because the tx was included but not yet executed.
-                            // For executed levels, a missing outcome is a malformed RPC response.
-                            let outcome = match response.outcome {
-                                Some(outcome) => outcome,
-                                None if !builder.wait_until.is_executed() => return Ok(None),
-                                None => {
-                                    return Err(Error::InvalidTransaction(format!(
-                                        "Transaction submitted with wait_until={:?} but no \
-                                         execution outcome was returned by the RPC.",
-                                        builder.wait_until,
-                                    )));
-                                }
-                            };
-
-                            // Inspect outcome status — only InvalidTxError becomes Err.
-                            // ActionError means the tx executed (nonce incremented, gas consumed),
-                            // so we return Ok(Some(outcome)) and let the caller inspect is_failure().
-                            use crate::types::{FinalExecutionStatus, TxExecutionError};
-                            match outcome.status {
-                                FinalExecutionStatus::Failure(
-                                    TxExecutionError::InvalidTxError(e),
-                                ) => {
-                                    return Err(Error::InvalidTx(Box::new(e)));
-                                }
-                                _ => return Ok(Some(outcome)),
-                            }
+                            return process_send_response(response, builder.wait_until);
                         }
                         Err(RpcError::InvalidTx(
                             crate::types::InvalidTxError::InvalidNonce { tx_nonce, ak_nonce },

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1233,7 +1233,7 @@ impl CallBuilder {
 }
 
 impl IntoFuture for CallBuilder {
-    type Output = Result<FinalExecutionOutcome, Error>;
+    type Output = Result<Option<FinalExecutionOutcome>, Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -1266,7 +1266,7 @@ impl TransactionSend {
 }
 
 impl IntoFuture for TransactionSend {
-    type Output = Result<FinalExecutionOutcome, Error>;
+    type Output = Result<Option<FinalExecutionOutcome>, Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -1352,18 +1352,17 @@ impl IntoFuture for TransactionSend {
                     // Send
                     match builder.rpc.send_tx(&signed_tx, builder.wait_until).await {
                         Ok(response) => {
-                            let outcome = response.outcome.ok_or_else(|| {
-                                Error::InvalidTransaction(format!(
-                                    "Transaction {} submitted with wait_until={:?} but no execution \
-                                     outcome was returned. Use rpc().send_tx() for fire-and-forget \
-                                     submission.",
-                                    response.transaction_hash, builder.wait_until,
-                                ))
-                            })?;
+                            // When wait_until is a non-executed level (None, Included,
+                            // IncludedFinal), the outcome may legitimately be absent
+                            // because the tx was included but not yet executed.
+                            let outcome = match response.outcome {
+                                Some(outcome) => outcome,
+                                None => return Ok(None),
+                            };
 
                             // Inspect outcome status — only InvalidTxError becomes Err.
                             // ActionError means the tx executed (nonce incremented, gas consumed),
-                            // so we return Ok(outcome) and let the caller inspect is_failure().
+                            // so we return Ok(Some(outcome)) and let the caller inspect is_failure().
                             use crate::types::{FinalExecutionStatus, TxExecutionError};
                             match outcome.status {
                                 FinalExecutionStatus::Failure(
@@ -1371,7 +1370,7 @@ impl IntoFuture for TransactionSend {
                                 ) => {
                                     return Err(Error::InvalidTx(Box::new(e)));
                                 }
-                                _ => return Ok(outcome),
+                                _ => return Ok(Some(outcome)),
                             }
                         }
                         Err(RpcError::InvalidTx(
@@ -1424,7 +1423,7 @@ impl IntoFuture for TransactionSend {
 }
 
 impl IntoFuture for TransactionBuilder {
-    type Output = Result<FinalExecutionOutcome, Error>;
+    type Output = Result<Option<FinalExecutionOutcome>, Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1355,9 +1355,17 @@ impl IntoFuture for TransactionSend {
                             // When wait_until is a non-executed level (None, Included,
                             // IncludedFinal), the outcome may legitimately be absent
                             // because the tx was included but not yet executed.
+                            // For executed levels, a missing outcome is a malformed RPC response.
                             let outcome = match response.outcome {
                                 Some(outcome) => outcome,
-                                None => return Ok(None),
+                                None if !builder.wait_until.is_executed() => return Ok(None),
+                                None => {
+                                    return Err(Error::InvalidTransaction(format!(
+                                        "Transaction submitted with wait_until={:?} but no \
+                                         execution outcome was returned by the RPC.",
+                                        builder.wait_until,
+                                    )));
+                                }
                             };
 
                             // Inspect outcome status — only InvalidTxError becomes Err.

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -23,6 +23,7 @@
 //! # async fn example() -> Result<(), Error> {
 //! let near = Near::testnet().build();
 //!
+//! // With the default wait level (ExecutedOptimistic), the outcome is always present.
 //! match near.transfer("bob.testnet", "1 NEAR").await {
 //!     Ok(Some(outcome)) if outcome.is_success() => {
 //!         println!("Success! Hash: {}", outcome.transaction_hash());
@@ -32,8 +33,9 @@
 //!         println!("Action failed: {:?}, gas used: {}", outcome.failure_message(), outcome.total_gas_used());
 //!     }
 //!     Ok(None) => {
-//!         // Transaction was included but not yet executed (when using a non-executed wait level)
-//!         println!("Transaction included, not yet executed");
+//!         // Only returned when using a non-executed wait level like
+//!         // .send().wait_until(TxExecutionStatus::Included)
+//!         unreachable!("default wait level always returns an outcome");
 //!     }
 //!     Err(Error::InvalidTx(e)) => {
 //!         // Transaction was rejected before execution (bad nonce, insufficient balance, etc.)

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -24,12 +24,16 @@
 //! let near = Near::testnet().build();
 //!
 //! match near.transfer("bob.testnet", "1 NEAR").await {
-//!     Ok(outcome) if outcome.is_success() => {
+//!     Ok(Some(outcome)) if outcome.is_success() => {
 //!         println!("Success! Hash: {}", outcome.transaction_hash());
 //!     }
-//!     Ok(outcome) => {
+//!     Ok(Some(outcome)) => {
 //!         // Transaction executed but an action failed — inspect the outcome
 //!         println!("Action failed: {:?}, gas used: {}", outcome.failure_message(), outcome.total_gas_used());
+//!     }
+//!     Ok(None) => {
+//!         // Transaction was included but not yet executed (when using a non-executed wait level)
+//!         println!("Transaction included, not yet executed");
 //!     }
 //!     Err(Error::InvalidTx(e)) => {
 //!         // Transaction was rejected before execution (bad nonce, insufficient balance, etc.)

--- a/crates/near-kit/tests/integration/debug_rpc_responses.rs
+++ b/crates/near-kit/tests/integration/debug_rpc_responses.rs
@@ -162,6 +162,7 @@ async fn debug_transaction_receipts() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!("\n========================================");
@@ -334,6 +335,7 @@ async fn debug_access_key_details() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     let keys = near.access_keys(&account_id).await.unwrap();

--- a/crates/near-kit/tests/integration/delegate_action_integration.rs
+++ b/crates/near-kit/tests/integration/delegate_action_integration.rs
@@ -64,6 +64,7 @@ async fn test_delegate_action_transfer() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create recipient account
@@ -78,6 +79,7 @@ async fn test_delegate_action_transfer() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!(
@@ -131,6 +133,7 @@ async fn test_delegate_action_transfer() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!(
@@ -185,6 +188,7 @@ async fn test_delegate_action_function_call() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create contract account and deploy a simple contract
@@ -242,6 +246,7 @@ async fn test_delegate_action_function_call() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!("Delegate action function call successful!");
@@ -281,6 +286,7 @@ async fn test_delegate_action_multiple_actions() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // New account to be created via delegate action
@@ -324,6 +330,7 @@ async fn test_delegate_action_multiple_actions() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!("Delegate action with multiple actions succeeded");
@@ -372,6 +379,7 @@ async fn test_delegate_action_roundtrip_encoding() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create a delegate action

--- a/crates/near-kit/tests/integration/error_consolidation_integration.rs
+++ b/crates/near-kit/tests/integration/error_consolidation_integration.rs
@@ -42,7 +42,8 @@ async fn test_successful_transfer_returns_ok() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
-        .expect("Successful transaction should return Ok");
+        .expect("Successful transaction should return Ok")
+        .unwrap();
 
     assert!(outcome.is_success());
     assert!(!outcome.transaction_hash().is_zero());
@@ -83,7 +84,8 @@ async fn test_action_error_returns_ok_with_failure_outcome() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(outcome.is_failure(), "Outcome should be a failure");
     assert!(!outcome.is_success());
@@ -129,7 +131,8 @@ async fn test_function_call_error_returns_ok_with_failure_outcome() {
         .args(serde_json::json!({}))
         .gas(Gas::from_tgas(30))
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(outcome.is_failure());
     assert!(outcome.failure_message().is_some());

--- a/crates/near-kit/tests/integration/error_handling_integration.rs
+++ b/crates/near-kit/tests/integration/error_handling_integration.rs
@@ -183,6 +183,7 @@ async fn test_error_view_nonexistent_method() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Call a method that doesn't exist
@@ -231,6 +232,7 @@ async fn test_error_view_with_invalid_args() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Call with invalid JSON args (not valid for the method)
@@ -323,6 +325,7 @@ async fn test_error_insufficient_balance_transfer() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Try to transfer more than available — rejected at RPC validation level
@@ -370,7 +373,8 @@ async fn test_error_create_account_that_already_exists() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(
         outcome.is_failure(),
@@ -411,7 +415,8 @@ async fn test_error_delete_nonexistent_key() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(
         outcome.is_failure(),
@@ -447,6 +452,7 @@ async fn test_error_function_call_panic() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     let contract_near = Near::custom(rpc_url)
@@ -460,7 +466,8 @@ async fn test_error_function_call_panic() {
         .args(serde_json::json!({}))
         .gas(Gas::from_tgas(30))
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(
         outcome.is_failure(),
@@ -490,6 +497,7 @@ async fn test_error_function_call_insufficient_gas() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     let contract_near = Near::custom(rpc_url)
@@ -503,7 +511,8 @@ async fn test_error_function_call_insufficient_gas() {
         .args(serde_json::json!({ "text": "test" }))
         .gas(Gas::from_gas(1000)) // Extremely low gas
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(
         outcome.is_failure(),

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -46,6 +46,7 @@ async fn create_funded_account(
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     let near = Near::custom(rpc_url)
@@ -78,6 +79,7 @@ async fn test_near_publish_shorthand_updatable() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     assert!(!outcome.transaction_hash().to_string().is_empty());
@@ -100,6 +102,7 @@ async fn test_near_publish_shorthand_immutable() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     assert!(!outcome.transaction_hash().to_string().is_empty());
@@ -134,6 +137,7 @@ async fn test_near_deploy_from_shorthand_publisher() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Verify by calling a view method on the deployed contract
@@ -174,6 +178,7 @@ async fn test_near_deploy_from_shorthand_hash() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Verify by calling a view method
@@ -214,6 +219,7 @@ async fn test_publish_deploy_from_call_end_to_end() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Call a mutating method on the deployed contract
@@ -226,6 +232,7 @@ async fn test_publish_deploy_from_call_end_to_end() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Verify the message was stored
@@ -258,6 +265,7 @@ async fn test_publish_contract_by_account() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!(
@@ -286,6 +294,7 @@ async fn test_publish_contract_by_hash() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!(
@@ -314,6 +323,7 @@ async fn test_deploy_from_publisher() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create a user account that will deploy from the publisher
@@ -327,6 +337,7 @@ async fn test_deploy_from_publisher() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!(
@@ -369,6 +380,7 @@ async fn test_deploy_from_hash() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create a user account that will deploy from the hash
@@ -382,6 +394,7 @@ async fn test_deploy_from_hash() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!(
@@ -421,6 +434,7 @@ async fn test_state_init_by_hash() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create initial state data (empty for this test)
@@ -433,6 +447,7 @@ async fn test_state_init_by_hash() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!(
@@ -461,6 +476,7 @@ async fn test_state_init_by_publisher() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create initial state data with some sample data
@@ -475,6 +491,7 @@ async fn test_state_init_by_publisher() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!(
@@ -508,6 +525,7 @@ async fn test_action_create_account() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     assert!(root_near.account_exists(&child_id).await.unwrap());
@@ -597,6 +615,7 @@ async fn test_action_function_call() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 }
 
@@ -649,6 +668,7 @@ async fn test_action_add_function_call_key() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Verify the key was added
@@ -717,6 +737,7 @@ async fn test_action_delete_account() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     assert!(root_near.account_exists(&to_delete_id).await.unwrap());
@@ -733,6 +754,7 @@ async fn test_action_delete_account() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     assert!(!root_near.account_exists(&to_delete_id).await.unwrap());
@@ -768,6 +790,7 @@ async fn test_action_stake() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!("Stake action completed: {:?}", outcome.transaction_hash());
@@ -803,6 +826,7 @@ async fn test_multiple_actions() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Verify everything worked
@@ -849,6 +873,7 @@ async fn test_multiple_function_calls() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!(

--- a/crates/near-kit/tests/integration/offline_signing_integration.rs
+++ b/crates/near-kit/tests/integration/offline_signing_integration.rs
@@ -173,7 +173,8 @@ async fn test_sign_offline_function_call() {
     let _outcome = contract_near
         .send_with_options(&signed, TxExecutionStatus::Final)
         .await
-        .unwrap();
+        .unwrap()
+        .expect("Final guarantees an execution outcome");
 
     // Verify the message was added
     let messages: Vec<serde_json::Value> = contract_near

--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -269,6 +269,7 @@ async fn test_final_execution_outcome_full_fields() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Verify FinalExecutionOutcome fields
@@ -341,6 +342,7 @@ async fn test_execution_metadata_and_gas_profile() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Check if metadata is present (may not be in all protocol versions)
@@ -389,6 +391,7 @@ async fn test_tx_status_with_receipts() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     let tx_hash = outcome.transaction_hash();
@@ -483,6 +486,7 @@ async fn test_action_view_variants() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     let tx = &outcome.transaction;

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -867,6 +867,123 @@ async fn test_send_pre_signed_transaction() {
 }
 
 #[tokio::test]
+async fn test_send_with_included_status_returns_none() {
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    // Create sender account
+    let sender_key = SecretKey::generate_ed25519();
+    let sender_id = unique_account();
+
+    root_near
+        .transaction(&sender_id)
+        .create_account()
+        .transfer(NearToken::from_near(100))
+        .add_full_access_key(sender_key.public_key())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let sender_near = Near::custom(rpc_url)
+        .credentials(sender_key.to_string(), &sender_id)
+        .unwrap()
+        .build();
+
+    // Create receiver account
+    let receiver_key = SecretKey::generate_ed25519();
+    let receiver_id: AccountId = format!("recv-inc.{}", sender_id).parse().unwrap();
+
+    sender_near
+        .transaction(&receiver_id)
+        .create_account()
+        .transfer(NearToken::from_near(10))
+        .add_full_access_key(receiver_key.public_key())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Send with Included wait level — outcome should be None since the
+    // transaction was included but not yet executed.
+    let result = sender_near
+        .transfer(&receiver_id, NearToken::from_near(1))
+        .send()
+        .wait_until(TxExecutionStatus::Included)
+        .await
+        .unwrap();
+
+    assert!(
+        result.is_none(),
+        "Included status should return None outcome, got: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn test_send_with_options_included_returns_none() {
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    // Create sender account
+    let sender_key = SecretKey::generate_ed25519();
+    let sender_id = unique_account();
+
+    root_near
+        .transaction(&sender_id)
+        .create_account()
+        .transfer(NearToken::from_near(100))
+        .add_full_access_key(sender_key.public_key())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap()
+        .unwrap();
+
+    let sender_near = Near::custom(rpc_url)
+        .credentials(sender_key.to_string(), &sender_id)
+        .unwrap()
+        .build();
+
+    // Create receiver
+    let receiver_key = SecretKey::generate_ed25519();
+    let receiver_id: AccountId = format!("recv-inc2.{}", sender_id).parse().unwrap();
+
+    sender_near
+        .transaction(&receiver_id)
+        .create_account()
+        .transfer(NearToken::from_near(10))
+        .add_full_access_key(receiver_key.public_key())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap()
+        .unwrap();
+
+    // Sign offline and send with Included via send_with_options
+    let signed = sender_near
+        .transfer(&receiver_id, NearToken::from_near(1))
+        .sign()
+        .await
+        .unwrap();
+
+    let result = sender_near
+        .send_with_options(&signed, TxExecutionStatus::Included)
+        .await
+        .unwrap();
+
+    assert!(
+        result.is_none(),
+        "send_with_options with Included should return None outcome, got: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
 async fn test_sandbox_custom_chain_id() {
     let sandbox = SandboxConfig::builder().chain_id("pinet").fresh().await;
     let near = sandbox.client();

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -867,7 +867,7 @@ async fn test_send_pre_signed_transaction() {
 }
 
 #[tokio::test]
-async fn test_send_with_included_status_returns_none() {
+async fn test_included_status_returns_none_outcome() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
     let rpc_url = sandbox.rpc_url();
@@ -907,8 +907,7 @@ async fn test_send_with_included_status_returns_none() {
         .unwrap()
         .unwrap();
 
-    // Send with Included wait level — outcome should be None since the
-    // transaction was included but not yet executed.
+    // Via TransactionBuilder: Included wait level returns None outcome
     let result = sender_near
         .transfer(&receiver_id, NearToken::from_near(1))
         .send()
@@ -921,50 +920,8 @@ async fn test_send_with_included_status_returns_none() {
         "Included status should return None outcome, got: {:?}",
         result
     );
-}
 
-#[tokio::test]
-async fn test_send_with_options_included_returns_none() {
-    let sandbox = SandboxConfig::shared().await;
-    let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
-
-    // Create sender account
-    let sender_key = SecretKey::generate_ed25519();
-    let sender_id = unique_account();
-
-    root_near
-        .transaction(&sender_id)
-        .create_account()
-        .transfer(NearToken::from_near(100))
-        .add_full_access_key(sender_key.public_key())
-        .send()
-        .wait_until(TxExecutionStatus::Final)
-        .await
-        .unwrap()
-        .unwrap();
-
-    let sender_near = Near::custom(rpc_url)
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
-
-    // Create receiver
-    let receiver_key = SecretKey::generate_ed25519();
-    let receiver_id: AccountId = format!("recv-inc2.{}", sender_id).parse().unwrap();
-
-    sender_near
-        .transaction(&receiver_id)
-        .create_account()
-        .transfer(NearToken::from_near(10))
-        .add_full_access_key(receiver_key.public_key())
-        .send()
-        .wait_until(TxExecutionStatus::Final)
-        .await
-        .unwrap()
-        .unwrap();
-
-    // Sign offline and send with Included via send_with_options
+    // Via send_with_options: same behavior
     let signed = sender_near
         .transfer(&receiver_id, NearToken::from_near(1))
         .sign()

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -90,6 +90,7 @@ async fn test_sandbox_transfer() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!(
@@ -147,6 +148,7 @@ async fn test_sandbox_multiple_transfers() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create second account
@@ -158,6 +160,7 @@ async fn test_sandbox_multiple_transfers() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Check balances
@@ -208,6 +211,7 @@ async fn test_sandbox_simple_transfer() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     let initial_balance = root_near.balance(&receiver_id).await.unwrap();
@@ -267,6 +271,7 @@ async fn test_sandbox_create_account_outcome() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!("Transaction hash: {:?}", outcome.transaction_hash());
@@ -310,6 +315,7 @@ async fn test_sandbox_delete_account() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Verify it exists
@@ -328,6 +334,7 @@ async fn test_sandbox_delete_account() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Verify it no longer exists
@@ -369,6 +376,7 @@ async fn test_sandbox_add_and_delete_key() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Check that both keys exist
@@ -430,6 +438,7 @@ async fn test_sandbox_multiple_actions_in_one_transaction() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create bob
@@ -441,6 +450,7 @@ async fn test_sandbox_multiple_actions_in_one_transaction() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Verify both exist
@@ -518,6 +528,7 @@ async fn test_sandbox_set_balance_preserves_other_fields() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Get original account state
@@ -602,6 +613,7 @@ async fn test_sandbox_set_balance_for_staking() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     println!("Stake transaction: {:?}", outcome.transaction_hash());
@@ -774,6 +786,7 @@ async fn test_send_with_options_final() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Sign a transaction offline
@@ -789,7 +802,8 @@ async fn test_send_with_options_final() {
     let outcome = sender_near
         .send_with_options(&signed, TxExecutionStatus::Final)
         .await
-        .unwrap();
+        .unwrap()
+        .expect("Final guarantees an execution outcome");
 
     println!("Transaction succeeded: {:?}", outcome.transaction_hash());
 
@@ -836,6 +850,7 @@ async fn test_send_pre_signed_transaction() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Sign a transaction offline

--- a/crates/near-kit/tests/integration/transaction_failure_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_failure_integration.rs
@@ -105,7 +105,8 @@ async fn test_add_key_to_nonexistent_account() {
         .add_full_access_key(key.public_key())
         .send()
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(
         outcome.is_failure(),
@@ -141,7 +142,8 @@ async fn test_add_duplicate_key() {
     let outcome = account_near
         .add_full_access_key(key.public_key())
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(
         outcome.is_failure(),
@@ -202,7 +204,8 @@ async fn test_create_subaccount_of_nonexistent_parent() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(
         outcome.is_failure(),
@@ -295,7 +298,8 @@ async fn test_transaction_with_failing_action_in_middle() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(
         outcome.is_failure(),
@@ -322,7 +326,8 @@ async fn test_delete_nonexistent_account() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(
         outcome.is_failure(),
@@ -403,7 +408,8 @@ async fn test_stake_with_insufficient_balance() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(
         outcome.is_failure(),
@@ -453,6 +459,7 @@ async fn test_transfer_zero_amount() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Transfer zero

--- a/crates/near-kit/tests/integration/transaction_outcome_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_outcome_integration.rs
@@ -38,6 +38,7 @@ async fn test_failed_transaction_preserves_receipts() {
         .wait_until(TxExecutionStatus::Final)
         .await
         .expect("setup: deploy should succeed")
+        .unwrap()
         .result()
         .expect("setup: deploy should succeed on-chain");
 
@@ -53,7 +54,8 @@ async fn test_failed_transaction_preserves_receipts() {
         .args(serde_json::json!({}))
         .gas(Gas::from_tgas(10))
         .await
-        .expect("Action errors should return Ok(outcome)");
+        .expect("Action errors should return Ok(outcome)")
+        .unwrap();
 
     assert!(outcome.is_failure(), "Outcome should be a failure");
     assert!(

--- a/crates/near-kit/tests/integration/typed_contract_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_error_integration.rs
@@ -135,6 +135,7 @@ async fn test_typed_contract_call_without_signer() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create client WITHOUT a signer
@@ -175,6 +176,7 @@ async fn test_typed_contract_view_on_wrong_contract_type() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Try to use guestbook interface on FT contract
@@ -213,6 +215,7 @@ async fn test_typed_contract_call_with_insufficient_gas() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     let guestbook = near.contract::<Guestbook>(&contract_id);
@@ -226,10 +229,10 @@ async fn test_typed_contract_call_with_insufficient_gas() {
         .await;
 
     match result {
-        Ok(outcome) if outcome.is_failure() => {
+        Ok(Some(outcome)) if outcome.is_failure() => {
             println!("Insufficient gas error: {:?}", outcome.failure_message());
         }
-        Ok(outcome) => panic!("Expected failure outcome, got success: {:?}", outcome),
+        Ok(outcome) => panic!("Expected failure outcome, got: {:?}", outcome),
         Err(Error::Rpc(_)) | Err(Error::InvalidTx(_)) => { /* Also acceptable */ }
         Err(other) => panic!(
             "Expected Ok(failure) or Rpc/InvalidTx error, got: {:?}",
@@ -257,6 +260,7 @@ async fn test_typed_contract_view_returns_wrong_type() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Define a "wrong" contract interface that expects different return type
@@ -303,6 +307,7 @@ async fn test_typed_contract_query_at_invalid_block() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     let guestbook = near.contract::<Guestbook>(&contract_id);
@@ -344,6 +349,7 @@ async fn test_typed_contract_view_methods_still_work_without_signer() {
         .send()
         .wait_until(TxExecutionStatus::Final)
         .await
+        .unwrap()
         .unwrap();
 
     // Create client WITHOUT a signer


### PR DESCRIPTION
## Summary

- `send_with_options` and the `TransactionSend`/`TransactionBuilder`/`CallBuilder` `IntoFuture` impls now return `Result<Option<FinalExecutionOutcome>, Error>` instead of `Result<FinalExecutionOutcome, Error>`
- When `wait_until` is `None`, `Included`, or `IncludedFinal`, the RPC legitimately returns no execution outcome — this is no longer treated as an error
- Convenience methods (`send`, `call_with_args`, `call_with_options`) that always use `ExecutedOptimistic` still return `Result<FinalExecutionOutcome, Error>` directly
- Added integration tests for `Included` status via both `TransactionBuilder` and `send_with_options` paths

## Breaking change

`tx.send().await?` now returns `Option<FinalExecutionOutcome>`. For the default `ExecutedOptimistic` wait level, add `.unwrap()`:

```rust
// Before
let outcome = tx.send().await?;

// After
let outcome = tx.send().await?.unwrap();
```

## Test plan

- [x] All unit tests pass
- [x] All existing integration tests updated
- [x] New integration tests for `Included` status returning `None`
- [ ] Run sandbox integration tests with Docker