### PR TITLE
feat: expose unsigned transaction for external signing workflows

### DIFF
--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -752,8 +752,8 @@ impl TransactionBuilder {
     /// ```rust,no_run
     /// # use near_kit::*;
     /// # fn example(near: Near) -> Result<(), near_kit::Error> {
-    /// let block_hash: CryptoHash = "11111111111111111111111111111111".parse()?;
-    /// let public_key: PublicKey = "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp".parse()?;
+    /// let block_hash = CryptoHash::ZERO;
+    /// let public_key: PublicKey = "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp".parse().unwrap();
     ///
     /// let unsigned = near.transaction("bob.testnet")
     ///     .transfer(NearToken::from_near(1))

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -696,8 +696,9 @@ impl TransactionBuilder {
         );
 
         async move {
-            let key = signer.key();
-            let public_key = key.public_key().clone();
+            // Use public_key() directly to avoid side effects from key() —
+            // e.g. RotatingSigner advances its rotation counter on key().
+            let public_key = signer.public_key().clone();
 
             let access_key = self
                 .rpc

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -639,6 +639,155 @@ impl TransactionBuilder {
     // Execution
     // ========================================================================
 
+    /// Build the unsigned transaction without signing.
+    ///
+    /// Resolves the nonce and block hash from the network, then returns the
+    /// unsigned [`Transaction`]. Use this for external signing workflows
+    /// (hardware wallets, MPC, HSM) where you need the transaction hash
+    /// before signing.
+    ///
+    /// The returned [`Transaction`] provides [`get_hash()`](Transaction::get_hash)
+    /// for the bytes to sign, and [`complete()`](Transaction::complete) to attach
+    /// an externally-produced signature.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # async fn example(near: Near) -> Result<(), near_kit::Error> {
+    /// let unsigned = near.transaction("bob.testnet")
+    ///     .transfer(NearToken::from_near(1))
+    ///     .build()
+    ///     .await?;
+    ///
+    /// // Get the hash that needs signing
+    /// let hash = unsigned.get_hash();
+    ///
+    /// // Sign externally (Ledger, MPC, HSM, etc.)
+    /// // let sig_bytes = device.sign(hash.as_bytes())?;
+    /// // let signature = Signature::from_parts(KeyType::ED25519, &sig_bytes)?;
+    ///
+    /// // Complete and submit
+    /// // let signed = unsigned.complete(signature);
+    /// // near.send(&signed).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn build(self) -> Result<Transaction, Error> {
+        if self.actions.is_empty() {
+            return Err(Error::InvalidTransaction(
+                "Transaction must have at least one action".to_string(),
+            ));
+        }
+
+        let signer = self
+            .signer_override
+            .or(self.signer)
+            .ok_or(Error::NoSigner)?;
+
+        let signer_id = signer.account_id().clone();
+        let action_count = self.actions.len();
+
+        let span = tracing::info_span!(
+            "build_transaction",
+            sender = %signer_id,
+            receiver = %self.receiver_id,
+            action_count,
+        );
+
+        async move {
+            let key = signer.key();
+            let public_key = key.public_key().clone();
+
+            let access_key = self
+                .rpc
+                .view_access_key(
+                    &signer_id,
+                    &public_key,
+                    BlockReference::Finality(Finality::Final),
+                )
+                .await?;
+            let block_hash = access_key.block_hash;
+
+            let network = self.rpc.url().to_string();
+            let nonce = nonce_manager().next(
+                network,
+                signer_id.clone(),
+                public_key.clone(),
+                access_key.nonce,
+            );
+
+            let tx = Transaction::new(
+                signer_id,
+                public_key,
+                nonce,
+                self.receiver_id,
+                block_hash,
+                self.actions,
+            );
+
+            tracing::debug!(tx_hash = %tx.get_hash(), nonce, "Transaction built (unsigned)");
+
+            Ok(tx)
+        }
+        .instrument(span)
+        .await
+    }
+
+    /// Build an unsigned transaction offline without network access or a signer.
+    ///
+    /// Use this for fully air-gapped workflows where you provide all
+    /// transaction metadata manually.
+    ///
+    /// # Arguments
+    ///
+    /// * `signer_id` - The account that will sign and pay for the transaction
+    /// * `public_key` - The public key of the signer
+    /// * `block_hash` - A recent block hash (transaction expires ~24h after this block)
+    /// * `nonce` - The next nonce for the signing key (current nonce + 1)
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # fn example(near: Near) -> Result<(), near_kit::Error> {
+    /// let block_hash: CryptoHash = "11111111111111111111111111111111".parse()?;
+    /// let public_key: PublicKey = "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp".parse()?;
+    ///
+    /// let unsigned = near.transaction("bob.testnet")
+    ///     .transfer(NearToken::from_near(1))
+    ///     .build_offline("alice.testnet", public_key, block_hash, 12345)?;
+    ///
+    /// let hash = unsigned.get_hash();
+    /// // Sign hash externally, then call unsigned.complete(signature)
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn build_offline(
+        self,
+        signer_id: impl TryIntoAccountId,
+        public_key: PublicKey,
+        block_hash: CryptoHash,
+        nonce: u64,
+    ) -> Result<Transaction, Error> {
+        if self.actions.is_empty() {
+            return Err(Error::InvalidTransaction(
+                "Transaction must have at least one action".to_string(),
+            ));
+        }
+
+        let signer_id: AccountId = signer_id.try_into_account_id()?;
+
+        Ok(Transaction::new(
+            signer_id,
+            public_key,
+            nonce,
+            self.receiver_id,
+            block_hash,
+            self.actions,
+        ))
+    }
+
     /// Sign the transaction without sending it.
     ///
     /// Returns a `SignedTransaction` that can be inspected or sent later.

--- a/crates/near-kit/src/types/transaction.rs
+++ b/crates/near-kit/src/types/transaction.rs
@@ -72,12 +72,11 @@ impl Transaction {
     ///
     /// ```rust,no_run
     /// # use near_kit::*;
-    /// # fn example(tx: Transaction, sig_bytes: &[u8]) -> Result<(), near_kit::Error> {
+    /// # fn example(tx: Transaction, sig_bytes: [u8; 64]) {
     /// let hash = tx.get_hash();
     /// // sign hash externally...
-    /// let signature = Signature::from_parts(KeyType::ED25519, sig_bytes)?;
+    /// let signature = Signature::ed25519_from_bytes(sig_bytes);
     /// let signed = tx.complete(signature);
-    /// # Ok(())
     /// # }
     /// ```
     pub fn complete(self, signature: Signature) -> SignedTransaction {

--- a/crates/near-kit/src/types/transaction.rs
+++ b/crates/near-kit/src/types/transaction.rs
@@ -62,6 +62,30 @@ impl Transaction {
             signature,
         }
     }
+
+    /// Complete this transaction with an externally-produced signature.
+    ///
+    /// Use this for hardware wallet, MPC, or HSM signing workflows where you
+    /// sign the transaction hash externally and then reconstruct the signed transaction.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use near_kit::*;
+    /// # fn example(tx: Transaction, sig_bytes: &[u8]) -> Result<(), near_kit::Error> {
+    /// let hash = tx.get_hash();
+    /// // sign hash externally...
+    /// let signature = Signature::from_parts(KeyType::ED25519, sig_bytes)?;
+    /// let signed = tx.complete(signature);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn complete(self, signature: Signature) -> SignedTransaction {
+        SignedTransaction {
+            transaction: self,
+            signature,
+        }
+    }
 }
 
 /// A signed transaction ready to be sent.
@@ -169,5 +193,34 @@ mod tests {
 
         let signed = tx.sign(&secret);
         assert!(!signed.to_bytes().is_empty());
+    }
+
+    #[test]
+    fn test_complete_matches_sign() {
+        let secret = SecretKey::generate_ed25519();
+        let public = secret.public_key();
+
+        let tx1 = Transaction::new(
+            "alice.testnet".parse().unwrap(),
+            public.clone(),
+            1,
+            "bob.testnet".parse().unwrap(),
+            CryptoHash::ZERO,
+            vec![],
+        );
+
+        let tx2 = tx1.clone();
+
+        // Sign via the normal path
+        let signed_normal = tx1.sign(&secret);
+
+        // Sign manually via complete()
+        let hash = tx2.get_hash();
+        let signature = secret.sign(hash.as_bytes());
+        let signed_complete = tx2.complete(signature);
+
+        assert_eq!(signed_normal.get_hash(), signed_complete.get_hash());
+        assert_eq!(signed_normal.signature, signed_complete.signature);
+        assert_eq!(signed_normal.to_bytes(), signed_complete.to_bytes());
     }
 }


### PR DESCRIPTION
## Summary

- Add `Transaction::complete(signature)` method to attach an externally-produced signature to an unsigned transaction, producing a `SignedTransaction`
- Add `TransactionBuilder::build()` to resolve nonce/block_hash from the network and return the unsigned `Transaction` (requires a signer for account_id + public_key)
- Add `TransactionBuilder::build_offline(signer_id, public_key, block_hash, nonce)` for fully air-gapped workflows where all metadata is provided manually (no signer or network needed)

These three methods together enable hardware wallet, MPC, and HSM signing workflows: build the unsigned transaction, get its hash via `get_hash()`, sign externally, then call `complete(signature)` and submit with `near.send()`.

Closes #179

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy` passes clean
- [x] `cargo fmt --check` passes
- [x] All 414 unit tests pass, including new `test_complete_matches_sign` that verifies `complete()` produces identical output to `sign()`
- [x] Pre-commit hooks (clippy + rustfmt) pass