### PR TITLE
feat: unified FinalExecutionOutcome and high-level tx_status

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -880,40 +880,6 @@ impl Near {
         W::convert(response, &sender_id)
     }
 
-    /// Get the status of a transaction you sent.
-    ///
-    /// Convenience wrapper around [`tx_status`](Self::tx_status) that uses
-    /// the configured signer's account ID as the sender. Use this when
-    /// checking your own transactions.
-    ///
-    /// # Panics
-    ///
-    /// Panics if no signer is configured.
-    ///
-    /// # Example
-    ///
-    /// ```rust,no_run
-    /// # use near_kit::*;
-    /// # async fn example(near: &Near) -> Result<(), Error> {
-    /// let response = near.transfer("bob.testnet", NearToken::from_near(1))
-    ///     .wait_until(Included)
-    ///     .await?;
-    ///
-    /// // Later, poll for the full outcome:
-    /// let outcome = near.tx_status_of(&response.transaction_hash, Final).await?;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn tx_status_of<W: crate::types::WaitLevel>(
-        &self,
-        tx_hash: &crate::types::CryptoHash,
-        _level: W,
-    ) -> Result<W::Response, Error> {
-        let sender_id = self.account_id();
-        let response = self.rpc.tx_status(tx_hash, sender_id, W::status()).await?;
-        W::convert(response, sender_id)
-    }
-
     // ========================================================================
     // Convenience methods
     // ========================================================================

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -840,8 +840,78 @@ impl Near {
         signed_tx: &crate::types::SignedTransaction,
         _level: W,
     ) -> Result<W::Response, Error> {
+        let sender_id = &signed_tx.transaction.signer_id;
         let response = self.rpc.send_tx(signed_tx, W::status()).await?;
-        W::convert(response)
+        W::convert(response, sender_id)
+    }
+
+    /// Get transaction status with full receipt details.
+    ///
+    /// Uses `EXPERIMENTAL_tx_status` under the hood. The return type depends
+    /// on the wait level, just like [`send_with_options`](Self::send_with_options):
+    ///
+    /// - Executed levels ([`ExecutedOptimistic`](crate::types::ExecutedOptimistic),
+    ///   [`Executed`](crate::types::Executed), [`Final`](crate::types::Final))
+    ///   → [`FinalExecutionOutcome`](crate::types::FinalExecutionOutcome)
+    ///   (with `receipts` populated)
+    /// - Non-executed levels ([`Submitted`](crate::types::Submitted),
+    ///   [`Included`](crate::types::Included), [`IncludedFinal`](crate::types::IncludedFinal))
+    ///   → [`SendTxResponse`](crate::types::SendTxResponse)
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example(near: &Near, tx_hash: CryptoHash) -> Result<(), Error> {
+    /// let outcome = near.tx_status(&tx_hash, "alice.testnet", Final).await?;
+    /// println!("Gas used: {}", outcome.total_gas_used());
+    /// println!("Receipts: {}", outcome.receipts.len());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn tx_status<W: crate::types::WaitLevel>(
+        &self,
+        tx_hash: &crate::types::CryptoHash,
+        sender_id: impl crate::types::TryIntoAccountId,
+        _level: W,
+    ) -> Result<W::Response, Error> {
+        let sender_id = sender_id.try_into_account_id()?;
+        let response = self.rpc.tx_status(tx_hash, &sender_id, W::status()).await?;
+        W::convert(response, &sender_id)
+    }
+
+    /// Get the status of a transaction you sent.
+    ///
+    /// Convenience wrapper around [`tx_status`](Self::tx_status) that uses
+    /// the configured signer's account ID as the sender. Use this when
+    /// checking your own transactions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no signer is configured.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example(near: &Near) -> Result<(), Error> {
+    /// let response = near.transfer("bob.testnet", NearToken::from_near(1))
+    ///     .wait_until(Included)
+    ///     .await?;
+    ///
+    /// // Later, poll for the full outcome:
+    /// let outcome = near.tx_status_of(&response.transaction_hash, Final).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn tx_status_of<W: crate::types::WaitLevel>(
+        &self,
+        tx_hash: &crate::types::CryptoHash,
+        _level: W,
+    ) -> Result<W::Response, Error> {
+        let sender_id = self.account_id();
+        let response = self.rpc.tx_status(tx_hash, sender_id, W::status()).await?;
+        W::convert(response, sender_id)
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -7,10 +7,11 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::error::RpcError;
+use crate::types::rpc::RawTransactionResponse;
 use crate::types::{
     AccessKeyListView, AccessKeyView, AccountId, AccountView, BlockReference, BlockView,
-    CryptoHash, GasPrice, PublicKey, SendTxResponse, SendTxWithReceiptsResponse, SignedTransaction,
-    StatusResponse, TxExecutionStatus, ViewFunctionResult,
+    CryptoHash, GasPrice, PublicKey, SignedTransaction, StatusResponse, TxExecutionStatus,
+    ViewFunctionResult,
 };
 
 /// Network configuration presets.
@@ -587,34 +588,43 @@ impl RpcClient {
         &self,
         signed_tx: &SignedTransaction,
         wait_until: TxExecutionStatus,
-    ) -> Result<SendTxResponse, RpcError> {
+    ) -> Result<RawTransactionResponse, RpcError> {
         let tx_hash = signed_tx.get_hash();
         tracing::Span::current().record("tx_hash", tracing::field::display(&tx_hash));
         let params = serde_json::json!({
             "signed_tx_base64": signed_tx.to_base64(),
             "wait_until": wait_until.as_str(),
         });
-        let mut response: SendTxResponse = self.call("send_tx", params).await?;
+        let mut response: RawTransactionResponse = self.call("send_tx", params).await?;
         response.transaction_hash = tx_hash;
         Ok(response)
     }
 
     /// Get transaction status with full receipt details.
     ///
-    /// Uses EXPERIMENTAL_tx_status which returns complete receipt information.
+    /// Uses `EXPERIMENTAL_tx_status` which returns complete receipt information.
+    /// When the transaction has been executed, the outcome's `receipts` field
+    /// will be populated (unlike `send_tx` which leaves it empty).
     #[tracing::instrument(skip(self), fields(%tx_hash, sender = %sender_id, ?wait_until))]
     pub async fn tx_status(
         &self,
         tx_hash: &CryptoHash,
         sender_id: &AccountId,
         wait_until: TxExecutionStatus,
-    ) -> Result<SendTxWithReceiptsResponse, RpcError> {
+    ) -> Result<RawTransactionResponse, RpcError> {
         let params = serde_json::json!({
             "tx_hash": tx_hash.to_string(),
             "sender_account_id": sender_id.to_string(),
             "wait_until": wait_until.as_str(),
         });
-        self.call("EXPERIMENTAL_tx_status", params).await
+        let mut response: RawTransactionResponse =
+            self.call("EXPERIMENTAL_tx_status", params).await?;
+        response.transaction_hash = response
+            .outcome
+            .as_ref()
+            .map(|o| *o.transaction_hash())
+            .unwrap_or(*tx_hash);
+        Ok(response)
     }
 
     /// Merge block reference parameters into a JSON object.

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1387,8 +1387,8 @@ impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
                         Ok(response) => {
                             // W::convert handles the response appropriately:
                             // - Executed levels: extract outcome, check for InvalidTxError
-                            // - Non-executed levels: return SendTxResponse directly
-                            return W::convert(response);
+                            // - Non-executed levels: build SendTxResponse with hash + sender
+                            return W::convert(response, &signer_id);
                         }
                         Err(RpcError::InvalidTx(
                             crate::types::InvalidTxError::InvalidNonce { tx_nonce, ak_nonce },

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -52,7 +52,7 @@ mod hash;
 mod key;
 pub mod nep413;
 mod network;
-mod rpc;
+pub(crate) mod rpc;
 mod rpc_extra;
 mod transaction;
 mod units;
@@ -88,9 +88,9 @@ pub use rpc::{
     BandwidthRequestBitmap, BandwidthRequests, BandwidthRequestsV1, BlockHeaderView, BlockView,
     ChunkHeaderView, CongestionInfoView, DataReceiptData, DataReceiverView, DelegateActionView,
     ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus,
-    FinalExecutionOutcome, FinalExecutionOutcomeWithReceipts, FinalExecutionStatus, GasPrice,
-    GasProfileEntry, GlobalContractIdentifierView, MerkleDirection, MerklePathItem, NodeVersion,
-    Receipt, ReceiptContent, STORAGE_AMOUNT_PER_BYTE, SendTxResponse, SendTxWithReceiptsResponse,
+    FinalExecutionOutcome, FinalExecutionStatus, GasPrice, GasProfileEntry,
+    GlobalContractIdentifierView, MerkleDirection, MerklePathItem, NodeVersion,
+    RawTransactionResponse, Receipt, ReceiptContent, STORAGE_AMOUNT_PER_BYTE, SendTxResponse,
     SlashedValidator, StatusResponse, SyncInfo, TransactionView, TrieSplit, ValidatorInfo,
     ValidatorStakeView, ValidatorStakeViewV1, ViewFunctionResult,
 };

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -544,30 +544,68 @@ pub enum FinalExecutionStatus {
     SuccessValue(String),
 }
 
-/// Response from `send_tx` RPC.
+/// Response returned for non-executed wait levels.
 ///
-/// The `outcome` field is `Some` only for executed wait levels
-/// (`ExecutedOptimistic`, `Executed`, `Final`). For non-executed levels
-/// (`NONE`, `Included`, `IncludedFinal`) the outcome is absent.
+/// When you use a non-executed wait level ([`Submitted`](crate::types::Submitted),
+/// [`Included`](crate::types::Included), [`IncludedFinal`](crate::types::IncludedFinal)),
+/// the transaction hasn't been executed yet so there's no outcome to return.
+/// This type gives you the information needed to poll for the result later
+/// via [`Near::tx_status`](crate::Near::tx_status).
 ///
-/// The `transaction_hash` is always available regardless of wait level,
-/// populated from the signed transaction before sending.
-#[derive(Debug, Clone, Deserialize)]
+/// # Example
+///
+/// ```rust,no_run
+/// # use near_kit::*;
+/// # async fn example(near: &Near) -> Result<(), Error> {
+/// let response = near.transfer("bob.testnet", NearToken::from_near(1))
+///     .wait_until(Included)
+///     .await?;
+///
+/// // Later, poll for the full outcome:
+/// let outcome = near.tx_status(
+///     &response.transaction_hash,
+///     &response.sender_id,
+///     Final,
+/// ).await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
 pub struct SendTxResponse {
-    /// Hash of the submitted transaction. Always present.
+    /// Hash of the submitted transaction.
+    pub transaction_hash: CryptoHash,
+    /// Account ID of the transaction signer.
+    pub sender_id: AccountId,
+}
+
+/// Raw RPC response for transaction submission/status (internal).
+///
+/// Used internally to deserialize responses from `send_tx` and
+/// `EXPERIMENTAL_tx_status` before converting to user-facing types
+/// via [`WaitLevel::convert`](crate::types::WaitLevel::convert).
+#[doc(hidden)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct RawTransactionResponse {
+    /// Transaction hash — populated after deserialization from the signed tx
+    /// (for `send_tx`) or from the outcome (for `tx_status`).
     #[serde(skip)]
     pub transaction_hash: CryptoHash,
-    /// The wait level that was reached (e.g. `NONE`, `EXECUTED_OPTIMISTIC`, `FINAL`).
+    /// The wait level that was reached.
     pub final_execution_status: TxExecutionStatus,
     /// The execution outcome, present when the transaction has been executed.
     #[serde(flatten)]
     pub outcome: Option<FinalExecutionOutcome>,
 }
 
-/// Final execution outcome from send_tx RPC.
+/// Final execution outcome from a NEAR transaction.
 ///
-/// All fields are required — this type only appears when a transaction has actually
-/// been executed (not for `wait_until=NONE` responses).
+/// Returned by both `send_tx` and `EXPERIMENTAL_tx_status` RPC methods.
+/// All fields are required — this type only appears when a transaction has
+/// actually been executed (not for non-executed wait levels).
+///
+/// The `receipts` field contains full receipt details when the outcome comes
+/// from `EXPERIMENTAL_tx_status` (i.e. `near.tx_status()`). When the outcome
+/// comes from `send_tx` (i.e. `near.send()`), this field is an empty `Vec`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct FinalExecutionOutcome {
     /// Overall transaction execution result.
@@ -578,6 +616,9 @@ pub struct FinalExecutionOutcome {
     pub transaction_outcome: ExecutionOutcomeWithId,
     /// Outcomes of all receipts spawned by the transaction.
     pub receipts_outcome: Vec<ExecutionOutcomeWithId>,
+    /// Full receipt details (populated by `tx_status`, empty from `send`).
+    #[serde(default)]
+    pub receipts: Vec<Receipt>,
 }
 
 impl FinalExecutionOutcome {
@@ -1078,54 +1119,6 @@ pub struct DataReceiptData {
     pub data: Option<String>,
 }
 
-/// Response from `EXPERIMENTAL_tx_status` RPC.
-///
-/// Same pattern as [`SendTxResponse`] but includes full receipt details.
-#[derive(Debug, Clone, Deserialize)]
-pub struct SendTxWithReceiptsResponse {
-    /// The wait level that was reached.
-    pub final_execution_status: TxExecutionStatus,
-    /// The execution outcome, present when the transaction has been executed.
-    #[serde(flatten)]
-    pub outcome: Option<FinalExecutionOutcomeWithReceipts>,
-}
-
-/// Final execution outcome with receipts (from EXPERIMENTAL_tx_status).
-///
-/// All fields are required — this type only appears when a transaction has actually
-/// been executed.
-#[derive(Debug, Clone, Deserialize)]
-pub struct FinalExecutionOutcomeWithReceipts {
-    /// Overall transaction execution result.
-    pub status: FinalExecutionStatus,
-    /// The transaction that was executed.
-    pub transaction: TransactionView,
-    /// Outcome of the transaction itself.
-    pub transaction_outcome: ExecutionOutcomeWithId,
-    /// Outcomes of all receipts spawned by the transaction.
-    pub receipts_outcome: Vec<ExecutionOutcomeWithId>,
-    /// Full receipt details.
-    #[serde(default)]
-    pub receipts: Vec<Receipt>,
-}
-
-impl FinalExecutionOutcomeWithReceipts {
-    /// Check if the transaction succeeded.
-    pub fn is_success(&self) -> bool {
-        matches!(&self.status, FinalExecutionStatus::SuccessValue(_))
-    }
-
-    /// Check if the transaction failed.
-    pub fn is_failure(&self) -> bool {
-        matches!(&self.status, FinalExecutionStatus::Failure(_))
-    }
-
-    /// Get the transaction hash.
-    pub fn transaction_hash(&self) -> &CryptoHash {
-        &self.transaction_outcome.id
-    }
-}
-
 // ============================================================================
 // Node status types
 // ============================================================================
@@ -1611,7 +1604,7 @@ mod tests {
             },
             "receipts_outcome": []
         });
-        let response: SendTxResponse = serde_json::from_value(json).unwrap();
+        let response: RawTransactionResponse = serde_json::from_value(json).unwrap();
         assert_eq!(response.final_execution_status, TxExecutionStatus::Final);
         let outcome = response.outcome.unwrap();
         assert!(outcome.is_success());
@@ -1623,10 +1616,10 @@ mod tests {
         let json = serde_json::json!({
             "final_execution_status": "NONE"
         });
-        let response: SendTxResponse = serde_json::from_value(json).unwrap();
+        let response: RawTransactionResponse = serde_json::from_value(json).unwrap();
         assert_eq!(response.final_execution_status, TxExecutionStatus::None);
         assert!(response.outcome.is_none());
-        // transaction_hash is serde(skip) — populated by rpc.send_tx(), not deserialization
+        // transaction_hash is serde(skip) — populated by rpc methods, not deserialization
         assert!(response.transaction_hash.is_zero());
     }
 
@@ -1670,7 +1663,7 @@ mod tests {
             },
             "receipts_outcome": []
         });
-        let response: SendTxResponse = serde_json::from_value(json).unwrap();
+        let response: RawTransactionResponse = serde_json::from_value(json).unwrap();
         let outcome = response.outcome.unwrap();
         assert!(outcome.is_failure());
         assert!(!outcome.is_success());
@@ -1710,7 +1703,7 @@ mod tests {
             },
             "receipts_outcome": []
         });
-        let response: SendTxResponse = serde_json::from_value(json).unwrap();
+        let response: RawTransactionResponse = serde_json::from_value(json).unwrap();
         response.outcome.unwrap()
     }
 

--- a/crates/near-kit/src/types/wait_level.rs
+++ b/crates/near-kit/src/types/wait_level.rs
@@ -15,7 +15,7 @@
 //!     .wait_until(Final)
 //!     .await?;
 //!
-//! // Non-executed levels — returns SendTxResponse
+//! // Non-executed levels — returns SendTxResponse (hash + sender)
 //! let response = near.transfer("bob.testnet", NearToken::from_near(1))
 //!     .wait_until(Included)
 //!     .await?;
@@ -25,9 +25,10 @@
 //! ```
 
 use crate::error::Error;
+use crate::types::AccountId;
 
 use super::block_reference::TxExecutionStatus;
-use super::rpc::{FinalExecutionOutcome, SendTxResponse};
+use super::rpc::{FinalExecutionOutcome, RawTransactionResponse, SendTxResponse};
 
 mod sealed {
     pub trait Sealed {}
@@ -48,13 +49,16 @@ pub trait WaitLevel: sealed::Sealed + Send + Sync + 'static {
     /// The RPC wait_until value.
     fn status() -> TxExecutionStatus;
 
-    /// Convert an RPC response into the appropriate return type.
+    /// Convert a raw RPC response into the appropriate return type.
     ///
     /// For executed levels, this extracts the outcome and checks for
-    /// `InvalidTxError`. For non-executed levels, this returns the raw
-    /// `SendTxResponse`.
+    /// `InvalidTxError`. For non-executed levels, this builds a
+    /// [`SendTxResponse`] with the transaction hash and sender ID.
     #[doc(hidden)]
-    fn convert(response: SendTxResponse) -> Result<Self::Response, Error>;
+    fn convert(
+        response: RawTransactionResponse,
+        sender_id: &AccountId,
+    ) -> Result<Self::Response, Error>;
 }
 
 // =============================================================================
@@ -75,8 +79,14 @@ impl WaitLevel for Submitted {
     fn status() -> TxExecutionStatus {
         TxExecutionStatus::None
     }
-    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
-        Ok(response)
+    fn convert(
+        response: RawTransactionResponse,
+        sender_id: &AccountId,
+    ) -> Result<Self::Response, Error> {
+        Ok(SendTxResponse {
+            transaction_hash: response.transaction_hash,
+            sender_id: sender_id.clone(),
+        })
     }
 }
 
@@ -92,8 +102,14 @@ impl WaitLevel for Included {
     fn status() -> TxExecutionStatus {
         TxExecutionStatus::Included
     }
-    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
-        Ok(response)
+    fn convert(
+        response: RawTransactionResponse,
+        sender_id: &AccountId,
+    ) -> Result<Self::Response, Error> {
+        Ok(SendTxResponse {
+            transaction_hash: response.transaction_hash,
+            sender_id: sender_id.clone(),
+        })
     }
 }
 
@@ -109,8 +125,14 @@ impl WaitLevel for IncludedFinal {
     fn status() -> TxExecutionStatus {
         TxExecutionStatus::IncludedFinal
     }
-    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
-        Ok(response)
+    fn convert(
+        response: RawTransactionResponse,
+        sender_id: &AccountId,
+    ) -> Result<Self::Response, Error> {
+        Ok(SendTxResponse {
+            transaction_hash: response.transaction_hash,
+            sender_id: sender_id.clone(),
+        })
     }
 }
 
@@ -118,8 +140,11 @@ impl WaitLevel for IncludedFinal {
 // Executed wait levels → FinalExecutionOutcome
 // =============================================================================
 
-/// Extract and validate the execution outcome from a response.
-fn extract_outcome(response: SendTxResponse, level: &str) -> Result<FinalExecutionOutcome, Error> {
+/// Extract and validate the execution outcome from a raw response.
+fn extract_outcome(
+    response: RawTransactionResponse,
+    level: &str,
+) -> Result<FinalExecutionOutcome, Error> {
     let outcome = response.outcome.ok_or_else(|| {
         Error::InvalidTransaction(format!(
             "RPC returned no execution outcome for transaction {} at wait level {}",
@@ -150,7 +175,10 @@ impl WaitLevel for ExecutedOptimistic {
     fn status() -> TxExecutionStatus {
         TxExecutionStatus::ExecutedOptimistic
     }
-    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
+    fn convert(
+        response: RawTransactionResponse,
+        _sender_id: &AccountId,
+    ) -> Result<Self::Response, Error> {
         extract_outcome(response, "ExecutedOptimistic")
     }
 }
@@ -167,7 +195,10 @@ impl WaitLevel for Executed {
     fn status() -> TxExecutionStatus {
         TxExecutionStatus::Executed
     }
-    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
+    fn convert(
+        response: RawTransactionResponse,
+        _sender_id: &AccountId,
+    ) -> Result<Self::Response, Error> {
         extract_outcome(response, "Executed")
     }
 }
@@ -184,7 +215,10 @@ impl WaitLevel for Final {
     fn status() -> TxExecutionStatus {
         TxExecutionStatus::Final
     }
-    fn convert(response: SendTxResponse) -> Result<Self::Response, Error> {
+    fn convert(
+        response: RawTransactionResponse,
+        _sender_id: &AccountId,
+    ) -> Result<Self::Response, Error> {
         extract_outcome(response, "Final")
     }
 }

--- a/crates/near-kit/tests/integration/debug_rpc_responses.rs
+++ b/crates/near-kit/tests/integration/debug_rpc_responses.rs
@@ -232,13 +232,7 @@ async fn debug_transaction_receipts() {
 
     // Now get full receipt details via EXPERIMENTAL_tx_status
     let tx_hash = outcome.transaction_hash();
-    let full_status = near
-        .rpc()
-        .tx_status(tx_hash, &root_account, TxExecutionStatus::Final)
-        .await
-        .unwrap();
-
-    let full_outcome = full_status.outcome.expect("expected outcome with receipts");
+    let full_outcome = near.tx_status(tx_hash, &root_account, Final).await.unwrap();
 
     println!("\n========================================");
     println!("FULL RECEIPTS (via EXPERIMENTAL_tx_status)");

--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -9,9 +9,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use near_kit::sandbox::{SANDBOX_ROOT_ACCOUNT, SandboxConfig};
 use near_kit::*;
-use near_kit::{
-    AccessKeyPermissionView, ActionView, MerkleDirection, ReceiptContent, TxExecutionStatus,
-};
+use near_kit::{AccessKeyPermissionView, ActionView, MerkleDirection, ReceiptContent};
 
 /// Counter for generating unique subaccount names
 static COUNTER: AtomicUsize = AtomicUsize::new(0);
@@ -394,15 +392,9 @@ async fn test_tx_status_with_receipts() {
     let tx_hash = outcome.transaction_hash();
 
     // Now get the full transaction status with receipts
-    let status = near
-        .rpc()
-        .tx_status(tx_hash, &root_account, TxExecutionStatus::Final)
-        .await
-        .unwrap();
+    let status_outcome = near.tx_status(tx_hash, &root_account, Final).await.unwrap();
 
-    let status_outcome = status.outcome.expect("expected outcome with receipts");
-
-    // Verify FinalExecutionOutcomeWithReceipts fields
+    // Same FinalExecutionOutcome type as send() returns, with receipts populated
     assert!(status_outcome.is_success(), "Transaction should succeed");
 
     // Check receipts array

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -847,15 +847,9 @@ async fn test_send_with_options_included_returns_send_tx_response() {
         .await
         .unwrap();
 
-    // SendTxResponse always has transaction_hash
+    // SendTxResponse has transaction_hash and sender_id
     assert!(!response.transaction_hash.is_zero());
-
-    // Included does not wait for execution, so outcome should be None
-    assert!(
-        response.outcome.is_none(),
-        "expected no outcome for Included, got: {:?}",
-        response.outcome
-    );
+    assert_eq!(response.sender_id, signed.transaction.signer_id);
 }
 
 #[tokio::test]
@@ -905,11 +899,7 @@ async fn test_wait_until_included_on_builder() {
         .unwrap();
 
     assert!(!response.transaction_hash.is_zero());
-    assert!(
-        response.outcome.is_none(),
-        "expected no outcome for Included, got: {:?}",
-        response.outcome
-    );
+    assert_eq!(response.sender_id.as_str(), sender_id.as_str());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

Feedback on the DX of transaction status types. Several pain points:

1. **`rpc().tx_status()` returns a different type than `send()`** — `SendTxWithReceiptsResponse` with `Option<FinalExecutionOutcomeWithReceipts>`, while `send()` returns `FinalExecutionOutcome`. Two near-identical outcome types with no conversions between them.

2. **`FinalExecutionOutcomeWithReceipts` is missing helper methods** — no `json()`, `total_gas_used()`, `result()`, `failure_message()`. You get the outcome from `tx_status` and can't do anything useful with it without manually reimplementing these.

3. **No ergonomic way to go from "fire and forget" to "poll for result"** — if you send with `Included` and later want the full outcome, you need the tx hash and sender ID. The old `SendTxResponse` didn't carry `sender_id`, and `tx_status` lived only on the low-level `rpc()` client.

## What changed

### Unified `FinalExecutionOutcome`

`FinalExecutionOutcomeWithReceipts` was nearly identical to `FinalExecutionOutcome` — same fields plus `receipts: Vec<Receipt>`. Now there's one type with `#[serde(default)] receipts` that's empty from `send()` and populated from `tx_status()`. It's empty from `send()` because the `send_tx` RPC endpoint doesn't return receipt objects (only `EXPERIMENTAL_tx_status` does — `send_tx` passes `fetch_receipt: false` in nearcore).

```rust
// From send() — receipts is empty (send_tx RPC doesn't include them)
let outcome = near.transfer("bob.testnet", NearToken::from_near(1)).await?;
outcome.json::<MyType>()?;
outcome.total_gas_used();

// From tx_status() — same type, same helpers, but receipts populated
let outcome = near.tx_status(&hash, "alice.testnet", Final).await?;
outcome.json::<MyType>()?;       // works!
outcome.total_gas_used();         // works!
outcome.receipts.len();           // has receipt data
```

### High-level `near.tx_status()`

Type-safe with the same WaitLevel pattern as `send()`. No more `Option<outcome>` to unwrap:

```rust
// Executed level → FinalExecutionOutcome directly
let outcome = near.tx_status(&hash, "alice.testnet", Final).await?;

// Non-executed level → SendTxResponse
let response = near.tx_status(&hash, "alice.testnet", Included).await?;
```

### Clean `SendTxResponse`

Before, `SendTxResponse` had three fields — but with typestate, `outcome` was always `None` and `final_execution_status` was always redundant. Stripped to just what you need:

```rust
pub struct SendTxResponse {
    pub transaction_hash: CryptoHash,
    pub sender_id: AccountId,       // new — for the poll flow
}
```

This makes the "fire and forget → poll later" pattern ergonomic:

```rust
// Step 1: send fast, don't wait for execution
let response = near.transfer("bob.testnet", NearToken::from_near(1))
    .wait_until(Included)
    .await?;

// Step 2: later, poll for the full outcome
let outcome = near.tx_status(
    &response.transaction_hash,
    &response.sender_id,
    Final,
).await?;
```

### Removed types
- `FinalExecutionOutcomeWithReceipts` → merged into `FinalExecutionOutcome`
- `SendTxWithReceiptsResponse` → replaced by internal `RawTransactionResponse`

### Breaking changes
- `SendTxResponse` no longer has `outcome` or `final_execution_status` fields (now just `transaction_hash` + `sender_id`)
- `FinalExecutionOutcome` now has a `receipts: Vec<Receipt>` field
- `rpc().tx_status()` return type changed from `SendTxWithReceiptsResponse` to `RawTransactionResponse`

## Test plan
- [ ] CI passes (clippy, tests, examples)
- [ ] Sandbox integration tests verify `tx_status` returns receipts
- [ ] Sandbox integration tests verify `SendTxResponse` has `sender_id`