### PR TITLE
refactor: use Near::sandbox() in tests and examples

### DIFF
--- a/crates/near-kit/examples/global_contracts.rs
+++ b/crates/near-kit/examples/global_contracts.rs
@@ -34,12 +34,10 @@ async fn global_contracts_example() -> Result<(), Error> {
         .send()
         .await?;
 
-    let publisher_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .signer(InMemorySigner::from_secret_key(
-            publisher_account.as_str(),
-            publisher_key.secret_key,
-        )?)
-        .build();
+    let publisher_near = Near::sandbox(&sandbox).with_signer(InMemorySigner::from_secret_key(
+        publisher_account.as_str(),
+        publisher_key.secret_key,
+    )?);
 
     println!("Created publisher: {publisher_account}");
 
@@ -67,12 +65,10 @@ async fn global_contracts_example() -> Result<(), Error> {
         .send()
         .await?;
 
-    let user_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .signer(InMemorySigner::from_secret_key(
-            user_account.as_str(),
-            user_key.secret_key,
-        )?)
-        .build();
+    let user_near = Near::sandbox(&sandbox).with_signer(InMemorySigner::from_secret_key(
+        user_account.as_str(),
+        user_key.secret_key,
+    )?);
 
     // Deploy from the publisher's global contract
     user_near
@@ -129,12 +125,10 @@ async fn global_contracts_example() -> Result<(), Error> {
         .send()
         .await?;
 
-    let user2_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .signer(InMemorySigner::from_secret_key(
-            user2_account.as_str(),
-            user2_key.secret_key,
-        )?)
-        .build();
+    let user2_near = Near::sandbox(&sandbox).with_signer(InMemorySigner::from_secret_key(
+        user2_account.as_str(),
+        user2_key.secret_key,
+    )?);
 
     // Deploy from hash (type dispatches on CryptoHash)
     user2_near

--- a/crates/near-kit/examples/rotating_signer.rs
+++ b/crates/near-kit/examples/rotating_signer.rs
@@ -37,12 +37,10 @@ async fn high_throughput_example() -> Result<(), Error> {
         .await?;
 
     // Add remaining keys using a loop
-    let bot_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .signer(InMemorySigner::from_secret_key(
-            bot_account.as_str(),
-            keypairs[0].secret_key.clone(),
-        )?)
-        .build();
+    let bot_near = Near::sandbox(&sandbox).with_signer(InMemorySigner::from_secret_key(
+        bot_account.as_str(),
+        keypairs[0].secret_key.clone(),
+    )?);
 
     println!("Adding {} more access keys...", num_keys - 1);
 
@@ -59,9 +57,7 @@ async fn high_throughput_example() -> Result<(), Error> {
     let secret_keys: Vec<SecretKey> = keypairs.into_iter().map(|kp| kp.secret_key).collect();
     let rotating_signer = RotatingSigner::new(&bot_account, secret_keys)?;
 
-    let near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .signer(rotating_signer)
-        .build();
+    let near = Near::sandbox(&sandbox).with_signer(rotating_signer);
 
     // Create recipient accounts
     let num_recipients = 20;

--- a/crates/near-kit/examples/sequential_sends.rs
+++ b/crates/near-kit/examples/sequential_sends.rs
@@ -41,12 +41,10 @@ async fn sequential_example() -> Result<(), Error> {
         .await?;
 
     // Add remaining keys
-    let bot_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .signer(InMemorySigner::from_secret_key(
-            bot_account.as_str(),
-            keypairs[0].secret_key.clone(),
-        )?)
-        .build();
+    let bot_near = Near::sandbox(&sandbox).with_signer(InMemorySigner::from_secret_key(
+        bot_account.as_str(),
+        keypairs[0].secret_key.clone(),
+    )?);
 
     keypairs[1..]
         .iter()
@@ -82,16 +80,14 @@ async fn sequential_example() -> Result<(), Error> {
     println!("Sending {txs_per_key} sequential txs per key ({num_keys} keys in parallel)...\n");
 
     let start = std::time::Instant::now();
-    let rpc_url = sandbox.rpc_url().to_string();
 
     let handles: Vec<_> = per_key_signers
         .into_iter()
         .enumerate()
         .map(|(key_idx, signer)| {
-            let rpc_url = rpc_url.clone();
+            let near = bot_near.with_signer(signer);
             let recipient = recipient.clone();
             tokio::spawn(async move {
-                let near = Near::custom(&rpc_url, "sandbox").signer(signer).build();
                 for tx_idx in 0..txs_per_key {
                     near.transfer(&recipient, NearToken::from_millinear(1))
                         .send()

--- a/crates/near-kit/tests/integration/delegate_action_integration.rs
+++ b/crates/near-kit/tests/integration/delegate_action_integration.rs
@@ -36,7 +36,6 @@ async fn test_delegate_action_transfer() {
 
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account (who wants to transfer but won't pay gas)
     let sender_key = SecretKey::generate_ed25519();
@@ -90,10 +89,8 @@ async fn test_delegate_action_transfer() {
     println!("Recipient initial balance: {}", initial_balance);
 
     // --- SENDER: Create and sign a delegate action ---
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Build a delegate action for transferring 2 NEAR to recipient
     let delegate_result = sender_near
@@ -109,10 +106,8 @@ async fn test_delegate_action_transfer() {
     );
 
     // --- RELAYER: Submit the delegate action ---
-    let relayer_near = Near::custom(rpc_url, "sandbox")
-        .credentials(relayer_key.to_string(), &relayer_id)
-        .unwrap()
-        .build();
+    let relayer_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&relayer_id, relayer_key.to_string()).unwrap());
 
     // Decode the payload (simulating receiving it via HTTP)
     let signed_delegate = SignedDelegateAction::from_base64(&delegate_result.payload).unwrap();
@@ -157,7 +152,6 @@ async fn test_delegate_action_function_call() {
 
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -212,10 +206,8 @@ async fn test_delegate_action_function_call() {
     );
 
     // --- SENDER: Create delegate action for function call ---
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     let delegate_result = sender_near
         .transaction(&contract_id)
@@ -229,10 +221,8 @@ async fn test_delegate_action_function_call() {
     println!("Sender signed delegate action for function call");
 
     // --- RELAYER: Submit the delegate action ---
-    let relayer_near = Near::custom(rpc_url, "sandbox")
-        .credentials(relayer_key.to_string(), &relayer_id)
-        .unwrap()
-        .build();
+    let relayer_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&relayer_id, relayer_key.to_string()).unwrap());
 
     let signed_delegate = SignedDelegateAction::from_base64(&delegate_result.payload).unwrap();
 
@@ -253,7 +243,6 @@ async fn test_delegate_action_multiple_actions() {
 
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -293,10 +282,8 @@ async fn test_delegate_action_multiple_actions() {
     );
 
     // --- SENDER: Create delegate action with multiple actions ---
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create a new account with funding and a key - all in one delegate action
     let delegate_result = sender_near
@@ -311,10 +298,8 @@ async fn test_delegate_action_multiple_actions() {
     println!("Sender signed delegate action with multiple actions");
 
     // --- RELAYER: Submit the delegate action ---
-    let relayer_near = Near::custom(rpc_url, "sandbox")
-        .credentials(relayer_key.to_string(), &relayer_id)
-        .unwrap()
-        .build();
+    let relayer_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&relayer_id, relayer_key.to_string()).unwrap());
 
     let signed_delegate = SignedDelegateAction::from_base64(&delegate_result.payload).unwrap();
 
@@ -344,7 +329,6 @@ async fn test_delegate_action_roundtrip_encoding() {
 
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -375,10 +359,8 @@ async fn test_delegate_action_roundtrip_encoding() {
         .unwrap();
 
     // Create a delegate action
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     let delegate_result = sender_near
         .transaction(&recipient_id)
@@ -417,7 +399,6 @@ async fn test_delegate_action_validation_errors() {
 
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -433,10 +414,8 @@ async fn test_delegate_action_validation_errors() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Test: Empty actions should fail
     let result = sender_near

--- a/crates/near-kit/tests/integration/error_consolidation_integration.rs
+++ b/crates/near-kit/tests/integration/error_consolidation_integration.rs
@@ -70,10 +70,8 @@ async fn test_action_error_returns_ok_with_failure_outcome() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Delete a key that doesn't exist — ActionError, but returned as Ok
     let fake_key = SecretKey::generate_ed25519();
@@ -118,10 +116,8 @@ async fn test_function_call_error_returns_ok_with_failure_outcome() {
         .await
         .unwrap();
 
-    let contract_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &contract_id)
-        .unwrap()
-        .build();
+    let contract_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&contract_id, key.to_string()).unwrap());
 
     // Call a non-existent method — returns Ok with failure outcome
     let outcome = contract_near
@@ -161,10 +157,8 @@ async fn test_wrong_signer_key_returns_access_key_not_found() {
 
     // Try to sign with a wrong key
     let wrong_key = SecretKey::generate_ed25519();
-    let wrong_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(wrong_key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let wrong_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, wrong_key.to_string()).unwrap());
 
     let err = wrong_near
         .transfer(&account_id, NearToken::from_near(1))

--- a/crates/near-kit/tests/integration/error_handling_integration.rs
+++ b/crates/near-kit/tests/integration/error_handling_integration.rs
@@ -252,7 +252,6 @@ async fn test_error_view_with_invalid_args() {
 async fn test_error_transfer_to_nonexistent_implicit_account() {
     let sandbox = SandboxConfig::shared().await;
     let near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create a sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -267,10 +266,8 @@ async fn test_error_transfer_to_nonexistent_implicit_account() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Transfer to a non-existent named account (not implicit)
     // This should work because the receiver doesn't need to exist for named accounts
@@ -291,7 +288,6 @@ async fn test_error_transfer_to_nonexistent_implicit_account() {
 async fn test_error_insufficient_balance_transfer() {
     let sandbox = SandboxConfig::shared().await;
     let near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender with small balance
     let sender_key = SecretKey::generate_ed25519();
@@ -306,10 +302,8 @@ async fn test_error_insufficient_balance_transfer() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create receiver
     let receiver_key = SecretKey::generate_ed25519();
@@ -339,7 +333,6 @@ async fn test_error_insufficient_balance_transfer() {
 async fn test_error_create_account_that_already_exists() {
     let sandbox = SandboxConfig::shared().await;
     let near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create an account first
     let account_key = SecretKey::generate_ed25519();
@@ -355,10 +348,8 @@ async fn test_error_create_account_that_already_exists() {
         .unwrap();
 
     // Create a signer for the parent
-    let parent_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sandbox.root_secret_key(), SANDBOX_ROOT_ACCOUNT)
-        .unwrap()
-        .build();
+    let parent_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(SANDBOX_ROOT_ACCOUNT, sandbox.root_secret_key()).unwrap());
 
     // Try to create the same account again — action error returns Ok(outcome)
     let new_key = SecretKey::generate_ed25519();
@@ -383,7 +374,6 @@ async fn test_error_create_account_that_already_exists() {
 async fn test_error_delete_nonexistent_key() {
     let sandbox = SandboxConfig::shared().await;
     let near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create an account
     let account_key = SecretKey::generate_ed25519();
@@ -398,10 +388,8 @@ async fn test_error_delete_nonexistent_key() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(rpc_url, "sandbox")
-        .credentials(account_key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, account_key.to_string()).unwrap());
 
     // Try to delete a key that doesn't exist on the account — action error returns Ok(outcome)
     let fake_key = SecretKey::generate_ed25519();
@@ -431,7 +419,6 @@ async fn test_error_delete_nonexistent_key() {
 async fn test_error_function_call_panic() {
     let sandbox = SandboxConfig::shared().await;
     let near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Deploy guestbook contract
     let contract_key = SecretKey::generate_ed25519();
@@ -449,10 +436,8 @@ async fn test_error_function_call_panic() {
         .await
         .unwrap();
 
-    let contract_near = Near::custom(rpc_url, "sandbox")
-        .credentials(contract_key.to_string(), &contract_id)
-        .unwrap()
-        .build();
+    let contract_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&contract_id, contract_key.to_string()).unwrap());
 
     // Call a method that doesn't exist — action error returns Ok(outcome)
     let outcome = contract_near
@@ -474,7 +459,6 @@ async fn test_error_function_call_panic() {
 async fn test_error_function_call_insufficient_gas() {
     let sandbox = SandboxConfig::shared().await;
     let near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Deploy guestbook contract
     let contract_key = SecretKey::generate_ed25519();
@@ -492,10 +476,8 @@ async fn test_error_function_call_insufficient_gas() {
         .await
         .unwrap();
 
-    let contract_near = Near::custom(rpc_url, "sandbox")
-        .credentials(contract_key.to_string(), &contract_id)
-        .unwrap()
-        .build();
+    let contract_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&contract_id, contract_key.to_string()).unwrap());
 
     // Call with very low gas — action error returns Ok(outcome)
     let outcome = contract_near

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -32,7 +32,7 @@ fn load_test_contract() -> Vec<u8> {
 
 async fn create_funded_account(
     root_near: &Near,
-    rpc_url: &str,
+    sandbox: &near_kit::sandbox::Sandbox,
     funding: NearToken,
 ) -> (Near, AccountId, SecretKey) {
     let account_key = SecretKey::generate_ed25519();
@@ -48,10 +48,8 @@ async fn create_funded_account(
         .await
         .unwrap();
 
-    let near = Near::custom(rpc_url, "sandbox")
-        .credentials(account_key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, account_key.to_string()).unwrap());
 
     (near, account_id, account_key)
 }
@@ -65,10 +63,9 @@ async fn create_funded_account(
 async fn test_near_publish_shorthand_updatable() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (publisher_near, _, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
 
@@ -88,10 +85,9 @@ async fn test_near_publish_shorthand_updatable() {
 async fn test_near_publish_shorthand_immutable() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (publisher_near, _, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
 
@@ -110,11 +106,10 @@ async fn test_near_publish_shorthand_immutable() {
 async fn test_near_deploy_from_shorthand_publisher() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Publisher publishes the contract
     let (publisher_near, publisher_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
 
@@ -127,7 +122,7 @@ async fn test_near_deploy_from_shorthand_publisher() {
 
     // User deploys using the Near::deploy_from() shorthand
     let (user_near, user_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(10)).await;
 
     user_near
         .deploy_from(publisher_id.clone())
@@ -150,10 +145,9 @@ async fn test_near_deploy_from_shorthand_publisher() {
 async fn test_near_deploy_from_shorthand_hash() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (publisher_near, _, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
     let code_hash = CryptoHash::hash(&wasm_code);
@@ -167,7 +161,7 @@ async fn test_near_deploy_from_shorthand_hash() {
 
     // User deploys using the Near::deploy_from() shorthand with CryptoHash
     let (user_near, user_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(10)).await;
 
     user_near
         .deploy_from(code_hash)
@@ -190,11 +184,10 @@ async fn test_near_deploy_from_shorthand_hash() {
 async fn test_publish_deploy_from_call_end_to_end() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Publisher publishes an updatable contract
     let (publisher_near, publisher_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
 
@@ -207,7 +200,7 @@ async fn test_publish_deploy_from_call_end_to_end() {
 
     // User deploys from the publisher's global contract
     let (user_near, user_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(10)).await;
 
     user_near
         .deploy_from(publisher_id.as_str())
@@ -243,11 +236,10 @@ async fn test_publish_deploy_from_call_end_to_end() {
 async fn test_publish_contract_by_account() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create a publisher account
     let (publisher_near, publisher_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
 
@@ -271,11 +263,10 @@ async fn test_publish_contract_by_account() {
 async fn test_publish_contract_by_hash() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create a publisher account
     let (publisher_near, publisher_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
 
@@ -299,11 +290,10 @@ async fn test_publish_contract_by_hash() {
 async fn test_deploy_from_publisher() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create a publisher account
     let (publisher_near, publisher_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
 
@@ -318,7 +308,7 @@ async fn test_deploy_from_publisher() {
 
     // Create a user account that will deploy from the publisher
     let (user_near, user_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(10)).await;
 
     // Deploy from the publisher's global contract (passing AccountId directly)
     let outcome = user_near
@@ -350,11 +340,10 @@ async fn test_deploy_from_publisher() {
 async fn test_deploy_from_hash() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create a publisher account
     let (publisher_near, publisher_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
 
@@ -373,7 +362,7 @@ async fn test_deploy_from_hash() {
 
     // Create a user account that will deploy from the hash
     let (user_near, user_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(10)).await;
 
     // Deploy from the code hash
     let outcome = user_near
@@ -405,11 +394,10 @@ async fn test_deploy_from_hash() {
 async fn test_state_init_by_hash() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create a publisher account
     let (publisher_near, publisher_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
     let code_hash = CryptoHash::hash(&wasm_code);
@@ -446,11 +434,10 @@ async fn test_state_init_by_hash() {
 async fn test_state_init_by_publisher() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create a publisher account
     let (publisher_near, publisher_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let wasm_code = load_test_contract();
 
@@ -492,10 +479,9 @@ async fn test_state_init_by_publisher() {
 async fn test_action_create_account() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (parent_near, parent_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(20)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(20)).await;
 
     let child_key = SecretKey::generate_ed25519();
     let child_id: AccountId = format!("child.{}", parent_id).parse().unwrap();
@@ -518,12 +504,11 @@ async fn test_action_create_account() {
 async fn test_action_transfer() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (sender_near, _, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(20)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(20)).await;
     let (_, receiver_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(5)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(5)).await;
 
     let initial_balance = root_near.balance(&receiver_id).await.unwrap();
 
@@ -546,10 +531,9 @@ async fn test_action_transfer() {
 async fn test_action_deploy_contract() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (contract_near, contract_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(20)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(20)).await;
 
     let wasm_code = load_test_contract();
 
@@ -571,10 +555,9 @@ async fn test_action_deploy_contract() {
 async fn test_action_function_call() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (contract_near, contract_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(20)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(20)).await;
 
     let wasm_code = load_test_contract();
 
@@ -605,10 +588,9 @@ async fn test_action_function_call() {
 async fn test_action_add_full_access_key() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (account_near, account_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(10)).await;
 
     let new_key = SecretKey::generate_ed25519();
 
@@ -630,10 +612,9 @@ async fn test_action_add_full_access_key() {
 async fn test_action_add_function_call_key() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (account_near, account_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(10)).await;
 
     let fc_key = SecretKey::generate_ed25519();
     let receiver_contract: AccountId = "some-contract.sandbox".parse().unwrap();
@@ -661,10 +642,9 @@ async fn test_action_add_function_call_key() {
 async fn test_action_delete_key() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (account_near, account_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(10)).await;
 
     // Add a second key
     let second_key = SecretKey::generate_ed25519();
@@ -700,10 +680,9 @@ async fn test_action_delete_key() {
 async fn test_action_delete_account() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (beneficiary_near, beneficiary_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(10)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(10)).await;
 
     // Create an account to delete
     let to_delete_key = SecretKey::generate_ed25519();
@@ -722,10 +701,8 @@ async fn test_action_delete_account() {
     assert!(root_near.account_exists(&to_delete_id).await.unwrap());
 
     // Delete the account
-    let to_delete_near = Near::custom(rpc_url, "sandbox")
-        .credentials(to_delete_key.to_string(), &to_delete_id)
-        .unwrap()
-        .build();
+    let to_delete_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&to_delete_id, to_delete_key.to_string()).unwrap());
 
     to_delete_near
         .transaction(&to_delete_id)
@@ -743,11 +720,10 @@ async fn test_action_delete_account() {
 async fn test_action_stake() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create a validator account with small initial balance
     let (staker_near, staker_id, staker_key) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(100)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(100)).await;
 
     // Patch the balance to 2M NEAR (enough to meet sandbox minimum stake of ~800K)
     let staking_balance = NearToken::from_near(2_000_000);
@@ -783,10 +759,9 @@ async fn test_action_stake() {
 async fn test_multiple_actions() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (parent_near, parent_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(50)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(50)).await;
 
     let child_key = SecretKey::generate_ed25519();
     let child_id: AccountId = format!("multi.{}", parent_id).parse().unwrap();
@@ -821,10 +796,9 @@ async fn test_multiple_actions() {
 async fn test_multiple_function_calls() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     let (contract_near, contract_id, _) =
-        create_funded_account(&root_near, rpc_url, NearToken::from_near(20)).await;
+        create_funded_account(&root_near, sandbox, NearToken::from_near(20)).await;
 
     let wasm_code = load_test_contract();
 

--- a/crates/near-kit/tests/integration/offline_signing_integration.rs
+++ b/crates/near-kit/tests/integration/offline_signing_integration.rs
@@ -27,7 +27,6 @@ fn unique_account() -> AccountId {
 async fn test_sign_offline_transfer() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -43,10 +42,8 @@ async fn test_sign_offline_transfer() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create receiver account (must be created by sender as subaccount)
     let receiver_key = SecretKey::generate_ed25519();
@@ -116,7 +113,6 @@ async fn test_sign_offline_transfer() {
 async fn test_sign_offline_function_call() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create account with contract
     let contract_key = SecretKey::generate_ed25519();
@@ -136,10 +132,8 @@ async fn test_sign_offline_function_call() {
         .await
         .unwrap();
 
-    let contract_near = Near::custom(rpc_url, "sandbox")
-        .credentials(contract_key.to_string(), &contract_id)
-        .unwrap()
-        .build();
+    let contract_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&contract_id, contract_key.to_string()).unwrap());
 
     // Get block_hash and nonce for offline signing
     let block = contract_near
@@ -194,7 +188,6 @@ async fn test_sign_offline_function_call() {
 async fn test_signed_transaction_roundtrip_bytes() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -210,10 +203,8 @@ async fn test_signed_transaction_roundtrip_bytes() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create receiver account (must be created by sender as subaccount)
     let receiver_key = SecretKey::generate_ed25519();
@@ -267,7 +258,6 @@ async fn test_signed_transaction_roundtrip_bytes() {
 async fn test_signed_transaction_roundtrip_base64() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -283,10 +273,8 @@ async fn test_signed_transaction_roundtrip_base64() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create receiver account (must be created by sender as subaccount)
     let receiver_key = SecretKey::generate_ed25519();
@@ -332,7 +320,6 @@ async fn test_signed_transaction_roundtrip_base64() {
 async fn test_offline_sign_and_transport_simulation() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -349,10 +336,8 @@ async fn test_offline_sign_and_transport_simulation() {
         .unwrap();
 
     // --- ONLINE MACHINE ---
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create receiver account (must be created by sender as subaccount)
     let receiver_key = SecretKey::generate_ed25519();

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -55,7 +55,6 @@ async fn test_sandbox_balance() {
 async fn test_sandbox_transfer() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -72,10 +71,8 @@ async fn test_sandbox_transfer() {
         .unwrap();
 
     // Create sender's client
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Generate a new keypair for the receiver
     let receiver_key = SecretKey::generate_ed25519();
@@ -110,7 +107,6 @@ async fn test_sandbox_transfer() {
 async fn test_sandbox_multiple_transfers() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -126,10 +122,8 @@ async fn test_sandbox_multiple_transfers() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Generate keypairs for multiple receivers
     let receiver1_key = SecretKey::generate_ed25519();
@@ -175,7 +169,6 @@ async fn test_sandbox_multiple_transfers() {
 async fn test_sandbox_simple_transfer() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -191,10 +184,8 @@ async fn test_sandbox_simple_transfer() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create a receiver account
     let receiver_key = SecretKey::generate_ed25519();
@@ -233,7 +224,6 @@ async fn test_sandbox_simple_transfer() {
 async fn test_sandbox_create_account_outcome() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -249,10 +239,8 @@ async fn test_sandbox_create_account_outcome() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create a contract account
     let contract_key = SecretKey::generate_ed25519();
@@ -277,7 +265,6 @@ async fn test_sandbox_create_account_outcome() {
 async fn test_sandbox_delete_account() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create parent account
     let parent_key = SecretKey::generate_ed25519();
@@ -293,10 +280,8 @@ async fn test_sandbox_delete_account() {
         .await
         .unwrap();
 
-    let parent_near = Near::custom(rpc_url, "sandbox")
-        .credentials(parent_key.to_string(), &parent_id)
-        .unwrap()
-        .build();
+    let parent_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&parent_id, parent_key.to_string()).unwrap());
 
     // Create an account to delete
     let temp_key = SecretKey::generate_ed25519();
@@ -316,10 +301,8 @@ async fn test_sandbox_delete_account() {
     assert!(root_near.account_exists(&temp_id).await.unwrap());
 
     // Create a new client with the temp account's key to delete it
-    let temp_near = Near::custom(rpc_url, "sandbox")
-        .credentials(temp_key.to_string(), &temp_id)
-        .unwrap()
-        .build();
+    let temp_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&temp_id, temp_key.to_string()).unwrap());
 
     // Delete the account, sending remaining balance to parent account
     temp_near
@@ -338,7 +321,6 @@ async fn test_sandbox_delete_account() {
 async fn test_sandbox_add_and_delete_key() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create an account
     let account_key = SecretKey::generate_ed25519();
@@ -355,10 +337,8 @@ async fn test_sandbox_add_and_delete_key() {
         .unwrap();
 
     // Create a new client for this account
-    let account_near = Near::custom(rpc_url, "sandbox")
-        .credentials(account_key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, account_key.to_string()).unwrap());
 
     // Add a second key
     let second_key = SecretKey::generate_ed25519();
@@ -393,7 +373,6 @@ async fn test_sandbox_add_and_delete_key() {
 async fn test_sandbox_multiple_actions_in_one_transaction() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create parent account
     let parent_key = SecretKey::generate_ed25519();
@@ -409,10 +388,8 @@ async fn test_sandbox_multiple_actions_in_one_transaction() {
         .await
         .unwrap();
 
-    let parent_near = Near::custom(rpc_url, "sandbox")
-        .credentials(parent_key.to_string(), &parent_id)
-        .unwrap()
-        .build();
+    let parent_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&parent_id, parent_key.to_string()).unwrap());
 
     // Create two accounts in separate transactions
     let alice_key = SecretKey::generate_ed25519();
@@ -500,7 +477,6 @@ async fn test_sandbox_set_balance() {
 async fn test_sandbox_set_balance_preserves_other_fields() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create an account and deploy a contract to it
     let account_key = SecretKey::generate_ed25519();
@@ -545,10 +521,8 @@ async fn test_sandbox_set_balance_preserves_other_fields() {
     );
 
     // Verify the contract still works
-    let account_near = Near::custom(rpc_url, "sandbox")
-        .credentials(account_key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, account_key.to_string()).unwrap());
 
     let messages: Vec<serde_json::Value> = account_near
         .view(&account_id, "get_messages")
@@ -562,7 +536,6 @@ async fn test_sandbox_set_balance_preserves_other_fields() {
 async fn test_sandbox_set_balance_for_staking() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create a validator account with small initial balance
     let validator_key = SecretKey::generate_ed25519();
@@ -590,10 +563,8 @@ async fn test_sandbox_set_balance_for_staking() {
     assert_eq!(balance.total, staking_balance);
 
     // Now we can actually stake with enough to meet the minimum
-    let validator_near = Near::custom(rpc_url, "sandbox")
-        .credentials(validator_key.to_string(), &validator_id)
-        .unwrap()
-        .build();
+    let validator_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&validator_id, validator_key.to_string()).unwrap());
 
     let stake_amount = NearToken::from_near(1_000_000);
     let outcome = validator_near
@@ -673,7 +644,6 @@ async fn test_sandbox_patch_debug() {
 async fn test_sign_message_nep413() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create an account with a signer
     let account_key = SecretKey::generate_ed25519();
@@ -689,10 +659,8 @@ async fn test_sign_message_nep413() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(rpc_url, "sandbox")
-        .credentials(account_key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, account_key.to_string()).unwrap());
 
     // Sign a message using NEP-413
     let params = nep413::SignMessageParams {
@@ -741,7 +709,6 @@ async fn test_sign_message_without_signer_fails() {
 async fn test_send_with_options_final() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -757,10 +724,8 @@ async fn test_send_with_options_final() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create receiver account
     let receiver_key = SecretKey::generate_ed25519();
@@ -800,7 +765,6 @@ async fn test_send_with_options_final() {
 async fn test_send_with_options_included_returns_send_tx_response() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -816,10 +780,8 @@ async fn test_send_with_options_included_returns_send_tx_response() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create receiver account
     let receiver_key = SecretKey::generate_ed25519();
@@ -862,7 +824,6 @@ async fn test_send_with_options_included_returns_send_tx_response() {
 async fn test_wait_until_included_on_builder() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -878,10 +839,8 @@ async fn test_wait_until_included_on_builder() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create receiver account
     let receiver_key = SecretKey::generate_ed25519();
@@ -916,7 +875,6 @@ async fn test_wait_until_included_on_builder() {
 async fn test_send_pre_signed_transaction() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create sender account
     let sender_key = SecretKey::generate_ed25519();
@@ -932,10 +890,8 @@ async fn test_send_pre_signed_transaction() {
         .await
         .unwrap();
 
-    let sender_near = Near::custom(rpc_url, "sandbox")
-        .credentials(sender_key.to_string(), &sender_id)
-        .unwrap()
-        .build();
+    let sender_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&sender_id, sender_key.to_string()).unwrap());
 
     // Create receiver account
     let receiver_key = SecretKey::generate_ed25519();

--- a/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
+++ b/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
@@ -43,10 +43,8 @@ async fn test_in_memory_signer_from_secret_key() {
         .unwrap();
 
     // Create client with InMemorySigner from secret key
-    let near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Should be able to sign transactions
     let receiver_id: AccountId = format!("recv.{}", account_id).parse().unwrap();
@@ -92,9 +90,7 @@ async fn test_in_memory_signer_from_seed_phrase() {
     assert_eq!(*pubkey, key.public_key(), "Public keys should match");
 
     // Create client with seed phrase signer
-    let near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .signer(signer)
-        .build();
+    let near = Near::sandbox(sandbox).with_signer(signer);
 
     // Should be able to query account
     let balance = near.balance(&account_id).await.unwrap();
@@ -132,9 +128,7 @@ async fn test_rotating_signer_uses_multiple_keys() {
     // Create a rotating signer with all three keys
     let signer = RotatingSigner::new(&account_id, vec![key1, key2, key3]).unwrap();
 
-    let near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .signer(signer)
-        .build();
+    let near = Near::sandbox(sandbox).with_signer(signer);
 
     // Execute multiple transactions - the rotating signer should cycle through keys
     for i in 0..6 {
@@ -178,9 +172,7 @@ async fn test_rotating_signer_with_single_key() {
     // Rotating signer with just one key should still work
     let signer = RotatingSigner::new(&account_id, vec![key]).unwrap();
 
-    let near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .signer(signer)
-        .build();
+    let near = Near::sandbox(sandbox).with_signer(signer);
 
     // Should work fine with single key
     let sub_id: AccountId = format!("single.{}", account_id).parse().unwrap();
@@ -253,10 +245,8 @@ async fn test_sign_with_override() {
         .unwrap();
 
     // Create client with account1's signer
-    let near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key1.to_string(), &account1_id)
-        .unwrap()
-        .build();
+    let near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account1_id, key1.to_string()).unwrap());
 
     // Use sign_with to send a transaction from account2
     let signer2 = InMemorySigner::from_secret_key(account2_id.clone(), key2).unwrap();
@@ -302,10 +292,8 @@ async fn test_wrong_key_for_account() {
         .unwrap();
 
     // Create client with the WRONG key
-    let near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(wrong_key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, wrong_key.to_string()).unwrap());
 
     // Try to send a transaction - should fail with access key error
     let sub_id: AccountId = format!("wrongkey.{}", account_id).parse().unwrap();
@@ -352,16 +340,12 @@ async fn test_deleted_key_fails() {
         .unwrap();
 
     // Create client with key1
-    let near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key1.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key1.to_string()).unwrap());
 
     // Delete key1 using key2
-    let near2 = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key2.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let near2 = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key2.to_string()).unwrap());
 
     near2
         .delete_key(key1.public_key())
@@ -403,10 +387,8 @@ async fn test_signing_with_ed25519_key() {
         .await
         .unwrap();
 
-    let ed_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(ed_key.to_string(), &ed_account)
-        .unwrap()
-        .build();
+    let ed_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&ed_account, ed_key.to_string()).unwrap());
 
     // Should work with Ed25519
     let sub_id: AccountId = format!("ed25519.{}", ed_account).parse().unwrap();

--- a/crates/near-kit/tests/integration/token_integration.rs
+++ b/crates/near-kit/tests/integration/token_integration.rs
@@ -45,9 +45,7 @@ async fn deploy_ft_contract(
 
     // Initialize the FT contract
     // The near-sdk-rs example FT uses "new" with owner_id, total_supply, metadata
-    let ft_near = Near::custom(near.rpc_url(), "sandbox")
-        .credentials(ft_key.to_string(), &ft_id)?
-        .build();
+    let ft_near = near.with_signer(InMemorySigner::new(&ft_id, ft_key.to_string())?);
 
     ft_near
         .call(&ft_id, "new")
@@ -177,7 +175,6 @@ async fn test_ft_total_supply() {
 async fn test_ft_transfer() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create owner account (sender)
     let owner_key = SecretKey::generate_ed25519();
@@ -197,10 +194,8 @@ async fn test_ft_transfer() {
     let receiver_key = SecretKey::generate_ed25519();
     let receiver_id: AccountId = format!("receiver.{}", owner_id).parse().unwrap();
 
-    let owner_near = Near::custom(rpc_url, "sandbox")
-        .credentials(owner_key.to_string(), &owner_id)
-        .unwrap()
-        .build();
+    let owner_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&owner_id, owner_key.to_string()).unwrap());
 
     owner_near
         .transaction(&receiver_id)
@@ -267,7 +262,6 @@ async fn test_ft_transfer() {
 async fn test_ft_storage_deposit() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create owner account
     let owner_key = SecretKey::generate_ed25519();
@@ -284,10 +278,8 @@ async fn test_ft_storage_deposit() {
         .unwrap();
 
     // Create owner's near client for signing
-    let owner_near = Near::custom(rpc_url, "sandbox")
-        .credentials(owner_key.to_string(), &owner_id)
-        .unwrap()
-        .build();
+    let owner_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&owner_id, owner_key.to_string()).unwrap());
 
     // Create account to register - must be created by owner
     let user_key = SecretKey::generate_ed25519();
@@ -352,9 +344,7 @@ async fn deploy_nft_contract(
         .await?;
 
     // Initialize the NFT contract
-    let nft_near = Near::custom(near.rpc_url(), "sandbox")
-        .credentials(nft_key.to_string(), &nft_id)?
-        .build();
+    let nft_near = near.with_signer(InMemorySigner::new(&nft_id, nft_key.to_string())?);
 
     nft_near
         .call(&nft_id, "new")
@@ -380,9 +370,7 @@ async fn mint_nft(
     token_id: &str,
     owner_id: &AccountId,
 ) -> Result<(), Error> {
-    let nft_near = Near::custom(near.rpc_url(), "sandbox")
-        .credentials(nft_key.to_string(), nft_id)?
-        .build();
+    let nft_near = near.with_signer(InMemorySigner::new(nft_id, nft_key.to_string())?);
 
     nft_near
         .call(nft_id, "nft_mint")
@@ -546,7 +534,6 @@ async fn test_nft_tokens_for_owner() {
 async fn test_nft_transfer() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create owner account
     let owner_key = SecretKey::generate_ed25519();
@@ -563,10 +550,8 @@ async fn test_nft_transfer() {
         .unwrap();
 
     // Create owner's client for signing
-    let owner_near = Near::custom(rpc_url, "sandbox")
-        .credentials(owner_key.to_string(), &owner_id)
-        .unwrap()
-        .build();
+    let owner_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&owner_id, owner_key.to_string()).unwrap());
 
     // Create receiver account - must be created by owner
     let receiver_key = SecretKey::generate_ed25519();
@@ -662,7 +647,6 @@ async fn test_nft_total_supply() {
 async fn test_nft_supply_for_owner() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Create first owner account
     let owner1_key = SecretKey::generate_ed25519();
@@ -679,10 +663,8 @@ async fn test_nft_supply_for_owner() {
         .unwrap();
 
     // Create owner1's client for signing
-    let owner1_near = Near::custom(rpc_url, "sandbox")
-        .credentials(owner1_key.to_string(), &owner1_id)
-        .unwrap()
-        .build();
+    let owner1_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&owner1_id, owner1_key.to_string()).unwrap());
 
     // Create second owner as subaccount of owner1
     let owner2_key = SecretKey::generate_ed25519();

--- a/crates/near-kit/tests/integration/tracing_integration.rs
+++ b/crates/near-kit/tests/integration/tracing_integration.rs
@@ -197,7 +197,6 @@ async fn test_ft_balance_of_span_hierarchy() {
 
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
-    let rpc_url = sandbox.rpc_url();
 
     // Deploy an FT contract
     let ft_key = SecretKey::generate_ed25519();
@@ -231,10 +230,8 @@ async fn test_ft_balance_of_span_hierarchy() {
         .await
         .unwrap();
 
-    let ft_near = Near::custom(rpc_url, "sandbox")
-        .credentials(ft_key.to_string(), &ft_id)
-        .unwrap()
-        .build();
+    let ft_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&ft_id, ft_key.to_string()).unwrap());
 
     ft_near
         .call(&ft_id, "new")

--- a/crates/near-kit/tests/integration/transaction_failure_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_failure_integration.rs
@@ -41,10 +41,8 @@ async fn test_deploy_invalid_wasm() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Try to deploy invalid WASM (random bytes)
     let invalid_wasm = vec![0u8; 100]; // Not valid WASM
@@ -73,10 +71,8 @@ async fn test_deploy_empty_wasm() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Try to deploy empty WASM
     let empty_wasm: Vec<u8> = vec![];
@@ -132,10 +128,8 @@ async fn test_add_duplicate_key() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Try to add the same key again — action error returns Ok(outcome)
     let outcome = account_near
@@ -167,10 +161,8 @@ async fn test_delete_last_full_access_key() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Delete the only key - this should succeed but leave the account inaccessible
     // Note: NEAR protocol allows this
@@ -278,10 +270,8 @@ async fn test_transaction_with_failing_action_in_middle() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Try a multi-action transaction where one action fails
     // First action: valid key deletion (the one we're signing with)
@@ -351,10 +341,8 @@ async fn test_delete_account_to_nonexistent_beneficiary() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Try to delete account with non-existent beneficiary
     let nonexistent_beneficiary: AccountId = "nonexistent-beneficiary.sandbox".parse().unwrap();
@@ -391,10 +379,8 @@ async fn test_stake_with_insufficient_balance() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Try to stake more than available
     let outcome = account_near
@@ -436,10 +422,8 @@ async fn test_transfer_zero_amount() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Transfer zero amount
     let receiver: AccountId = format!("recv.{}", account_id).parse().unwrap();
@@ -481,10 +465,8 @@ async fn test_transfer_max_amount() {
         .await
         .unwrap();
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &account_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&account_id, key.to_string()).unwrap());
 
     // Transfer max u128 (way more than balance) — rejected at RPC validation
     // level (CostOverflow is caught before on-chain execution)

--- a/crates/near-kit/tests/integration/transaction_outcome_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_outcome_integration.rs
@@ -41,10 +41,8 @@ async fn test_failed_transaction_preserves_receipts() {
         .result()
         .expect("setup: deploy should succeed on-chain");
 
-    let account_near = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &contract_id)
-        .unwrap()
-        .build();
+    let account_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&contract_id, key.to_string()).unwrap());
 
     // Call a non-existent method — the transaction executes but fails on-chain
     // Action errors return Ok(outcome) where outcome.is_failure() is true

--- a/crates/near-kit/tests/integration/typed_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_error_integration.rs
@@ -36,10 +36,8 @@ async fn funded_account(
         .await
         .unwrap();
 
-    let client = Near::custom(sandbox.rpc_url(), "sandbox")
-        .credentials(key.to_string(), &id)
-        .unwrap()
-        .build();
+    let client =
+        Near::sandbox(sandbox).with_signer(InMemorySigner::new(&id, key.to_string()).unwrap());
 
     (client, id, key)
 }


### PR DESCRIPTION
## Summary
- Replaces `Near::custom(rpc_url, "sandbox")` with `Near::sandbox()` throughout tests and examples
- `Near::sandbox()` already sets the chain_id automatically, so manually passing `"sandbox"` is unnecessary
- Uses `.with_signer()` to configure non-root signers instead of the builder pattern
- Intentionally read-only clients (no signer) left as `Near::custom()` since `Near::sandbox()` always adds the root signer
- Net reduction of ~200 lines

## Test plan
- [x] `cargo check --tests --examples -p near-kit` passes
- [x] Clippy and rustfmt pass via pre-commit hook