### PR TITLE
feat: type-safe wait levels for transaction submission

### DIFF
--- a/crates/near-kit/examples/global_contracts.rs
+++ b/crates/near-kit/examples/global_contracts.rs
@@ -50,7 +50,7 @@ async fn global_contracts_example() -> Result<(), Error> {
     publisher_near
         .publish(wasm_code.clone(), PublishMode::Updatable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await?;
 
     println!("Published guestbook contract (updatable)\n");
@@ -78,7 +78,7 @@ async fn global_contracts_example() -> Result<(), Error> {
     user_near
         .deploy_from(&publisher_account)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await?;
 
     println!("Deployed to {user_account} from publisher\n");
@@ -91,7 +91,7 @@ async fn global_contracts_example() -> Result<(), Error> {
         .gas(Gas::from_tgas(30))
         .deposit(NearToken::ZERO)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await?;
 
     let messages: Vec<serde_json::Value> = root_near
@@ -112,7 +112,7 @@ async fn global_contracts_example() -> Result<(), Error> {
     publisher_near
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await?;
 
     println!("Published same contract (immutable)\n");
@@ -140,7 +140,7 @@ async fn global_contracts_example() -> Result<(), Error> {
     user2_near
         .deploy_from(code_hash)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await?;
 
     println!("Deployed to {user2_account} from code hash");

--- a/crates/near-kit/examples/sequential_sends.rs
+++ b/crates/near-kit/examples/sequential_sends.rs
@@ -95,7 +95,7 @@ async fn sequential_example() -> Result<(), Error> {
                 for tx_idx in 0..txs_per_key {
                     near.transfer(&recipient, NearToken::from_millinear(1))
                         .send()
-                        .wait_until(TxExecutionStatus::Included)
+                        .wait_until(Included)
                         .await
                         .unwrap();
                     println!("  key[{key_idx}] tx {tx_idx} included");

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -15,7 +15,6 @@ use super::query::{AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQue
 use super::rpc::{MAINNET, RetryConfig, RpcClient, TESTNET};
 use super::signer::{InMemorySigner, Signer};
 use super::transaction::{CallBuilder, TransactionBuilder};
-use crate::types::TxExecutionStatus;
 
 /// Trait for sandbox network configuration.
 ///
@@ -560,7 +559,7 @@ impl Near {
     ///
     /// // Transfer with wait for finality
     /// near.transfer("bob.testnet", NearToken::from_near(1000))
-    ///     .wait_until(TxExecutionStatus::Final)
+    ///     .wait_until(Final)
     ///     .await?;
     /// # Ok(())
     /// # }
@@ -823,34 +822,26 @@ impl Near {
         &self,
         signed_tx: &crate::types::SignedTransaction,
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        self.send_with_options(signed_tx, TxExecutionStatus::ExecutedOptimistic)
+        self.send_with_options(signed_tx, crate::types::ExecutedOptimistic)
             .await
     }
 
-    /// Send a pre-signed transaction with custom wait options.
-    pub async fn send_with_options(
+    /// Send a pre-signed transaction with a custom wait level.
+    ///
+    /// The return type depends on the wait level:
+    /// - Executed levels ([`ExecutedOptimistic`](crate::types::ExecutedOptimistic),
+    ///   [`Executed`](crate::types::Executed), [`Final`](crate::types::Final))
+    ///   → [`FinalExecutionOutcome`](crate::types::FinalExecutionOutcome)
+    /// - Non-executed levels ([`Submitted`](crate::types::Submitted),
+    ///   [`Included`](crate::types::Included), [`IncludedFinal`](crate::types::IncludedFinal))
+    ///   → [`SendTxResponse`](crate::types::SendTxResponse)
+    pub async fn send_with_options<W: crate::types::WaitLevel>(
         &self,
         signed_tx: &crate::types::SignedTransaction,
-        wait_until: TxExecutionStatus,
-    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        let response = self.rpc.send_tx(signed_tx, wait_until).await?;
-        let outcome = response.outcome.ok_or_else(|| {
-            Error::InvalidTransaction(format!(
-                "Transaction {} submitted with wait_until={:?} but no execution outcome \
-                 was returned. Use rpc().send_tx() for fire-and-forget submission.",
-                response.transaction_hash, wait_until,
-            ))
-        })?;
-
-        // Only InvalidTxError becomes Err — action errors return Ok(outcome)
-        // so callers can inspect the full outcome via is_failure()/failure_message().
-        use crate::types::{FinalExecutionStatus, TxExecutionError};
-        match outcome.status {
-            FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(e)) => {
-                Err(Error::InvalidTx(Box::new(e)))
-            }
-            _ => Ok(outcome),
-        }
+        _level: W,
+    ) -> Result<W::Response, Error> {
+        let response = self.rpc.send_tx(signed_tx, W::status()).await?;
+        W::convert(response)
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -40,7 +40,7 @@ use crate::types::{
     AccountId, Action, BlockReference, CryptoHash, DelegateAction, DeterministicAccountStateInit,
     FinalExecutionOutcome, Finality, Gas, GlobalContractIdentifier, GlobalContractRef, IntoGas,
     IntoNearToken, NearToken, NonDelegateAction, PublicKey, PublishMode, SignedDelegateAction,
-    SignedTransaction, Transaction, TryIntoAccountId, TxExecutionStatus,
+    SignedTransaction, Transaction, TryIntoAccountId, WaitLevel,
 };
 
 use super::nonce_manager::NonceManager;
@@ -161,7 +161,6 @@ pub struct TransactionBuilder {
     receiver_id: AccountId,
     actions: Vec<Action>,
     signer_override: Option<Arc<dyn Signer>>,
-    wait_until: TxExecutionStatus,
     max_nonce_retries: u32,
 }
 
@@ -178,7 +177,6 @@ impl fmt::Debug for TransactionBuilder {
             )
             .field("receiver_id", &self.receiver_id)
             .field("action_count", &self.actions.len())
-            .field("wait_until", &self.wait_until)
             .field("max_nonce_retries", &self.max_nonce_retries)
             .finish()
     }
@@ -197,7 +195,6 @@ impl TransactionBuilder {
             receiver_id,
             actions: Vec::new(),
             signer_override: None,
-            wait_until: TxExecutionStatus::ExecutedOptimistic,
             max_nonce_retries,
         }
     }
@@ -623,10 +620,12 @@ impl TransactionBuilder {
         self
     }
 
-    /// Set the execution wait level.
-    pub fn wait_until(mut self, status: TxExecutionStatus) -> Self {
-        self.wait_until = status;
-        self
+    /// Set the execution wait level and prepare to send.
+    ///
+    /// This is a shorthand for `.send().wait_until(level)`.
+    /// The return type changes based on the wait level — see [`TransactionSend::wait_until`].
+    pub fn wait_until<W: crate::types::WaitLevel>(self, level: W) -> TransactionSend<W> {
+        self.send().wait_until(level)
     }
 
     /// Override the number of nonce retries for this transaction on `InvalidNonce`
@@ -809,9 +808,13 @@ impl TransactionBuilder {
 
     /// Send the transaction.
     ///
-    /// This is equivalent to awaiting the builder directly.
+    /// Returns a [`TransactionSend`] that defaults to [`ExecutedOptimistic`] wait level.
+    /// Chain `.wait_until(...)` to change the wait level before awaiting.
     pub fn send(self) -> TransactionSend {
-        TransactionSend { builder: self }
+        TransactionSend {
+            builder: self,
+            _marker: std::marker::PhantomData,
+        }
     }
 }
 
@@ -1191,8 +1194,8 @@ impl CallBuilder {
     }
 
     /// Set the execution wait level.
-    pub fn wait_until(self, status: TxExecutionStatus) -> TransactionBuilder {
-        self.finish().wait_until(status)
+    pub fn wait_until<W: WaitLevel>(self, level: W) -> TransactionSend<W> {
+        self.finish().wait_until(level)
     }
 
     /// Override the number of nonce retries for this transaction on `InvalidNonce`
@@ -1246,15 +1249,42 @@ impl IntoFuture for CallBuilder {
 // ============================================================================
 
 /// Future for sending a transaction.
-pub struct TransactionSend {
+///
+/// The type parameter `W` determines the wait level and the return type:
+/// - Executed levels ([`ExecutedOptimistic`], [`Executed`], [`Final`]) → [`FinalExecutionOutcome`]
+/// - Non-executed levels ([`Submitted`], [`Included`], [`IncludedFinal`]) → [`SendTxResponse`]
+pub struct TransactionSend<W: WaitLevel = crate::types::ExecutedOptimistic> {
     builder: TransactionBuilder,
+    _marker: std::marker::PhantomData<W>,
 }
 
-impl TransactionSend {
-    /// Set the execution wait level.
-    pub fn wait_until(mut self, status: TxExecutionStatus) -> Self {
-        self.builder.wait_until = status;
-        self
+impl<W: WaitLevel> TransactionSend<W> {
+    /// Change the execution wait level.
+    ///
+    /// The return type changes based on the wait level:
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example(near: &Near) -> Result<(), Error> {
+    /// // Executed levels return FinalExecutionOutcome
+    /// let outcome = near.transfer("bob.testnet", NearToken::from_near(1))
+    ///     .send()
+    ///     .wait_until(Final)
+    ///     .await?;
+    ///
+    /// // Non-executed levels return SendTxResponse
+    /// let response = near.transfer("bob.testnet", NearToken::from_near(1))
+    ///     .send()
+    ///     .wait_until(Included)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn wait_until<W2: WaitLevel>(self, _level: W2) -> TransactionSend<W2> {
+        TransactionSend {
+            builder: self.builder,
+            _marker: std::marker::PhantomData,
+        }
     }
 
     /// Override the number of nonce retries for this transaction on `InvalidNonce`
@@ -1265,8 +1295,8 @@ impl TransactionSend {
     }
 }
 
-impl IntoFuture for TransactionSend {
-    type Output = Result<FinalExecutionOutcome, Error>;
+impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
+    type Output = Result<W::Response, Error>;
     type IntoFuture = Pin<Box<dyn Future<Output = Self::Output> + Send>>;
 
     fn into_future(self) -> Self::IntoFuture {
@@ -1297,6 +1327,7 @@ impl IntoFuture for TransactionSend {
             async move {
                 // Retry loop for transient InvalidTxErrors (nonce conflicts, expired block hash)
                 let max_nonce_retries = builder.max_nonce_retries;
+                let wait_until = W::status();
                 let network = builder.rpc.url().to_string();
                 let mut last_error: Option<Error> = None;
                 let mut last_ak_nonce: Option<u64> = None;
@@ -1350,29 +1381,12 @@ impl IntoFuture for TransactionSend {
                     };
 
                     // Send
-                    match builder.rpc.send_tx(&signed_tx, builder.wait_until).await {
+                    match builder.rpc.send_tx(&signed_tx, wait_until).await {
                         Ok(response) => {
-                            let outcome = response.outcome.ok_or_else(|| {
-                                Error::InvalidTransaction(format!(
-                                    "Transaction {} submitted with wait_until={:?} but no execution \
-                                     outcome was returned. Use rpc().send_tx() for fire-and-forget \
-                                     submission.",
-                                    response.transaction_hash, builder.wait_until,
-                                ))
-                            })?;
-
-                            // Inspect outcome status — only InvalidTxError becomes Err.
-                            // ActionError means the tx executed (nonce incremented, gas consumed),
-                            // so we return Ok(outcome) and let the caller inspect is_failure().
-                            use crate::types::{FinalExecutionStatus, TxExecutionError};
-                            match outcome.status {
-                                FinalExecutionStatus::Failure(
-                                    TxExecutionError::InvalidTxError(e),
-                                ) => {
-                                    return Err(Error::InvalidTx(Box::new(e)));
-                                }
-                                _ => return Ok(outcome),
-                            }
+                            // W::convert handles the response appropriately:
+                            // - Executed levels: extract outcome, check for InvalidTxError
+                            // - Non-executed levels: return SendTxResponse directly
+                            return W::convert(response);
                         }
                         Err(RpcError::InvalidTx(
                             crate::types::InvalidTxError::InvalidNonce { tx_nonce, ak_nonce },

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -808,7 +808,7 @@ impl TransactionBuilder {
 
     /// Send the transaction.
     ///
-    /// Returns a [`TransactionSend`] that defaults to [`ExecutedOptimistic`] wait level.
+    /// Returns a [`TransactionSend`] that defaults to [`crate::types::ExecutedOptimistic`] wait level.
     /// Chain `.wait_until(...)` to change the wait level before awaiting.
     pub fn send(self) -> TransactionSend {
         TransactionSend {
@@ -1251,8 +1251,10 @@ impl IntoFuture for CallBuilder {
 /// Future for sending a transaction.
 ///
 /// The type parameter `W` determines the wait level and the return type:
-/// - Executed levels ([`ExecutedOptimistic`], [`Executed`], [`Final`]) → [`FinalExecutionOutcome`]
-/// - Non-executed levels ([`Submitted`], [`Included`], [`IncludedFinal`]) → [`SendTxResponse`]
+/// - Executed levels ([`crate::types::ExecutedOptimistic`], [`crate::types::Executed`],
+///   [`crate::types::Final`]) → [`FinalExecutionOutcome`]
+/// - Non-executed levels ([`crate::types::Submitted`], [`crate::types::Included`],
+///   [`crate::types::IncludedFinal`]) → [`crate::types::SendTxResponse`]
 pub struct TransactionSend<W: WaitLevel = crate::types::ExecutedOptimistic> {
     builder: TransactionBuilder,
     _marker: std::marker::PhantomData<W>,

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -172,7 +172,7 @@
 //!
 //! // Wait for different execution levels
 //! near.transfer("bob.testnet", NearToken::from_near(1))
-//!     .wait_until(TxExecutionStatus::Final)
+//!     .wait_until(Final)
 //!     .await?;
 //! # Ok(())
 //! # }

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -56,6 +56,7 @@ mod rpc;
 mod rpc_extra;
 mod transaction;
 mod units;
+mod wait_level;
 
 pub use account::{AccountId, AccountIdExt, AccountIdRef, AccountType, TryIntoAccountId};
 pub use action::{
@@ -100,3 +101,6 @@ pub use rpc_extra::{
 };
 pub use transaction::{SignedTransaction, Transaction};
 pub use units::{Gas, IntoGas, IntoNearToken, NearToken};
+pub use wait_level::{
+    Executed, ExecutedOptimistic, Final, Included, IncludedFinal, Submitted, WaitLevel,
+};

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -546,8 +546,9 @@ pub enum FinalExecutionStatus {
 
 /// Response from `send_tx` RPC.
 ///
-/// When `wait_until=NONE`, the outcome is absent and only `final_execution_status`
-/// is populated. For all other wait levels the outcome is present.
+/// The `outcome` field is `Some` only for executed wait levels
+/// (`ExecutedOptimistic`, `Executed`, `Final`). For non-executed levels
+/// (`NONE`, `Included`, `IncludedFinal`) the outcome is absent.
 ///
 /// The `transaction_hash` is always available regardless of wait level,
 /// populated from the signed transaction before sending.
@@ -671,7 +672,7 @@ impl FinalExecutionOutcome {
 /// The `Failure` variant contains an [`ActionError`] rather than
 /// [`TxExecutionError`] because receipt execution outcomes can only fail with
 /// action errors. Transaction-validation errors (`InvalidTxError`) are caught
-/// earlier in the send path and surfaced as [`Error::InvalidTx`].
+/// earlier in the send path and surfaced as [`crate::error::Error::InvalidTx`].
 ///
 /// The NEAR RPC serialises the failure as `{"Failure": {"ActionError": {…}}}`.
 /// A custom [`Deserialize`] impl unwraps the outer `TxExecutionError` envelope.

--- a/crates/near-kit/src/types/wait_level.rs
+++ b/crates/near-kit/src/types/wait_level.rs
@@ -1,0 +1,190 @@
+//! Type-safe wait levels for transaction submission.
+//!
+//! Instead of using a runtime enum, each wait level is its own type with an
+//! associated `Response` type. This lets the compiler determine the return type
+//! of `send().wait_until(...)` based on which marker you pass in:
+//!
+//! ```rust,no_run
+//! # use near_kit::*;
+//! # async fn example(near: &Near) -> Result<(), Error> {
+//! // Default — returns FinalExecutionOutcome
+//! near.transfer("bob.testnet", NearToken::from_near(1)).await?;
+//!
+//! // Executed levels — also returns FinalExecutionOutcome
+//! near.transfer("bob.testnet", NearToken::from_near(1))
+//!     .wait_until(Final)
+//!     .await?;
+//!
+//! // Non-executed levels — returns SendTxResponse
+//! let response = near.transfer("bob.testnet", NearToken::from_near(1))
+//!     .wait_until(Included)
+//!     .await?;
+//! println!("tx hash: {}", response.transaction_hash);
+//! # Ok(())
+//! # }
+//! ```
+
+use crate::error::Error;
+
+use super::block_reference::TxExecutionStatus;
+use super::rpc::{FinalExecutionOutcome, SendTxResponse};
+
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Trait for type-safe transaction wait levels.
+///
+/// Each wait level is a zero-sized marker type that carries:
+/// - The [`TxExecutionStatus`] to send to the RPC
+/// - An associated [`Response`](WaitLevel::Response) type that determines
+///   what `send().wait_until(...)` returns
+///
+/// This trait is sealed and cannot be implemented outside this crate.
+pub trait WaitLevel: sealed::Sealed + Send + Sync + 'static {
+    /// The type returned when awaiting a transaction with this wait level.
+    type Response: Send + 'static;
+
+    /// The RPC wait_until value.
+    fn status() -> TxExecutionStatus;
+
+    /// Convert an RPC response into the appropriate return type.
+    ///
+    /// For executed levels, this extracts the outcome and checks for
+    /// `InvalidTxError`. For non-executed levels, this returns the raw
+    /// `SendTxResponse`.
+    #[doc(hidden)]
+    fn convert(response: SendTxResponse) -> Result<Self::Response, Error>;
+}
+
+// =============================================================================
+// Non-executed wait levels → SendTxResponse
+// =============================================================================
+
+/// Don't wait, return immediately after the RPC accepts the transaction.
+///
+/// Returns [`SendTxResponse`] (no execution outcome available).
+///
+/// Named `Submitted` instead of `None` to avoid shadowing `Option::None`.
+#[derive(Clone, Copy, Debug)]
+pub struct Submitted;
+
+impl sealed::Sealed for Submitted {}
+impl WaitLevel for Submitted {
+    type Response = SendTxResponse;
+    fn status() -> TxExecutionStatus {
+        TxExecutionStatus::None
+    }
+    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
+        Ok(response)
+    }
+}
+
+/// Wait for the transaction to be included in a block.
+///
+/// Returns [`SendTxResponse`] (no execution outcome available).
+#[derive(Clone, Copy, Debug)]
+pub struct Included;
+
+impl sealed::Sealed for Included {}
+impl WaitLevel for Included {
+    type Response = SendTxResponse;
+    fn status() -> TxExecutionStatus {
+        TxExecutionStatus::Included
+    }
+    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
+        Ok(response)
+    }
+}
+
+/// Wait for the transaction's block to reach finality.
+///
+/// Returns [`SendTxResponse`] (no execution outcome available).
+#[derive(Clone, Copy, Debug)]
+pub struct IncludedFinal;
+
+impl sealed::Sealed for IncludedFinal {}
+impl WaitLevel for IncludedFinal {
+    type Response = SendTxResponse;
+    fn status() -> TxExecutionStatus {
+        TxExecutionStatus::IncludedFinal
+    }
+    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
+        Ok(response)
+    }
+}
+
+// =============================================================================
+// Executed wait levels → FinalExecutionOutcome
+// =============================================================================
+
+/// Extract and validate the execution outcome from a response.
+fn extract_outcome(response: SendTxResponse, level: &str) -> Result<FinalExecutionOutcome, Error> {
+    let outcome = response.outcome.ok_or_else(|| {
+        Error::InvalidTransaction(format!(
+            "RPC returned no execution outcome for transaction {} at wait level {}",
+            response.transaction_hash, level,
+        ))
+    })?;
+
+    use super::error::TxExecutionError;
+    use super::rpc::FinalExecutionStatus;
+    match outcome.status {
+        FinalExecutionStatus::Failure(TxExecutionError::InvalidTxError(e)) => {
+            Err(Error::InvalidTx(Box::new(e)))
+        }
+        _ => Ok(outcome),
+    }
+}
+
+/// Wait for execution (optimistic, not yet finalized).
+///
+/// Returns [`FinalExecutionOutcome`]. This is the default when using
+/// `.send().await` without specifying a wait level.
+#[derive(Clone, Copy, Debug)]
+pub struct ExecutedOptimistic;
+
+impl sealed::Sealed for ExecutedOptimistic {}
+impl WaitLevel for ExecutedOptimistic {
+    type Response = FinalExecutionOutcome;
+    fn status() -> TxExecutionStatus {
+        TxExecutionStatus::ExecutedOptimistic
+    }
+    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
+        extract_outcome(response, "ExecutedOptimistic")
+    }
+}
+
+/// Wait for execution in a finalized block.
+///
+/// Returns [`FinalExecutionOutcome`].
+#[derive(Clone, Copy, Debug)]
+pub struct Executed;
+
+impl sealed::Sealed for Executed {}
+impl WaitLevel for Executed {
+    type Response = FinalExecutionOutcome;
+    fn status() -> TxExecutionStatus {
+        TxExecutionStatus::Executed
+    }
+    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
+        extract_outcome(response, "Executed")
+    }
+}
+
+/// Wait for full finality (all receipts executed, all blocks finalized).
+///
+/// Returns [`FinalExecutionOutcome`].
+#[derive(Clone, Copy, Debug)]
+pub struct Final;
+
+impl sealed::Sealed for Final {}
+impl WaitLevel for Final {
+    type Response = FinalExecutionOutcome;
+    fn status() -> TxExecutionStatus {
+        TxExecutionStatus::Final
+    }
+    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
+        extract_outcome(response, "Final")
+    }
+}

--- a/crates/near-kit/tests/integration/basic_integration.rs
+++ b/crates/near-kit/tests/integration/basic_integration.rs
@@ -142,7 +142,7 @@ async fn test_create_and_query_account() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(new_account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/debug_rpc_responses.rs
+++ b/crates/near-kit/tests/integration/debug_rpc_responses.rs
@@ -160,7 +160,7 @@ async fn debug_transaction_receipts() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -332,7 +332,7 @@ async fn debug_access_key_details() {
             Some(NearToken::from_near(1)), // allowance
         )
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -454,7 +454,7 @@ async fn test_error_invalid_method() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/delegate_action_integration.rs
+++ b/crates/near-kit/tests/integration/delegate_action_integration.rs
@@ -48,7 +48,7 @@ async fn test_delegate_action_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -62,7 +62,7 @@ async fn test_delegate_action_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(relayer_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -76,7 +76,7 @@ async fn test_delegate_action_transfer() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(recipient_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -129,7 +129,7 @@ async fn test_delegate_action_transfer() {
         .transaction(signed_delegate.sender_id())
         .signed_delegate_action(signed_delegate)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -169,7 +169,7 @@ async fn test_delegate_action_function_call() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -183,7 +183,7 @@ async fn test_delegate_action_function_call() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(relayer_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -202,7 +202,7 @@ async fn test_delegate_action_function_call() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -240,7 +240,7 @@ async fn test_delegate_action_function_call() {
         .transaction(signed_delegate.sender_id())
         .signed_delegate_action(signed_delegate)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -265,7 +265,7 @@ async fn test_delegate_action_multiple_actions() {
         .transfer(NearToken::from_near(20))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -279,7 +279,7 @@ async fn test_delegate_action_multiple_actions() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(relayer_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -322,7 +322,7 @@ async fn test_delegate_action_multiple_actions() {
         .transaction(signed_delegate.sender_id())
         .signed_delegate_action(signed_delegate)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -356,7 +356,7 @@ async fn test_delegate_action_roundtrip_encoding() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -370,7 +370,7 @@ async fn test_delegate_action_roundtrip_encoding() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(recipient_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -429,7 +429,7 @@ async fn test_delegate_action_validation_errors() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/error_consolidation_integration.rs
+++ b/crates/near-kit/tests/integration/error_consolidation_integration.rs
@@ -40,7 +40,7 @@ async fn test_successful_transfer_returns_ok() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Successful transaction should return Ok");
 
@@ -66,7 +66,7 @@ async fn test_action_error_returns_ok_with_failure_outcome() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -81,7 +81,7 @@ async fn test_action_error_returns_ok_with_failure_outcome() {
         .transaction(&account_id)
         .delete_key(fake_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -114,7 +114,7 @@ async fn test_function_call_error_returns_ok_with_failure_outcome() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -155,7 +155,7 @@ async fn test_wrong_signer_key_returns_access_key_not_found() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/error_handling_integration.rs
+++ b/crates/near-kit/tests/integration/error_handling_integration.rs
@@ -147,7 +147,7 @@ async fn test_error_view_on_newly_created_account() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -181,7 +181,7 @@ async fn test_error_view_nonexistent_method() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -229,7 +229,7 @@ async fn test_error_view_with_invalid_args() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -263,7 +263,7 @@ async fn test_error_transfer_to_nonexistent_implicit_account() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -302,7 +302,7 @@ async fn test_error_insufficient_balance_transfer() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -321,7 +321,7 @@ async fn test_error_insufficient_balance_transfer() {
         .transfer(NearToken::from_millinear(100))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -350,7 +350,7 @@ async fn test_error_create_account_that_already_exists() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -368,7 +368,7 @@ async fn test_error_create_account_that_already_exists() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(new_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -394,7 +394,7 @@ async fn test_error_delete_nonexistent_key() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -409,7 +409,7 @@ async fn test_error_delete_nonexistent_key() {
         .transaction(&account_id)
         .delete_key(fake_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -445,7 +445,7 @@ async fn test_error_function_call_panic() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -488,7 +488,7 @@ async fn test_error_function_call_insufficient_gas() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -44,7 +44,7 @@ async fn create_funded_account(
         .transfer(funding)
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -76,7 +76,7 @@ async fn test_near_publish_shorthand_updatable() {
     let outcome = publisher_near
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -98,7 +98,7 @@ async fn test_near_publish_shorthand_immutable() {
     let outcome = publisher_near
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -121,7 +121,7 @@ async fn test_near_deploy_from_shorthand_publisher() {
     publisher_near
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -132,7 +132,7 @@ async fn test_near_deploy_from_shorthand_publisher() {
     user_near
         .deploy_from(publisher_id.clone())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -161,7 +161,7 @@ async fn test_near_deploy_from_shorthand_hash() {
     publisher_near
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -172,7 +172,7 @@ async fn test_near_deploy_from_shorthand_hash() {
     user_near
         .deploy_from(code_hash)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -201,7 +201,7 @@ async fn test_publish_deploy_from_call_end_to_end() {
     publisher_near
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -212,7 +212,7 @@ async fn test_publish_deploy_from_call_end_to_end() {
     user_near
         .deploy_from(publisher_id.as_str())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -224,7 +224,7 @@ async fn test_publish_deploy_from_call_end_to_end() {
         .gas(Gas::from_tgas(30))
         .deposit(NearToken::ZERO)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -256,7 +256,7 @@ async fn test_publish_contract_by_account() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -284,7 +284,7 @@ async fn test_publish_contract_by_hash() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -312,7 +312,7 @@ async fn test_deploy_from_publisher() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -325,7 +325,7 @@ async fn test_deploy_from_publisher() {
         .transaction(&user_id)
         .deploy_from(publisher_id.clone())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -367,7 +367,7 @@ async fn test_deploy_from_hash() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -380,7 +380,7 @@ async fn test_deploy_from_hash() {
         .transaction(&user_id)
         .deploy_from(code_hash)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -419,7 +419,7 @@ async fn test_state_init_by_hash() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -431,7 +431,7 @@ async fn test_state_init_by_hash() {
     let outcome = publisher_near
         .state_init(si, NearToken::from_near(5))
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -459,7 +459,7 @@ async fn test_state_init_by_publisher() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -473,7 +473,7 @@ async fn test_state_init_by_publisher() {
     let outcome = publisher_near
         .state_init(si, NearToken::from_near(5))
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -506,7 +506,7 @@ async fn test_action_create_account() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(child_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -531,7 +531,7 @@ async fn test_action_transfer() {
         .transaction(&receiver_id)
         .transfer(NearToken::from_near(3))
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -557,7 +557,7 @@ async fn test_action_deploy_contract() {
         .transaction(&contract_id)
         .deploy(wasm_code)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -583,7 +583,7 @@ async fn test_action_function_call() {
         .transaction(&contract_id)
         .deploy(wasm_code)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -595,7 +595,7 @@ async fn test_action_function_call() {
         .gas(Gas::from_tgas(30))
         .deposit(NearToken::ZERO)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 }
@@ -616,7 +616,7 @@ async fn test_action_add_full_access_key() {
         .transaction(&account_id)
         .add_full_access_key(new_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -647,7 +647,7 @@ async fn test_action_add_function_call_key() {
             Some(NearToken::from_near(1)),
         )
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -673,7 +673,7 @@ async fn test_action_delete_key() {
         .transaction(&account_id)
         .add_full_access_key(second_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -686,7 +686,7 @@ async fn test_action_delete_key() {
         .transaction(&account_id)
         .delete_key(second_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -715,7 +715,7 @@ async fn test_action_delete_account() {
         .transfer(NearToken::from_near(2))
         .add_full_access_key(to_delete_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -731,7 +731,7 @@ async fn test_action_delete_account() {
         .transaction(&to_delete_id)
         .delete_account(&beneficiary_id)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -766,7 +766,7 @@ async fn test_action_stake() {
         .transaction(&staker_id)
         .stake(stake_amount, staker_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -801,7 +801,7 @@ async fn test_multiple_actions() {
         .add_full_access_key(child_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -833,7 +833,7 @@ async fn test_multiple_function_calls() {
         .transaction(&contract_id)
         .deploy(wasm_code)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -847,7 +847,7 @@ async fn test_multiple_function_calls() {
         .args(serde_json::json!({ "text": "Second message" }))
         .gas(Gas::from_tgas(15))
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/offline_signing_integration.rs
+++ b/crates/near-kit/tests/integration/offline_signing_integration.rs
@@ -39,7 +39,7 @@ async fn test_sign_offline_transfer() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -58,7 +58,7 @@ async fn test_sign_offline_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -132,7 +132,7 @@ async fn test_sign_offline_function_call() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -171,7 +171,7 @@ async fn test_sign_offline_function_call() {
 
     // Send and wait for finalization so the view call sees the state change
     let _outcome = contract_near
-        .send_with_options(&signed, TxExecutionStatus::Final)
+        .send_with_options(&signed, Final)
         .await
         .unwrap();
 
@@ -206,7 +206,7 @@ async fn test_signed_transaction_roundtrip_bytes() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -225,7 +225,7 @@ async fn test_signed_transaction_roundtrip_bytes() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -279,7 +279,7 @@ async fn test_signed_transaction_roundtrip_base64() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -298,7 +298,7 @@ async fn test_signed_transaction_roundtrip_base64() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -344,7 +344,7 @@ async fn test_offline_sign_and_transport_simulation() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -364,7 +364,7 @@ async fn test_offline_sign_and_transport_simulation() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -267,7 +267,7 @@ async fn test_final_execution_outcome_full_fields() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -339,7 +339,7 @@ async fn test_execution_metadata_and_gas_profile() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -387,7 +387,7 @@ async fn test_tx_status_with_receipts() {
         .transfer(NearToken::from_near(2))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -481,7 +481,7 @@ async fn test_action_view_variants() {
         .transfer(NearToken::from_near(3))
         .add_full_access_key(account1_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -40,7 +40,7 @@ async fn test_sandbox_balance() {
         .transfer(NearToken::from_near(1000))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -67,7 +67,7 @@ async fn test_sandbox_transfer() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -88,7 +88,7 @@ async fn test_sandbox_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -122,7 +122,7 @@ async fn test_sandbox_multiple_transfers() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -145,7 +145,7 @@ async fn test_sandbox_multiple_transfers() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(receiver1_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -156,7 +156,7 @@ async fn test_sandbox_multiple_transfers() {
         .transfer(NearToken::from_near(3))
         .add_full_access_key(receiver2_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -187,7 +187,7 @@ async fn test_sandbox_simple_transfer() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -206,7 +206,7 @@ async fn test_sandbox_simple_transfer() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -215,7 +215,7 @@ async fn test_sandbox_simple_transfer() {
     // Now do a simple transfer using the convenience method
     sender_near
         .transfer(&receiver_id, NearToken::from_near(2))
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -245,7 +245,7 @@ async fn test_sandbox_create_account_outcome() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -265,7 +265,7 @@ async fn test_sandbox_create_account_outcome() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(contract_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -289,7 +289,7 @@ async fn test_sandbox_delete_account() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(parent_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -308,7 +308,7 @@ async fn test_sandbox_delete_account() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(temp_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -326,7 +326,7 @@ async fn test_sandbox_delete_account() {
         .transaction(&temp_id)
         .delete_account(&parent_id)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -350,7 +350,7 @@ async fn test_sandbox_add_and_delete_key() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -367,7 +367,7 @@ async fn test_sandbox_add_and_delete_key() {
         .transaction(&account_id)
         .add_full_access_key(second_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -380,7 +380,7 @@ async fn test_sandbox_add_and_delete_key() {
         .transaction(&account_id)
         .delete_key(second_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -405,7 +405,7 @@ async fn test_sandbox_multiple_actions_in_one_transaction() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(parent_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -428,7 +428,7 @@ async fn test_sandbox_multiple_actions_in_one_transaction() {
         .transfer(NearToken::from_near(20))
         .add_full_access_key(alice_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -439,7 +439,7 @@ async fn test_sandbox_multiple_actions_in_one_transaction() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(bob_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -475,7 +475,7 @@ async fn test_sandbox_set_balance() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -516,7 +516,7 @@ async fn test_sandbox_set_balance_preserves_other_fields() {
         .add_full_access_key(account_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -574,7 +574,7 @@ async fn test_sandbox_set_balance_for_staking() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(validator_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -600,7 +600,7 @@ async fn test_sandbox_set_balance_for_staking() {
         .transaction(&validator_id)
         .stake(stake_amount, validator_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -627,7 +627,7 @@ async fn test_sandbox_patch_debug() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -685,7 +685,7 @@ async fn test_sign_message_nep413() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -753,7 +753,7 @@ async fn test_send_with_options_final() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -772,7 +772,7 @@ async fn test_send_with_options_final() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -786,10 +786,7 @@ async fn test_send_with_options_final() {
     println!("Signed transaction hash: {}", signed.get_hash());
 
     // Send with Final wait option
-    let outcome = sender_near
-        .send_with_options(&signed, TxExecutionStatus::Final)
-        .await
-        .unwrap();
+    let outcome = sender_near.send_with_options(&signed, Final).await.unwrap();
 
     println!("Transaction succeeded: {:?}", outcome.transaction_hash());
 
@@ -797,6 +794,122 @@ async fn test_send_with_options_final() {
     let balance = root_near.balance(&receiver_id).await.unwrap();
     println!("Receiver balance: {}", balance.total);
     assert!(balance.total > NearToken::from_near(14));
+}
+
+#[tokio::test]
+async fn test_send_with_options_included_returns_send_tx_response() {
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    // Create sender account
+    let sender_key = SecretKey::generate_ed25519();
+    let sender_id = unique_account();
+
+    root_near
+        .transaction(&sender_id)
+        .create_account()
+        .transfer(NearToken::from_near(100))
+        .add_full_access_key(sender_key.public_key())
+        .send()
+        .wait_until(Final)
+        .await
+        .unwrap();
+
+    let sender_near = Near::custom(rpc_url)
+        .credentials(sender_key.to_string(), &sender_id)
+        .unwrap()
+        .build();
+
+    // Create receiver account
+    let receiver_key = SecretKey::generate_ed25519();
+    let receiver_id: AccountId = format!("recv-inc.{}", sender_id).parse().unwrap();
+
+    sender_near
+        .transaction(&receiver_id)
+        .create_account()
+        .transfer(NearToken::from_near(10))
+        .add_full_access_key(receiver_key.public_key())
+        .send()
+        .wait_until(Final)
+        .await
+        .unwrap();
+
+    // Sign and send with Included — returns SendTxResponse, not FinalExecutionOutcome
+    let signed = sender_near
+        .transfer(&receiver_id, NearToken::from_near(1))
+        .sign()
+        .await
+        .unwrap();
+
+    let response = sender_near
+        .send_with_options(&signed, Included)
+        .await
+        .unwrap();
+
+    // SendTxResponse always has transaction_hash
+    assert!(!response.transaction_hash.is_zero());
+
+    // Included does not wait for execution, so outcome should be None
+    assert!(
+        response.outcome.is_none(),
+        "expected no outcome for Included, got: {:?}",
+        response.outcome
+    );
+}
+
+#[tokio::test]
+async fn test_wait_until_included_on_builder() {
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+    let rpc_url = sandbox.rpc_url();
+
+    // Create sender account
+    let sender_key = SecretKey::generate_ed25519();
+    let sender_id = unique_account();
+
+    root_near
+        .transaction(&sender_id)
+        .create_account()
+        .transfer(NearToken::from_near(100))
+        .add_full_access_key(sender_key.public_key())
+        .send()
+        .wait_until(Final)
+        .await
+        .unwrap();
+
+    let sender_near = Near::custom(rpc_url)
+        .credentials(sender_key.to_string(), &sender_id)
+        .unwrap()
+        .build();
+
+    // Create receiver account
+    let receiver_key = SecretKey::generate_ed25519();
+    let receiver_id: AccountId = format!("recv-inc2.{}", sender_id).parse().unwrap();
+
+    sender_near
+        .transaction(&receiver_id)
+        .create_account()
+        .transfer(NearToken::from_near(10))
+        .add_full_access_key(receiver_key.public_key())
+        .send()
+        .wait_until(Final)
+        .await
+        .unwrap();
+
+    // Use Included directly on the builder — this was the original bug path
+    let response: SendTxResponse = sender_near
+        .transfer(&receiver_id, NearToken::from_near(1))
+        .wait_until(Included)
+        .await
+        .unwrap();
+
+    assert!(!response.transaction_hash.is_zero());
+    assert!(
+        response.outcome.is_none(),
+        "expected no outcome for Included, got: {:?}",
+        response.outcome
+    );
 }
 
 #[tokio::test]
@@ -815,7 +928,7 @@ async fn test_send_pre_signed_transaction() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -834,7 +947,7 @@ async fn test_send_pre_signed_transaction() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
+++ b/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
@@ -38,7 +38,7 @@ async fn test_in_memory_signer_from_secret_key() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -55,7 +55,7 @@ async fn test_in_memory_signer_from_secret_key() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -80,7 +80,7 @@ async fn test_in_memory_signer_from_seed_phrase() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -123,7 +123,7 @@ async fn test_rotating_signer_uses_multiple_keys() {
         .add_full_access_key(key2.public_key())
         .add_full_access_key(key3.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -140,7 +140,7 @@ async fn test_rotating_signer_uses_multiple_keys() {
             .transfer(NearToken::from_near(1))
             .add_full_access_key(SecretKey::generate_ed25519().public_key())
             .send()
-            .wait_until(TxExecutionStatus::Final)
+            .wait_until(Final)
             .await
             .unwrap();
     }
@@ -167,7 +167,7 @@ async fn test_rotating_signer_with_single_key() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -183,7 +183,7 @@ async fn test_rotating_signer_with_single_key() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -232,7 +232,7 @@ async fn test_sign_with_override() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(key1.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -242,7 +242,7 @@ async fn test_sign_with_override() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(key2.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -262,7 +262,7 @@ async fn test_sign_with_override() {
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .sign_with(signer2)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -291,7 +291,7 @@ async fn test_wrong_key_for_account() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(correct_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -309,7 +309,7 @@ async fn test_wrong_key_for_account() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await;
 
     assert!(result.is_err(), "Should fail with wrong key");
@@ -341,7 +341,7 @@ async fn test_deleted_key_fails() {
         .add_full_access_key(key1.public_key())
         .add_full_access_key(key2.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -359,7 +359,7 @@ async fn test_deleted_key_fails() {
 
     near2
         .delete_key(key1.public_key())
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -371,7 +371,7 @@ async fn test_deleted_key_fails() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await;
 
     assert!(result.is_err(), "Should fail with deleted key");
@@ -393,7 +393,7 @@ async fn test_signing_with_ed25519_key() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(ed_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -410,7 +410,7 @@ async fn test_signing_with_ed25519_key() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/token_error_integration.rs
+++ b/crates/near-kit/tests/integration/token_error_integration.rs
@@ -37,7 +37,7 @@ async fn test_ft_metadata_on_non_contract_account() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -88,7 +88,7 @@ async fn test_ft_balance_of_on_non_contract() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -117,7 +117,7 @@ async fn test_ft_transfer_without_signer() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -178,7 +178,7 @@ async fn test_ft_on_wrong_contract_type() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -217,7 +217,7 @@ async fn test_nft_metadata_on_non_contract() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -241,7 +241,7 @@ async fn test_nft_token_on_non_contract() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -285,7 +285,7 @@ async fn test_nft_on_wrong_contract_type() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/token_integration.rs
+++ b/crates/near-kit/tests/integration/token_integration.rs
@@ -40,7 +40,7 @@ async fn deploy_ft_contract(
         .add_full_access_key(ft_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await?;
 
     // Initialize the FT contract
@@ -82,7 +82,7 @@ async fn test_ft_metadata() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -116,7 +116,7 @@ async fn test_ft_balance_of() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -158,7 +158,7 @@ async fn test_ft_total_supply() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -189,7 +189,7 @@ async fn test_ft_transfer() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -208,7 +208,7 @@ async fn test_ft_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -221,7 +221,7 @@ async fn test_ft_transfer() {
     // First, register receiver for storage
     let bounds = ft.storage_balance_bounds().await.unwrap();
     ft.storage_deposit(&receiver_id, bounds.min)
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -240,7 +240,7 @@ async fn test_ft_transfer() {
     let transfer_amount = 100_000_000_000_000_000_000_u128; // 100 tokens (18 decimals)
 
     ft.transfer_with_memo(&receiver_id, transfer_amount, "Test transfer")
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -279,7 +279,7 @@ async fn test_ft_storage_deposit() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -299,7 +299,7 @@ async fn test_ft_storage_deposit() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(user_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -314,7 +314,7 @@ async fn test_ft_storage_deposit() {
     // Register user
     let bounds = ft.storage_balance_bounds().await.unwrap();
     ft.storage_deposit(&user_id, bounds.min)
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -348,7 +348,7 @@ async fn deploy_nft_contract(
         .add_full_access_key(nft_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await?;
 
     // Initialize the NFT contract
@@ -417,7 +417,7 @@ async fn test_nft_metadata() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -450,7 +450,7 @@ async fn test_nft_token_query() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -497,7 +497,7 @@ async fn test_nft_tokens_for_owner() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -558,7 +558,7 @@ async fn test_nft_transfer() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -578,7 +578,7 @@ async fn test_nft_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -599,7 +599,7 @@ async fn test_nft_transfer() {
     let nft_with_signer = owner_near.nft(&nft_id).unwrap();
     nft_with_signer
         .transfer_with_memo(&receiver_id, "transfer-test", "Gift for you!")
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -625,7 +625,7 @@ async fn test_nft_total_supply() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -674,7 +674,7 @@ async fn test_nft_supply_for_owner() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner1_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -694,7 +694,7 @@ async fn test_nft_supply_for_owner() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(owner2_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -760,7 +760,7 @@ async fn test_ft_amount_arithmetic_from_real_balances() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -803,7 +803,7 @@ async fn test_ft_metadata_caching() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/tracing_integration.rs
+++ b/crates/near-kit/tests/integration/tracing_integration.rs
@@ -125,7 +125,7 @@ async fn test_send_transaction_span_hierarchy() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -212,7 +212,7 @@ async fn test_ft_balance_of_span_hierarchy() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -227,7 +227,7 @@ async fn test_ft_balance_of_span_hierarchy() {
         .add_full_access_key(ft_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -249,7 +249,7 @@ async fn test_ft_balance_of_span_hierarchy() {
             }
         }))
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/transaction_failure_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_failure_integration.rs
@@ -37,7 +37,7 @@ async fn test_deploy_invalid_wasm() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -69,7 +69,7 @@ async fn test_deploy_empty_wasm() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -128,7 +128,7 @@ async fn test_add_duplicate_key() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -163,7 +163,7 @@ async fn test_delete_last_full_access_key() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -200,7 +200,7 @@ async fn test_create_subaccount_of_nonexistent_parent() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -226,7 +226,7 @@ async fn test_create_account_without_initial_balance() {
         .add_full_access_key(key.public_key())
         // No .transfer() call
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await;
 
     // Note: Creating an account without balance may succeed
@@ -250,7 +250,7 @@ async fn test_create_account_with_insufficient_balance() {
         .transfer(NearToken::from_yoctonear(1)) // Way too small
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await;
 
     // This may fail due to insufficient balance for storage
@@ -274,7 +274,7 @@ async fn test_transaction_with_failing_action_in_middle() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -293,7 +293,7 @@ async fn test_transaction_with_failing_action_in_middle() {
         .transaction(&account_id)
         .delete_key(fake_key.public_key()) // This key doesn't exist
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -320,7 +320,7 @@ async fn test_delete_nonexistent_account() {
         .transaction(&nonexistent)
         .delete_account(SANDBOX_ROOT_ACCOUNT)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -347,7 +347,7 @@ async fn test_delete_account_to_nonexistent_beneficiary() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -363,7 +363,7 @@ async fn test_delete_account_to_nonexistent_beneficiary() {
         .transaction(&account_id)
         .delete_account(&nonexistent_beneficiary)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await;
 
     // This should fail because the beneficiary doesn't exist
@@ -387,7 +387,7 @@ async fn test_stake_with_insufficient_balance() {
         .transfer(NearToken::from_near(1)) // Small balance
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -401,7 +401,7 @@ async fn test_stake_with_insufficient_balance() {
         .transaction(&account_id)
         .stake(NearToken::from_near(1000), key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -432,7 +432,7 @@ async fn test_transfer_zero_amount() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -451,7 +451,7 @@ async fn test_transfer_zero_amount() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -477,7 +477,7 @@ async fn test_transfer_max_amount() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/transaction_outcome_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_outcome_integration.rs
@@ -35,7 +35,7 @@ async fn test_failed_transaction_preserves_receipts() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("setup: deploy should succeed")
         .result()

--- a/crates/near-kit/tests/integration/typed_contract_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_error_integration.rs
@@ -96,7 +96,7 @@ async fn test_typed_contract_view_on_account_without_contract() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -133,7 +133,7 @@ async fn test_typed_contract_call_without_signer() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -173,7 +173,7 @@ async fn test_typed_contract_view_on_wrong_contract_type() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -211,7 +211,7 @@ async fn test_typed_contract_call_with_insufficient_gas() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -255,7 +255,7 @@ async fn test_typed_contract_view_returns_wrong_type() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -301,7 +301,7 @@ async fn test_typed_contract_query_at_invalid_block() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 
@@ -342,7 +342,7 @@ async fn test_typed_contract_view_methods_still_work_without_signer() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/typed_contract_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_integration.rs
@@ -76,7 +76,7 @@ async fn deploy_guestbook(near: &Near, contract_account: &str) -> Result<(), nea
         .add_full_access_key(new_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await?;
 
     Ok(())
@@ -138,7 +138,7 @@ async fn test_typed_contract_call_methods() {
         .add_message(AddMessageArgs {
             text: "Hello from typed contract!".to_string(),
         })
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Failed to add message");
 
@@ -184,7 +184,7 @@ async fn test_typed_contract_multiple_messages() {
             .add_message(AddMessageArgs {
                 text: text.to_string(),
             })
-            .wait_until(TxExecutionStatus::Final)
+            .wait_until(Final)
             .await
             .expect("Failed to add message");
     }
@@ -231,7 +231,7 @@ async fn test_typed_contract_with_custom_gas() {
             text: "Message with custom gas".to_string(),
         })
         .gas("50 Tgas")
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Failed to add message with custom gas");
 
@@ -265,7 +265,7 @@ async fn test_typed_contract_block_reference() {
         .add_message(AddMessageArgs {
             text: "Test message".to_string(),
         })
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Failed to add message");
 
@@ -301,7 +301,7 @@ async fn test_typed_contract_payable_method() {
         .add_message(AddMessageArgs {
             text: "Regular message".to_string(),
         })
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Failed to add regular message");
 
@@ -311,7 +311,7 @@ async fn test_typed_contract_payable_method() {
             text: "Premium message".to_string(),
         })
         .deposit("1 NEAR")
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Failed to add premium message");
 
@@ -375,7 +375,7 @@ async fn test_typed_contract_no_args_view() {
         .add_message(AddMessageArgs {
             text: "Test message".to_string(),
         })
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .expect("Failed to add message");
 

--- a/crates/near-kit/tests/integration/typed_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_error_integration.rs
@@ -32,7 +32,7 @@ async fn funded_account(
         .transfer(balance)
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(TxExecutionStatus::Final)
+        .wait_until(Final)
         .await
         .unwrap();
 


### PR DESCRIPTION
## Summary

- Introduces a sealed `WaitLevel` trait with marker types (`Final`, `Included`, `ExecutedOptimistic`, etc.) that determine the return type at compile time
- Executed levels (`ExecutedOptimistic`, `Executed`, `Final`) → `FinalExecutionOutcome`
- Non-executed levels (`Submitted`, `Included`, `IncludedFinal`) → `SendTxResponse`
- `TransactionSend<W>` is generic over the wait level, so the compiler enforces the correct return type
- The default `.send().await` path is unchanged — still returns `FinalExecutionOutcome`

Fixes the bug where `.send().wait_until(Included).await` would error because the builder always expected a `FinalExecutionOutcome`, but non-executed wait levels legitimately return no execution outcome.

### Before
```rust
// ❌ Runtime error: "no execution outcome was returned"
near.transfer("bob", amount).send().wait_until(TxExecutionStatus::Included).await?;
```

### After
```rust
// ✅ Compile-time return type: SendTxResponse
let response = near.transfer("bob", amount).send().wait_until(Included).await?;
println!("tx hash: {}", response.transaction_hash);

// ✅ Compile-time return type: FinalExecutionOutcome (unchanged)
let outcome = near.transfer("bob", amount).send().wait_until(Final).await?;

// ✅ Default path unchanged
let outcome = near.transfer("bob", amount).await?;
```

Supersedes #159.

## Test plan
- [ ] Existing integration tests pass (all updated from `TxExecutionStatus::Final` → `Final`)
- [ ] New test: `test_send_with_options_included_returns_send_tx_response` — verifies `Included` returns `SendTxResponse` with `outcome: None`
- [ ] New test: `test_wait_until_included_on_builder` — verifies the builder path with `Included` (the original bug)