### PR TITLE
feat: enrich tracing spans for CLI teach-me support

### DIFF
--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -151,7 +151,7 @@ impl RpcClient {
     }
 
     /// Make a raw RPC call with retries.
-    #[tracing::instrument(skip(self, params), fields(rpc.method = method, rpc.url = %self.url))]
+    #[tracing::instrument(skip(self, params), fields(rpc.method = method, rpc.url = %sanitize_url(&self.url)))]
     pub async fn call<P: Serialize, R: DeserializeOwned>(
         &self,
         method: &str,
@@ -779,6 +779,16 @@ fn block_id_or_null(block: Option<&BlockReference>) -> serde_json::Value {
     }
 }
 
+/// Strip query string, fragment, and userinfo from a URL for safe logging.
+///
+/// RPC provider URLs may carry API keys as query parameters or path tokens.
+/// This returns `scheme://host/path` so credentials don't leak into tracing spans.
+fn sanitize_url(url: &str) -> &str {
+    // Strip query and fragment
+    let end = url.find('?').or_else(|| url.find('#')).unwrap_or(url.len());
+    &url[..end]
+}
+
 /// Check if an HTTP status code is retryable.
 fn is_retryable_status(status: u16) -> bool {
     // 408 Request Timeout - retryable
@@ -859,6 +869,42 @@ mod tests {
         let debug = format!("{:?}", client);
         assert!(debug.contains("RpcClient"));
         assert!(debug.contains("rpc.testnet.near.org"));
+    }
+
+    // ========================================================================
+    // sanitize_url tests
+    // ========================================================================
+
+    #[test]
+    fn test_sanitize_url_plain() {
+        assert_eq!(
+            sanitize_url("https://rpc.mainnet.near.org"),
+            "https://rpc.mainnet.near.org"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_url_strips_query() {
+        assert_eq!(
+            sanitize_url("https://rpc.provider.com/v1?api_key=secret123"),
+            "https://rpc.provider.com/v1"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_url_strips_fragment() {
+        assert_eq!(
+            sanitize_url("https://rpc.provider.com/v1#section"),
+            "https://rpc.provider.com/v1"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_url_strips_query_and_fragment() {
+        assert_eq!(
+            sanitize_url("https://rpc.provider.com/v1?key=val#frag"),
+            "https://rpc.provider.com/v1"
+        );
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -151,7 +151,7 @@ impl RpcClient {
     }
 
     /// Make a raw RPC call with retries.
-    #[tracing::instrument(skip(self, params), fields(rpc.method = method))]
+    #[tracing::instrument(skip(self, params), fields(rpc.method = method, rpc.url = %self.url))]
     pub async fn call<P: Serialize, R: DeserializeOwned>(
         &self,
         method: &str,
@@ -201,6 +201,12 @@ impl RpcClient {
         &self,
         request: &JsonRpcRequest<'_, impl Serialize>,
     ) -> Result<R, RpcError> {
+        if tracing::enabled!(tracing::Level::TRACE) {
+            if let Ok(json) = serde_json::to_string(request) {
+                tracing::trace!(payload = %json, "RPC request");
+            }
+        }
+
         let response = self
             .client
             .post(&self.url)
@@ -211,6 +217,8 @@ impl RpcClient {
 
         let status = response.status();
         let body = response.text().await?;
+
+        tracing::trace!(payload = %body, "RPC response");
 
         if !status.is_success() {
             let retryable = is_retryable_status(status.as_u16());

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -54,6 +54,67 @@ fn nonce_manager() -> &'static NonceManager {
     NONCE_MANAGER.get_or_init(NonceManager::new)
 }
 
+/// Produce a comma-separated summary of action types for tracing spans.
+///
+/// Function calls include the method name, e.g. `"create_account,transfer,function_call(init)"`.
+fn actions_summary(actions: &[Action]) -> String {
+    actions
+        .iter()
+        .map(|a| match a {
+            Action::CreateAccount(_) => "create_account".to_string(),
+            Action::DeployContract(_) => "deploy_contract".to_string(),
+            Action::FunctionCall(fc) => format!("function_call({})", fc.method_name),
+            Action::Transfer(_) => "transfer".to_string(),
+            Action::Stake(_) => "stake".to_string(),
+            Action::AddKey(_) => "add_key".to_string(),
+            Action::DeleteKey(_) => "delete_key".to_string(),
+            Action::DeleteAccount(_) => "delete_account".to_string(),
+            Action::Delegate(_) => "delegate".to_string(),
+            Action::DeployGlobalContract(_) => "deploy_global_contract".to_string(),
+            Action::UseGlobalContract(_) => "use_global_contract".to_string(),
+            Action::DeterministicStateInit(_) => "deterministic_state_init".to_string(),
+            Action::TransferToGasKey(_) => "transfer_to_gas_key".to_string(),
+            Action::WithdrawFromGasKey(_) => "withdraw_from_gas_key".to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+/// Record function-call span fields from the action list.
+///
+/// When the actions contain exactly one function call, records `method`, `gas`,
+/// and `deposit` on the current span. Multiple function calls emit a debug event
+/// per call instead, since span fields can't repeat.
+fn record_function_call_fields(actions: &[Action]) {
+    let function_calls: Vec<_> = actions
+        .iter()
+        .filter_map(|a| match a {
+            Action::FunctionCall(fc) => Some(fc),
+            _ => None,
+        })
+        .collect();
+
+    match function_calls.as_slice() {
+        [fc] => {
+            let span = tracing::Span::current();
+            span.record("method", fc.method_name.as_str());
+            span.record("gas", tracing::field::display(&fc.gas));
+            span.record("deposit", tracing::field::display(&fc.deposit));
+        }
+        multiple if !multiple.is_empty() => {
+            for fc in multiple {
+                tracing::debug!(
+                    method = %fc.method_name,
+                    gas = %fc.gas,
+                    deposit = %fc.deposit,
+                    "function_call action"
+                );
+            }
+        }
+        _ => {}
+    }
+}
+
 // ============================================================================
 // Delegate Action Types
 // ============================================================================
@@ -693,9 +754,16 @@ impl TransactionBuilder {
             sender = %signer_id,
             receiver = %self.receiver_id,
             action_count,
+            actions = %actions_summary(&self.actions),
+            method = tracing::field::Empty,
+            gas = tracing::field::Empty,
+            deposit = tracing::field::Empty,
         );
 
+        let actions = self.actions;
         async move {
+            record_function_call_fields(&actions);
+
             // Use public_key() directly to avoid side effects from key() —
             // e.g. RotatingSigner advances its rotation counter on key().
             let public_key = signer.public_key().clone();
@@ -724,7 +792,7 @@ impl TransactionBuilder {
                 nonce,
                 self.receiver_id,
                 block_hash,
-                self.actions,
+                actions,
             );
 
             tracing::debug!(tx_hash = %tx.get_hash(), nonce, "Transaction built (unsigned)");
@@ -832,9 +900,16 @@ impl TransactionBuilder {
             sender = %signer_id,
             receiver = %self.receiver_id,
             action_count,
+            actions = %actions_summary(&self.actions),
+            method = tracing::field::Empty,
+            gas = tracing::field::Empty,
+            deposit = tracing::field::Empty,
         );
 
+        let actions = self.actions;
         async move {
+            record_function_call_fields(&actions);
+
             // Get a signing key atomically. For RotatingSigner, this claims the next
             // key in rotation. The key contains both the public key and signing capability.
             let key = signer.key();
@@ -867,7 +942,7 @@ impl TransactionBuilder {
                 nonce,
                 self.receiver_id,
                 block_hash,
-                self.actions,
+                actions,
             );
 
             // Sign with the key
@@ -1474,9 +1549,15 @@ impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
                 sender = %signer_id,
                 receiver = %builder.receiver_id,
                 action_count = builder.actions.len(),
+                actions = %actions_summary(&builder.actions),
+                method = tracing::field::Empty,
+                gas = tracing::field::Empty,
+                deposit = tracing::field::Empty,
             );
 
             async move {
+                record_function_call_fields(&builder.actions);
+
                 // Retry loop for transient InvalidTxErrors (nonce conflicts, expired block hash)
                 let max_nonce_retries = builder.max_nonce_retries;
                 let wait_until = W::status();

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -58,26 +58,30 @@ fn nonce_manager() -> &'static NonceManager {
 ///
 /// Function calls include the method name, e.g. `"create_account,transfer,function_call(init)"`.
 fn actions_summary(actions: &[Action]) -> String {
-    actions
-        .iter()
-        .map(|a| match a {
-            Action::CreateAccount(_) => "create_account".to_string(),
-            Action::DeployContract(_) => "deploy_contract".to_string(),
-            Action::FunctionCall(fc) => format!("function_call({})", fc.method_name),
-            Action::Transfer(_) => "transfer".to_string(),
-            Action::Stake(_) => "stake".to_string(),
-            Action::AddKey(_) => "add_key".to_string(),
-            Action::DeleteKey(_) => "delete_key".to_string(),
-            Action::DeleteAccount(_) => "delete_account".to_string(),
-            Action::Delegate(_) => "delegate".to_string(),
-            Action::DeployGlobalContract(_) => "deploy_global_contract".to_string(),
-            Action::UseGlobalContract(_) => "use_global_contract".to_string(),
-            Action::DeterministicStateInit(_) => "deterministic_state_init".to_string(),
-            Action::TransferToGasKey(_) => "transfer_to_gas_key".to_string(),
-            Action::WithdrawFromGasKey(_) => "withdraw_from_gas_key".to_string(),
-        })
-        .collect::<Vec<_>>()
-        .join(",")
+    use std::fmt::Write;
+    let mut out = String::new();
+    for (i, a) in actions.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        match a {
+            Action::CreateAccount(_) => out.push_str("create_account"),
+            Action::DeployContract(_) => out.push_str("deploy_contract"),
+            Action::FunctionCall(fc) => write!(out, "function_call({})", fc.method_name).unwrap(),
+            Action::Transfer(_) => out.push_str("transfer"),
+            Action::Stake(_) => out.push_str("stake"),
+            Action::AddKey(_) => out.push_str("add_key"),
+            Action::DeleteKey(_) => out.push_str("delete_key"),
+            Action::DeleteAccount(_) => out.push_str("delete_account"),
+            Action::Delegate(_) => out.push_str("delegate"),
+            Action::DeployGlobalContract(_) => out.push_str("deploy_global_contract"),
+            Action::UseGlobalContract(_) => out.push_str("use_global_contract"),
+            Action::DeterministicStateInit(_) => out.push_str("deterministic_state_init"),
+            Action::TransferToGasKey(_) => out.push_str("transfer_to_gas_key"),
+            Action::WithdrawFromGasKey(_) => out.push_str("withdraw_from_gas_key"),
+        }
+    }
+    out
 }
 
 /// Record function-call span fields from the action list.

--- a/crates/near-kit/tests/integration/tracing_integration.rs
+++ b/crates/near-kit/tests/integration/tracing_integration.rs
@@ -32,6 +32,7 @@ fn unique_account() -> AccountId {
 struct SpanRecord {
     name: &'static str,
     parent_id: Option<Id>,
+    fields: HashMap<&'static str, String>,
 }
 
 /// Shared state for the capturing layer.
@@ -39,6 +40,41 @@ struct SpanRecord {
 struct CapturedSpans {
     /// span id -> record
     spans: Arc<Mutex<HashMap<u64, SpanRecord>>>,
+}
+
+/// Visitor that collects span fields as strings.
+struct FieldVisitor {
+    fields: HashMap<&'static str, String>,
+}
+
+impl FieldVisitor {
+    fn new() -> Self {
+        Self {
+            fields: HashMap::new(),
+        }
+    }
+}
+
+impl tracing::field::Visit for FieldVisitor {
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        self.fields.insert(field.name(), format!("{:?}", value));
+    }
+
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        self.fields.insert(field.name(), value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &tracing::field::Field, value: i64) {
+        self.fields.insert(field.name(), value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        self.fields.insert(field.name(), value.to_string());
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields.insert(field.name(), value.to_string());
+    }
 }
 
 impl CapturedSpans {
@@ -69,9 +105,19 @@ impl CapturedSpans {
     fn has_span(&self, name: &str) -> bool {
         self.spans.lock().unwrap().values().any(|r| r.name == name)
     }
+
+    /// Find a span by name and return its fields.
+    fn find_span_fields(&self, name: &str) -> Option<HashMap<&'static str, String>> {
+        self.spans
+            .lock()
+            .unwrap()
+            .values()
+            .find(|r| r.name == name)
+            .map(|r| r.fields.clone())
+    }
 }
 
-/// A tracing Layer that records span creation with parent info.
+/// A tracing Layer that records span creation with parent info and fields.
 struct CapturingLayer {
     state: CapturedSpans,
 }
@@ -82,18 +128,39 @@ where
 {
     fn on_new_span(
         &self,
-        _attrs: &tracing::span::Attributes<'_>,
+        attrs: &tracing::span::Attributes<'_>,
         id: &Id,
         ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
         let span = ctx.span(id).expect("span not found");
         let parent_id = span.parent().map(|p| p.id());
         let name = span.name();
-        self.state
-            .spans
-            .lock()
-            .unwrap()
-            .insert(id.into_u64(), SpanRecord { name, parent_id });
+
+        let mut visitor = FieldVisitor::new();
+        attrs.record(&mut visitor);
+
+        self.state.spans.lock().unwrap().insert(
+            id.into_u64(),
+            SpanRecord {
+                name,
+                parent_id,
+                fields: visitor.fields,
+            },
+        );
+    }
+
+    fn on_record(
+        &self,
+        id: &Id,
+        values: &tracing::span::Record<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let mut visitor = FieldVisitor::new();
+        values.record(&mut visitor);
+
+        if let Some(record) = self.state.spans.lock().unwrap().get_mut(&id.into_u64()) {
+            record.fields.extend(visitor.fields);
+        }
     }
 }
 
@@ -145,6 +212,31 @@ async fn test_send_transaction_span_hierarchy() {
         children.contains(&"view_access_key"),
         "expected 'view_access_key' as child of 'send_transaction', got: {children:?}"
     );
+
+    // Verify enriched span fields
+    let fields = captured
+        .find_span_fields("send_transaction")
+        .expect("send_transaction span should exist");
+    assert_eq!(
+        fields.get("actions").map(|s| s.as_str()),
+        Some("create_account,transfer,add_key"),
+        "expected actions summary for create+transfer+add_key transaction"
+    );
+
+    // No function call → method/gas/deposit should not be recorded
+    assert!(
+        !fields.contains_key("method") || fields.get("method").map(|s| s.as_str()) == Some(""),
+        "method should not be set for non-function-call transaction"
+    );
+
+    // Verify RPC spans have rpc.url field
+    let rpc_fields = captured
+        .find_span_fields("call")
+        .expect("RPC call span should exist");
+    assert!(
+        rpc_fields.contains_key("rpc.url"),
+        "expected rpc.url field on RPC call span, got: {rpc_fields:?}"
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -182,6 +274,97 @@ async fn test_sign_transaction_span_hierarchy() {
     assert!(
         children.contains(&"view_access_key"),
         "expected 'view_access_key' as child of 'sign_transaction', got: {children:?}"
+    );
+
+    // Verify enriched span fields
+    let fields = captured
+        .find_span_fields("sign_transaction")
+        .expect("sign_transaction span should exist");
+    assert_eq!(
+        fields.get("actions").map(|s| s.as_str()),
+        Some("create_account,transfer,add_key"),
+        "expected actions summary on sign_transaction span"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn test_function_call_span_fields() {
+    let captured = CapturedSpans::default();
+    let layer = CapturingLayer {
+        state: captured.clone(),
+    };
+
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    let sandbox = SandboxConfig::shared().await;
+    let root_near = sandbox.client();
+
+    // Deploy FT contract
+    let ft_key = SecretKey::generate_ed25519();
+    let ft_id = unique_account();
+
+    root_near
+        .transaction(&ft_id)
+        .create_account()
+        .transfer(NearToken::from_near(50))
+        .add_full_access_key(ft_key.public_key())
+        .deploy(
+            std::fs::read("tests/contracts/fungible_token.wasm")
+                .expect("fungible_token.wasm not found"),
+        )
+        .send()
+        .wait_until(Final)
+        .await
+        .unwrap();
+
+    // Clear setup spans — we only care about the function call
+    captured.spans.lock().unwrap().clear();
+
+    let ft_near = Near::sandbox(sandbox)
+        .with_signer(InMemorySigner::new(&ft_id, ft_key.to_string()).unwrap());
+
+    ft_near
+        .call(&ft_id, "new")
+        .args(serde_json::json!({
+            "owner_id": ft_id.to_string(),
+            "total_supply": "1000000000000000000000000",
+            "metadata": {
+                "spec": "ft-1.0.0",
+                "name": "Test Token",
+                "symbol": "TEST",
+                "decimals": 18
+            }
+        }))
+        .send()
+        .wait_until(Final)
+        .await
+        .unwrap();
+
+    // Verify send_transaction span has function call fields
+    let fields = captured
+        .find_span_fields("send_transaction")
+        .expect("send_transaction span should exist");
+
+    assert_eq!(
+        fields.get("actions").map(|s| s.as_str()),
+        Some("function_call(new)"),
+        "expected actions summary for function call transaction"
+    );
+
+    // Single function call → method, gas, deposit should be recorded as span fields
+    assert_eq!(
+        fields.get("method").map(|s| s.as_str()),
+        Some("new"),
+        "expected method field for single function call"
+    );
+    assert!(
+        fields.contains_key("gas"),
+        "expected gas field for single function call, got: {fields:?}"
+    );
+    assert!(
+        fields.contains_key("deposit"),
+        "expected deposit field for single function call, got: {fields:?}"
     );
 }
 


### PR DESCRIPTION
Closes #175

## Summary

- Add `rpc.url` field to the low-level RPC `call` span and TRACE-level events for request/response JSON payloads
- Add `actions` field to `send_transaction`, `sign_transaction`, and `build_transaction` spans with a comma-separated summary (e.g. `"create_account,transfer,function_call(init)"`)
- For single function-call transactions, record `method`, `gas`, and `deposit` as span fields; for multi-call, emit per-call DEBUG events
- Extend integration test capturing layer to verify span fields, add new test for function-call field recording

A tracing Layer can now reconstruct messages like:
> "Calling function 'ft_transfer' on contract 'usdc.near' with 0 NEAR deposit and 30.0 Tgas"

purely from span fields, without reaching into near-kit internals.

## Test plan

- [x] All 414 unit tests pass
- [x] Clippy clean
- [ ] Sandbox integration tests (CI)