### PR TITLE
fix: return SendTxResponse from send_with_options

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -849,8 +849,10 @@ impl Near {
     /// `outcome` field is `Some` when the transaction has been executed, and
     /// `None` for non-executed wait levels (`None`, `Included`, `IncludedFinal`).
     ///
-    /// Use [`send`](Self::send) if you always want a `FinalExecutionOutcome`
-    /// (it defaults to `ExecutedOptimistic`).
+    /// **Note:** Unlike [`send`](Self::send), this method does not convert
+    /// `InvalidTxError` failures into [`Error::InvalidTx`]. Callers that need
+    /// structured error handling for invalid transactions should inspect
+    /// `outcome.status` themselves or use [`send`](Self::send) instead.
     pub async fn send_with_options(
         &self,
         signed_tx: &crate::types::SignedTransaction,

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -823,27 +823,15 @@ impl Near {
         &self,
         signed_tx: &crate::types::SignedTransaction,
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        self.send_with_options(signed_tx, TxExecutionStatus::ExecutedOptimistic)
-            .await
-    }
-
-    /// Send a pre-signed transaction with custom wait options.
-    pub async fn send_with_options(
-        &self,
-        signed_tx: &crate::types::SignedTransaction,
-        wait_until: TxExecutionStatus,
-    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        let response = self.rpc.send_tx(signed_tx, wait_until).await?;
+        let response = self
+            .send_with_options(signed_tx, TxExecutionStatus::ExecutedOptimistic)
+            .await?;
         let outcome = response.outcome.ok_or_else(|| {
-            Error::InvalidTransaction(format!(
-                "Transaction {} submitted with wait_until={:?} but no execution outcome \
-                 was returned. Use rpc().send_tx() for fire-and-forget submission.",
-                response.transaction_hash, wait_until,
-            ))
+            Error::InvalidTransaction(
+                "RPC returned no execution outcome for ExecutedOptimistic".to_string(),
+            )
         })?;
 
-        // Only InvalidTxError becomes Err — action errors return Ok(outcome)
-        // so callers can inspect the full outcome via is_failure()/failure_message().
         use crate::types::{FinalExecutionStatus, TxExecutionError};
         match outcome.status {
             FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(e)) => {
@@ -851,6 +839,23 @@ impl Near {
             }
             _ => Ok(outcome),
         }
+    }
+
+    /// Send a pre-signed transaction with custom wait options.
+    ///
+    /// Returns the raw [`SendTxResponse`](crate::types::SendTxResponse), which
+    /// always contains the `transaction_hash` and `final_execution_status`. The
+    /// `outcome` field is `Some` when the transaction has been executed, and
+    /// `None` for non-executed wait levels (`None`, `Included`, `IncludedFinal`).
+    ///
+    /// Use [`send`](Self::send) if you always want a `FinalExecutionOutcome`
+    /// (it defaults to `ExecutedOptimistic`).
+    pub async fn send_with_options(
+        &self,
+        signed_tx: &crate::types::SignedTransaction,
+        wait_until: TxExecutionStatus,
+    ) -> Result<crate::types::SendTxResponse, Error> {
+        Ok(self.rpc.send_tx(signed_tx, wait_until).await?)
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -827,9 +827,10 @@ impl Near {
             .send_with_options(signed_tx, TxExecutionStatus::ExecutedOptimistic)
             .await?;
         let outcome = response.outcome.ok_or_else(|| {
-            Error::InvalidTransaction(
-                "RPC returned no execution outcome for ExecutedOptimistic".to_string(),
-            )
+            Error::InvalidTransaction(format!(
+                "RPC returned no execution outcome for transaction {} at wait level ExecutedOptimistic",
+                response.transaction_hash
+            ))
         })?;
 
         use crate::types::{FinalExecutionStatus, TxExecutionError};

--- a/crates/near-kit/tests/integration/offline_signing_integration.rs
+++ b/crates/near-kit/tests/integration/offline_signing_integration.rs
@@ -170,7 +170,7 @@ async fn test_sign_offline_function_call() {
         .unwrap();
 
     // Send and wait for finalization so the view call sees the state change
-    let _outcome = contract_near
+    let _response = contract_near
         .send_with_options(&signed, TxExecutionStatus::Final)
         .await
         .unwrap();

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -786,12 +786,12 @@ async fn test_send_with_options_final() {
     println!("Signed transaction hash: {}", signed.get_hash());
 
     // Send with Final wait option
-    let outcome = sender_near
+    let response = sender_near
         .send_with_options(&signed, TxExecutionStatus::Final)
         .await
         .unwrap();
 
-    println!("Transaction succeeded: {:?}", outcome.transaction_hash());
+    println!("Transaction succeeded: {:?}", response.transaction_hash);
 
     // Verify the transfer happened
     let balance = root_near.balance(&receiver_id).await.unwrap();
@@ -849,6 +849,69 @@ async fn test_send_pre_signed_transaction() {
     let outcome = sender_near.send(&signed).await.unwrap();
 
     println!("Transaction completed: {:?}", outcome.transaction_hash());
+}
+
+#[tokio::test]
+async fn test_send_with_options_included_returns_no_outcome() {
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    // Create sender account
+    let sender_key = SecretKey::generate_ed25519();
+    let sender_id = unique_account();
+
+    root_near
+        .transaction(&sender_id)
+        .create_account()
+        .transfer(NearToken::from_near(100))
+        .add_full_access_key(sender_key.public_key())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    let sender_near = Near::custom(rpc_url)
+        .credentials(sender_key.to_string(), &sender_id)
+        .unwrap()
+        .build();
+
+    // Create receiver account
+    let receiver_key = SecretKey::generate_ed25519();
+    let receiver_id: AccountId = format!("recv-inc.{}", sender_id).parse().unwrap();
+
+    sender_near
+        .transaction(&receiver_id)
+        .create_account()
+        .transfer(NearToken::from_near(10))
+        .add_full_access_key(receiver_key.public_key())
+        .send()
+        .wait_until(TxExecutionStatus::Final)
+        .await
+        .unwrap();
+
+    // Sign and send with Included — outcome may be None
+    let signed = sender_near
+        .transfer(&receiver_id, NearToken::from_near(1))
+        .sign()
+        .await
+        .unwrap();
+
+    let response = sender_near
+        .send_with_options(&signed, TxExecutionStatus::Included)
+        .await
+        .unwrap();
+
+    // transaction_hash is always available
+    assert!(!response.transaction_hash.is_zero());
+
+    // outcome may or may not be present for Included — both are valid
+    println!(
+        "Included response: hash={}, status={:?}, has_outcome={}",
+        response.transaction_hash,
+        response.final_execution_status,
+        response.outcome.is_some()
+    );
 }
 
 #[tokio::test]

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -905,12 +905,11 @@ async fn test_send_with_options_included_returns_no_outcome() {
     // transaction_hash is always available
     assert!(!response.transaction_hash.is_zero());
 
-    // outcome may or may not be present for Included — both are valid
-    println!(
-        "Included response: hash={}, status={:?}, has_outcome={}",
-        response.transaction_hash,
-        response.final_execution_status,
-        response.outcome.is_some()
+    // Included does not wait for execution, so outcome should be None
+    assert!(
+        response.outcome.is_none(),
+        "expected no outcome for Included, got: {:?}",
+        response.outcome
     );
 }
 


### PR DESCRIPTION
## Summary

- `send_with_options` now returns `SendTxResponse` instead of `FinalExecutionOutcome`
- `SendTxResponse` always has `transaction_hash` and `final_execution_status`; the `outcome` field is `Option<FinalExecutionOutcome>` — present when execution completed, absent for non-executed wait levels like `Included`
- `send()` is unchanged — still returns `FinalExecutionOutcome` directly

This fixes the error when using `send_with_options` with `Included` status, where a `None` outcome was incorrectly treated as an error.

Alternative to #158 — much simpler approach that doesn't change the ergonomic builder API at all.

## Breaking change

`send_with_options` return type changes from `Result<FinalExecutionOutcome, Error>` to `Result<SendTxResponse, Error>`. Callers using executed wait levels need to unwrap `.outcome`:

```rust
// Before
let outcome = near.send_with_options(&signed, Final).await?;

// After  
let response = near.send_with_options(&signed, Final).await?;
let outcome = response.outcome.unwrap();
```

## Test plan

- [x] All unit tests pass
- [x] Existing `send_with_options` tests updated
- [x] New integration test for `Included` status via `send_with_options`
- [ ] Run sandbox integration tests with Docker