### PR TITLE
fix: require chain_id in Near::custom()

### DIFF
--- a/crates/near-kit/examples/global_contracts.rs
+++ b/crates/near-kit/examples/global_contracts.rs
@@ -34,7 +34,7 @@ async fn global_contracts_example() -> Result<(), Error> {
         .send()
         .await?;
 
-    let publisher_near = Near::custom(sandbox.rpc_url())
+    let publisher_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .signer(InMemorySigner::from_secret_key(
             publisher_account.as_str(),
             publisher_key.secret_key,
@@ -67,7 +67,7 @@ async fn global_contracts_example() -> Result<(), Error> {
         .send()
         .await?;
 
-    let user_near = Near::custom(sandbox.rpc_url())
+    let user_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .signer(InMemorySigner::from_secret_key(
             user_account.as_str(),
             user_key.secret_key,
@@ -129,7 +129,7 @@ async fn global_contracts_example() -> Result<(), Error> {
         .send()
         .await?;
 
-    let user2_near = Near::custom(sandbox.rpc_url())
+    let user2_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .signer(InMemorySigner::from_secret_key(
             user2_account.as_str(),
             user2_key.secret_key,

--- a/crates/near-kit/examples/rotating_signer.rs
+++ b/crates/near-kit/examples/rotating_signer.rs
@@ -37,7 +37,7 @@ async fn high_throughput_example() -> Result<(), Error> {
         .await?;
 
     // Add remaining keys using a loop
-    let bot_near = Near::custom(sandbox.rpc_url())
+    let bot_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .signer(InMemorySigner::from_secret_key(
             bot_account.as_str(),
             keypairs[0].secret_key.clone(),
@@ -59,7 +59,7 @@ async fn high_throughput_example() -> Result<(), Error> {
     let secret_keys: Vec<SecretKey> = keypairs.into_iter().map(|kp| kp.secret_key).collect();
     let rotating_signer = RotatingSigner::new(&bot_account, secret_keys)?;
 
-    let near = Near::custom(sandbox.rpc_url())
+    let near = Near::custom(sandbox.rpc_url(), "sandbox")
         .signer(rotating_signer)
         .build();
 

--- a/crates/near-kit/examples/sequential_sends.rs
+++ b/crates/near-kit/examples/sequential_sends.rs
@@ -41,7 +41,7 @@ async fn sequential_example() -> Result<(), Error> {
         .await?;
 
     // Add remaining keys
-    let bot_near = Near::custom(sandbox.rpc_url())
+    let bot_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .signer(InMemorySigner::from_secret_key(
             bot_account.as_str(),
             keypairs[0].secret_key.clone(),
@@ -91,7 +91,7 @@ async fn sequential_example() -> Result<(), Error> {
             let rpc_url = rpc_url.clone();
             let recipient = recipient.clone();
             tokio::spawn(async move {
-                let near = Near::custom(&rpc_url).signer(signer).build();
+                let near = Near::custom(&rpc_url, "sandbox").signer(signer).build();
                 for tx_idx in 0..txs_per_key {
                     near.transfer(&recipient, NearToken::from_millinear(1))
                         .send()

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -119,9 +119,21 @@ impl Near {
         NearBuilder::new(TESTNET.rpc_url, ChainId::testnet())
     }
 
-    /// Create a builder with a custom RPC URL.
-    pub fn custom(rpc_url: impl Into<String>) -> NearBuilder {
-        NearBuilder::new(rpc_url, ChainId::new("custom"))
+    /// Create a builder with a custom RPC URL and chain ID.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use near_kit::Near;
+    ///
+    /// // Private mainnet RPC
+    /// let near = Near::custom("https://my-private-rpc.example.com", "mainnet").build();
+    ///
+    /// // Custom network
+    /// let near = Near::custom("https://rpc.pinet.near.org", "pinet").build();
+    /// ```
+    pub fn custom(rpc_url: impl Into<String>, chain_id: impl Into<ChainId>) -> NearBuilder {
+        NearBuilder::new(rpc_url, chain_id.into())
     }
 
     /// Create a configured client from environment variables.
@@ -172,7 +184,7 @@ impl Near {
     /// - `NEAR_MAX_NONCE_RETRIES` is set but not a valid integer
     pub fn from_env() -> Result<Near, Error> {
         let network = std::env::var("NEAR_NETWORK").ok();
-        let chain_id_override = std::env::var("NEAR_CHAIN_ID").ok();
+        let mut chain_id_override = std::env::var("NEAR_CHAIN_ID").ok();
         let account_id = std::env::var("NEAR_ACCOUNT_ID").ok();
         let private_key = std::env::var("NEAR_PRIVATE_KEY").ok();
 
@@ -180,10 +192,15 @@ impl Near {
         let mut builder = match network.as_deref() {
             Some("mainnet") => Near::mainnet(),
             Some("testnet") | None => Near::testnet(),
-            Some(url) => Near::custom(url),
+            Some(url) => {
+                let chain_id = chain_id_override
+                    .take()
+                    .unwrap_or_else(|| "custom".to_string());
+                Near::custom(url, chain_id)
+            }
         };
 
-        // Override chain_id if NEAR_CHAIN_ID is set
+        // Override chain_id if NEAR_CHAIN_ID is set (applies to mainnet/testnet presets)
         if let Some(id) = chain_id_override {
             builder = builder.chain_id(id);
         }
@@ -1187,8 +1204,15 @@ mod tests {
 
     #[test]
     fn test_near_custom_builder() {
-        let near = Near::custom("https://custom-rpc.example.com").build();
+        let near = Near::custom("https://custom-rpc.example.com", "mainnet").build();
         assert_eq!(near.rpc_url(), "https://custom-rpc.example.com");
+        assert!(near.chain_id().is_mainnet());
+    }
+
+    #[test]
+    fn test_near_custom_builder_with_chain_id_type() {
+        let near = Near::custom("https://rpc.example.com", ChainId::testnet()).build();
+        assert!(near.chain_id().is_testnet());
     }
 
     #[test]

--- a/crates/near-kit/src/types/network.rs
+++ b/crates/near-kit/src/types/network.rs
@@ -75,6 +75,18 @@ impl fmt::Display for ChainId {
     }
 }
 
+impl From<&str> for ChainId {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl From<String> for ChainId {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,5 +131,17 @@ mod tests {
         assert_eq!(chain_id.as_str(), "my-custom-network");
         assert!(!chain_id.is_mainnet());
         assert!(!chain_id.is_testnet());
+    }
+
+    #[test]
+    fn test_from_str() {
+        let chain_id: ChainId = "mainnet".into();
+        assert!(chain_id.is_mainnet());
+    }
+
+    #[test]
+    fn test_from_string() {
+        let chain_id: ChainId = String::from("testnet").into();
+        assert!(chain_id.is_testnet());
     }
 }

--- a/crates/near-kit/src/types/network.rs
+++ b/crates/near-kit/src/types/network.rs
@@ -77,13 +77,13 @@ impl fmt::Display for ChainId {
 
 impl From<&str> for ChainId {
     fn from(s: &str) -> Self {
-        Self(s.to_string())
+        Self::new(s)
     }
 }
 
 impl From<String> for ChainId {
     fn from(s: String) -> Self {
-        Self(s)
+        Self::new(s)
     }
 }
 

--- a/crates/near-kit/tests/integration/delegate_action_integration.rs
+++ b/crates/near-kit/tests/integration/delegate_action_integration.rs
@@ -90,7 +90,7 @@ async fn test_delegate_action_transfer() {
     println!("Recipient initial balance: {}", initial_balance);
 
     // --- SENDER: Create and sign a delegate action ---
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -109,7 +109,7 @@ async fn test_delegate_action_transfer() {
     );
 
     // --- RELAYER: Submit the delegate action ---
-    let relayer_near = Near::custom(rpc_url)
+    let relayer_near = Near::custom(rpc_url, "sandbox")
         .credentials(relayer_key.to_string(), &relayer_id)
         .unwrap()
         .build();
@@ -212,7 +212,7 @@ async fn test_delegate_action_function_call() {
     );
 
     // --- SENDER: Create delegate action for function call ---
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -229,7 +229,7 @@ async fn test_delegate_action_function_call() {
     println!("Sender signed delegate action for function call");
 
     // --- RELAYER: Submit the delegate action ---
-    let relayer_near = Near::custom(rpc_url)
+    let relayer_near = Near::custom(rpc_url, "sandbox")
         .credentials(relayer_key.to_string(), &relayer_id)
         .unwrap()
         .build();
@@ -293,7 +293,7 @@ async fn test_delegate_action_multiple_actions() {
     );
 
     // --- SENDER: Create delegate action with multiple actions ---
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -311,7 +311,7 @@ async fn test_delegate_action_multiple_actions() {
     println!("Sender signed delegate action with multiple actions");
 
     // --- RELAYER: Submit the delegate action ---
-    let relayer_near = Near::custom(rpc_url)
+    let relayer_near = Near::custom(rpc_url, "sandbox")
         .credentials(relayer_key.to_string(), &relayer_id)
         .unwrap()
         .build();
@@ -375,7 +375,7 @@ async fn test_delegate_action_roundtrip_encoding() {
         .unwrap();
 
     // Create a delegate action
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -433,7 +433,7 @@ async fn test_delegate_action_validation_errors() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();

--- a/crates/near-kit/tests/integration/error_consolidation_integration.rs
+++ b/crates/near-kit/tests/integration/error_consolidation_integration.rs
@@ -70,7 +70,7 @@ async fn test_action_error_returns_ok_with_failure_outcome() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -118,7 +118,7 @@ async fn test_function_call_error_returns_ok_with_failure_outcome() {
         .await
         .unwrap();
 
-    let contract_near = Near::custom(sandbox.rpc_url())
+    let contract_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &contract_id)
         .unwrap()
         .build();
@@ -161,7 +161,7 @@ async fn test_wrong_signer_key_returns_access_key_not_found() {
 
     // Try to sign with a wrong key
     let wrong_key = SecretKey::generate_ed25519();
-    let wrong_near = Near::custom(sandbox.rpc_url())
+    let wrong_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(wrong_key.to_string(), &account_id)
         .unwrap()
         .build();

--- a/crates/near-kit/tests/integration/error_handling_integration.rs
+++ b/crates/near-kit/tests/integration/error_handling_integration.rs
@@ -267,7 +267,7 @@ async fn test_error_transfer_to_nonexistent_implicit_account() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -306,7 +306,7 @@ async fn test_error_insufficient_balance_transfer() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -355,7 +355,7 @@ async fn test_error_create_account_that_already_exists() {
         .unwrap();
 
     // Create a signer for the parent
-    let parent_near = Near::custom(rpc_url)
+    let parent_near = Near::custom(rpc_url, "sandbox")
         .credentials(sandbox.root_secret_key(), SANDBOX_ROOT_ACCOUNT)
         .unwrap()
         .build();
@@ -398,7 +398,7 @@ async fn test_error_delete_nonexistent_key() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(rpc_url)
+    let account_near = Near::custom(rpc_url, "sandbox")
         .credentials(account_key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -449,7 +449,7 @@ async fn test_error_function_call_panic() {
         .await
         .unwrap();
 
-    let contract_near = Near::custom(rpc_url)
+    let contract_near = Near::custom(rpc_url, "sandbox")
         .credentials(contract_key.to_string(), &contract_id)
         .unwrap()
         .build();
@@ -492,7 +492,7 @@ async fn test_error_function_call_insufficient_gas() {
         .await
         .unwrap();
 
-    let contract_near = Near::custom(rpc_url)
+    let contract_near = Near::custom(rpc_url, "sandbox")
         .credentials(contract_key.to_string(), &contract_id)
         .unwrap()
         .build();
@@ -568,7 +568,7 @@ async fn test_error_transaction_without_signer() {
     let rpc_url = sandbox.rpc_url();
 
     // Create a Near client without a signer
-    let near = Near::custom(rpc_url).build();
+    let near = Near::custom(rpc_url, "sandbox").build();
 
     // Try to send a transaction
     let receiver: AccountId = "some-receiver.sandbox".parse().unwrap();

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -48,7 +48,7 @@ async fn create_funded_account(
         .await
         .unwrap();
 
-    let near = Near::custom(rpc_url)
+    let near = Near::custom(rpc_url, "sandbox")
         .credentials(account_key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -722,7 +722,7 @@ async fn test_action_delete_account() {
     assert!(root_near.account_exists(&to_delete_id).await.unwrap());
 
     // Delete the account
-    let to_delete_near = Near::custom(rpc_url)
+    let to_delete_near = Near::custom(rpc_url, "sandbox")
         .credentials(to_delete_key.to_string(), &to_delete_id)
         .unwrap()
         .build();

--- a/crates/near-kit/tests/integration/offline_signing_integration.rs
+++ b/crates/near-kit/tests/integration/offline_signing_integration.rs
@@ -43,7 +43,7 @@ async fn test_sign_offline_transfer() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -136,7 +136,7 @@ async fn test_sign_offline_function_call() {
         .await
         .unwrap();
 
-    let contract_near = Near::custom(rpc_url)
+    let contract_near = Near::custom(rpc_url, "sandbox")
         .credentials(contract_key.to_string(), &contract_id)
         .unwrap()
         .build();
@@ -210,7 +210,7 @@ async fn test_signed_transaction_roundtrip_bytes() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -283,7 +283,7 @@ async fn test_signed_transaction_roundtrip_base64() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -349,7 +349,7 @@ async fn test_offline_sign_and_transport_simulation() {
         .unwrap();
 
     // --- ONLINE MACHINE ---
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -72,7 +72,7 @@ async fn test_sandbox_transfer() {
         .unwrap();
 
     // Create sender's client
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -126,7 +126,7 @@ async fn test_sandbox_multiple_transfers() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -191,7 +191,7 @@ async fn test_sandbox_simple_transfer() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -249,7 +249,7 @@ async fn test_sandbox_create_account_outcome() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -293,7 +293,7 @@ async fn test_sandbox_delete_account() {
         .await
         .unwrap();
 
-    let parent_near = Near::custom(rpc_url)
+    let parent_near = Near::custom(rpc_url, "sandbox")
         .credentials(parent_key.to_string(), &parent_id)
         .unwrap()
         .build();
@@ -316,7 +316,7 @@ async fn test_sandbox_delete_account() {
     assert!(root_near.account_exists(&temp_id).await.unwrap());
 
     // Create a new client with the temp account's key to delete it
-    let temp_near = Near::custom(rpc_url)
+    let temp_near = Near::custom(rpc_url, "sandbox")
         .credentials(temp_key.to_string(), &temp_id)
         .unwrap()
         .build();
@@ -355,7 +355,7 @@ async fn test_sandbox_add_and_delete_key() {
         .unwrap();
 
     // Create a new client for this account
-    let account_near = Near::custom(rpc_url)
+    let account_near = Near::custom(rpc_url, "sandbox")
         .credentials(account_key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -409,7 +409,7 @@ async fn test_sandbox_multiple_actions_in_one_transaction() {
         .await
         .unwrap();
 
-    let parent_near = Near::custom(rpc_url)
+    let parent_near = Near::custom(rpc_url, "sandbox")
         .credentials(parent_key.to_string(), &parent_id)
         .unwrap()
         .build();
@@ -545,7 +545,7 @@ async fn test_sandbox_set_balance_preserves_other_fields() {
     );
 
     // Verify the contract still works
-    let account_near = Near::custom(rpc_url)
+    let account_near = Near::custom(rpc_url, "sandbox")
         .credentials(account_key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -590,7 +590,7 @@ async fn test_sandbox_set_balance_for_staking() {
     assert_eq!(balance.total, staking_balance);
 
     // Now we can actually stake with enough to meet the minimum
-    let validator_near = Near::custom(rpc_url)
+    let validator_near = Near::custom(rpc_url, "sandbox")
         .credentials(validator_key.to_string(), &validator_id)
         .unwrap()
         .build();
@@ -689,7 +689,7 @@ async fn test_sign_message_nep413() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(rpc_url)
+    let account_near = Near::custom(rpc_url, "sandbox")
         .credentials(account_key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -757,7 +757,7 @@ async fn test_send_with_options_final() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -816,7 +816,7 @@ async fn test_send_with_options_included_returns_send_tx_response() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -878,7 +878,7 @@ async fn test_wait_until_included_on_builder() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();
@@ -932,7 +932,7 @@ async fn test_send_pre_signed_transaction() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url)
+    let sender_near = Near::custom(rpc_url, "sandbox")
         .credentials(sender_key.to_string(), &sender_id)
         .unwrap()
         .build();

--- a/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
+++ b/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
@@ -43,7 +43,7 @@ async fn test_in_memory_signer_from_secret_key() {
         .unwrap();
 
     // Create client with InMemorySigner from secret key
-    let near = Near::custom(sandbox.rpc_url())
+    let near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -92,7 +92,9 @@ async fn test_in_memory_signer_from_seed_phrase() {
     assert_eq!(*pubkey, key.public_key(), "Public keys should match");
 
     // Create client with seed phrase signer
-    let near = Near::custom(sandbox.rpc_url()).signer(signer).build();
+    let near = Near::custom(sandbox.rpc_url(), "sandbox")
+        .signer(signer)
+        .build();
 
     // Should be able to query account
     let balance = near.balance(&account_id).await.unwrap();
@@ -130,7 +132,9 @@ async fn test_rotating_signer_uses_multiple_keys() {
     // Create a rotating signer with all three keys
     let signer = RotatingSigner::new(&account_id, vec![key1, key2, key3]).unwrap();
 
-    let near = Near::custom(sandbox.rpc_url()).signer(signer).build();
+    let near = Near::custom(sandbox.rpc_url(), "sandbox")
+        .signer(signer)
+        .build();
 
     // Execute multiple transactions - the rotating signer should cycle through keys
     for i in 0..6 {
@@ -174,7 +178,9 @@ async fn test_rotating_signer_with_single_key() {
     // Rotating signer with just one key should still work
     let signer = RotatingSigner::new(&account_id, vec![key]).unwrap();
 
-    let near = Near::custom(sandbox.rpc_url()).signer(signer).build();
+    let near = Near::custom(sandbox.rpc_url(), "sandbox")
+        .signer(signer)
+        .build();
 
     // Should work fine with single key
     let sub_id: AccountId = format!("single.{}", account_id).parse().unwrap();
@@ -247,7 +253,7 @@ async fn test_sign_with_override() {
         .unwrap();
 
     // Create client with account1's signer
-    let near = Near::custom(sandbox.rpc_url())
+    let near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key1.to_string(), &account1_id)
         .unwrap()
         .build();
@@ -296,7 +302,7 @@ async fn test_wrong_key_for_account() {
         .unwrap();
 
     // Create client with the WRONG key
-    let near = Near::custom(sandbox.rpc_url())
+    let near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(wrong_key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -346,13 +352,13 @@ async fn test_deleted_key_fails() {
         .unwrap();
 
     // Create client with key1
-    let near = Near::custom(sandbox.rpc_url())
+    let near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key1.to_string(), &account_id)
         .unwrap()
         .build();
 
     // Delete key1 using key2
-    let near2 = Near::custom(sandbox.rpc_url())
+    let near2 = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key2.to_string(), &account_id)
         .unwrap()
         .build();
@@ -397,7 +403,7 @@ async fn test_signing_with_ed25519_key() {
         .await
         .unwrap();
 
-    let ed_near = Near::custom(sandbox.rpc_url())
+    let ed_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(ed_key.to_string(), &ed_account)
         .unwrap()
         .build();

--- a/crates/near-kit/tests/integration/token_error_integration.rs
+++ b/crates/near-kit/tests/integration/token_error_integration.rs
@@ -122,7 +122,7 @@ async fn test_ft_transfer_without_signer() {
         .unwrap();
 
     // Create a client WITHOUT a signer
-    let no_signer_near = Near::custom(sandbox.rpc_url()).build();
+    let no_signer_near = Near::custom(sandbox.rpc_url(), "sandbox").build();
 
     // Try to transfer without a signer configured
     let ft = no_signer_near.ft(&owner_id).unwrap();
@@ -145,7 +145,7 @@ async fn test_ft_storage_deposit_without_signer() {
     let sandbox = SandboxConfig::shared().await;
 
     // Create a client WITHOUT a signer
-    let no_signer_near = Near::custom(sandbox.rpc_url()).build();
+    let no_signer_near = Near::custom(sandbox.rpc_url(), "sandbox").build();
 
     let ft = no_signer_near.ft("any-token.sandbox").unwrap();
 
@@ -256,7 +256,7 @@ async fn test_nft_token_on_non_contract() {
 async fn test_nft_transfer_without_signer() {
     let sandbox = SandboxConfig::shared().await;
 
-    let no_signer_near = Near::custom(sandbox.rpc_url()).build();
+    let no_signer_near = Near::custom(sandbox.rpc_url(), "sandbox").build();
 
     let nft = no_signer_near.nft("any-nft.sandbox").unwrap();
     let result = nft.transfer("bob.near", "token-1").await;

--- a/crates/near-kit/tests/integration/token_integration.rs
+++ b/crates/near-kit/tests/integration/token_integration.rs
@@ -45,7 +45,7 @@ async fn deploy_ft_contract(
 
     // Initialize the FT contract
     // The near-sdk-rs example FT uses "new" with owner_id, total_supply, metadata
-    let ft_near = Near::custom(near.rpc_url())
+    let ft_near = Near::custom(near.rpc_url(), "sandbox")
         .credentials(ft_key.to_string(), &ft_id)?
         .build();
 
@@ -197,7 +197,7 @@ async fn test_ft_transfer() {
     let receiver_key = SecretKey::generate_ed25519();
     let receiver_id: AccountId = format!("receiver.{}", owner_id).parse().unwrap();
 
-    let owner_near = Near::custom(rpc_url)
+    let owner_near = Near::custom(rpc_url, "sandbox")
         .credentials(owner_key.to_string(), &owner_id)
         .unwrap()
         .build();
@@ -284,7 +284,7 @@ async fn test_ft_storage_deposit() {
         .unwrap();
 
     // Create owner's near client for signing
-    let owner_near = Near::custom(rpc_url)
+    let owner_near = Near::custom(rpc_url, "sandbox")
         .credentials(owner_key.to_string(), &owner_id)
         .unwrap()
         .build();
@@ -352,7 +352,7 @@ async fn deploy_nft_contract(
         .await?;
 
     // Initialize the NFT contract
-    let nft_near = Near::custom(near.rpc_url())
+    let nft_near = Near::custom(near.rpc_url(), "sandbox")
         .credentials(nft_key.to_string(), &nft_id)?
         .build();
 
@@ -380,7 +380,7 @@ async fn mint_nft(
     token_id: &str,
     owner_id: &AccountId,
 ) -> Result<(), Error> {
-    let nft_near = Near::custom(near.rpc_url())
+    let nft_near = Near::custom(near.rpc_url(), "sandbox")
         .credentials(nft_key.to_string(), nft_id)?
         .build();
 
@@ -563,7 +563,7 @@ async fn test_nft_transfer() {
         .unwrap();
 
     // Create owner's client for signing
-    let owner_near = Near::custom(rpc_url)
+    let owner_near = Near::custom(rpc_url, "sandbox")
         .credentials(owner_key.to_string(), &owner_id)
         .unwrap()
         .build();
@@ -679,7 +679,7 @@ async fn test_nft_supply_for_owner() {
         .unwrap();
 
     // Create owner1's client for signing
-    let owner1_near = Near::custom(rpc_url)
+    let owner1_near = Near::custom(rpc_url, "sandbox")
         .credentials(owner1_key.to_string(), &owner1_id)
         .unwrap()
         .build();

--- a/crates/near-kit/tests/integration/tracing_integration.rs
+++ b/crates/near-kit/tests/integration/tracing_integration.rs
@@ -231,7 +231,7 @@ async fn test_ft_balance_of_span_hierarchy() {
         .await
         .unwrap();
 
-    let ft_near = Near::custom(rpc_url)
+    let ft_near = Near::custom(rpc_url, "sandbox")
         .credentials(ft_key.to_string(), &ft_id)
         .unwrap()
         .build();

--- a/crates/near-kit/tests/integration/transaction_failure_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_failure_integration.rs
@@ -41,7 +41,7 @@ async fn test_deploy_invalid_wasm() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -73,7 +73,7 @@ async fn test_deploy_empty_wasm() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -132,7 +132,7 @@ async fn test_add_duplicate_key() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -167,7 +167,7 @@ async fn test_delete_last_full_access_key() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -278,7 +278,7 @@ async fn test_transaction_with_failing_action_in_middle() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -351,7 +351,7 @@ async fn test_delete_account_to_nonexistent_beneficiary() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -391,7 +391,7 @@ async fn test_stake_with_insufficient_balance() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -436,7 +436,7 @@ async fn test_transfer_zero_amount() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();
@@ -481,7 +481,7 @@ async fn test_transfer_max_amount() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &account_id)
         .unwrap()
         .build();

--- a/crates/near-kit/tests/integration/transaction_outcome_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_outcome_integration.rs
@@ -41,7 +41,7 @@ async fn test_failed_transaction_preserves_receipts() {
         .result()
         .expect("setup: deploy should succeed on-chain");
 
-    let account_near = Near::custom(sandbox.rpc_url())
+    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &contract_id)
         .unwrap()
         .build();

--- a/crates/near-kit/tests/integration/typed_contract_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_error_integration.rs
@@ -138,7 +138,7 @@ async fn test_typed_contract_call_without_signer() {
         .unwrap();
 
     // Create client WITHOUT a signer
-    let no_signer_near = Near::custom(sandbox.rpc_url()).build();
+    let no_signer_near = Near::custom(sandbox.rpc_url(), "sandbox").build();
     let guestbook = no_signer_near.contract::<Guestbook>(&contract_id);
 
     // Try to call a mutating method without signer
@@ -347,7 +347,7 @@ async fn test_typed_contract_view_methods_still_work_without_signer() {
         .unwrap();
 
     // Create client WITHOUT a signer
-    let no_signer_near = Near::custom(sandbox.rpc_url()).build();
+    let no_signer_near = Near::custom(sandbox.rpc_url(), "sandbox").build();
     let guestbook = no_signer_near.contract::<Guestbook>(&contract_id);
 
     // View methods should still work without a signer

--- a/crates/near-kit/tests/integration/typed_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_error_integration.rs
@@ -36,7 +36,7 @@ async fn funded_account(
         .await
         .unwrap();
 
-    let client = Near::custom(sandbox.rpc_url())
+    let client = Near::custom(sandbox.rpc_url(), "sandbox")
         .credentials(key.to_string(), &id)
         .unwrap()
         .build();


### PR DESCRIPTION
Closes #168

## Problem

`Near::custom()` hardcodes `ChainId::new("custom")`, which silently breaks `KnownToken::resolve()` — it matches on `"mainnet"` / `"testnet"` and returns `TokenNotAvailable` for anything else. So `near.ft(tokens::USDC)` fails even when the client is actually talking to mainnet.

The workaround exists (`.chain_id("mainnet")` on the builder) but it's easy to forget, and the default of `"custom"` is a footgun.

## Fix

Make `chain_id` a required parameter:

```rust
// Before — chain_id silently set to "custom", tokens break
let near = Near::custom("https://my-private-rpc.example.com").build();

// After — explicit, KnownToken::resolve() works correctly
let near = Near::custom("https://my-private-rpc.example.com", "mainnet").build();
```

Accepts `&str`, `String`, or `ChainId` directly via `impl Into<ChainId>`:

```rust
Near::custom("https://rpc.pinet.near.org", "pinet").build();
Near::custom("https://rpc.example.com", ChainId::testnet()).build();
```

## What changed

- **`Near::custom(url)` → `Near::custom(url, chain_id)`** — breaking, but removes a real footgun
- **`From<&str>` / `From<String>` for `ChainId`** — so string literals work as chain_id
- **`from_env()`** — uses `NEAR_CHAIN_ID` if set, falls back to `"custom"` (same behavior as before)
- **Tests/examples** — mechanical update, all sandbox callers pass `"sandbox"`

## Test plan

- [x] `cargo check` / `cargo check --examples --tests`
- [x] Unit tests pass (`cargo test --lib`)
- [ ] Integration tests (sandbox)