### PR TITLE
fix: replace compromised slipped10 with inline SLIP-10 ed25519

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,15 +200,6 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -404,6 +395,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,13 +513,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.9.1"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bcd97a54c7ca5ce2f6eb16f6bede5b0ab5f0055fedc17d2f0b4466e21671ca"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
- "generic-array",
- "subtle",
+ "cmov",
 ]
 
 [[package]]
@@ -631,15 +627,6 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
@@ -659,6 +646,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -679,7 +667,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -802,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1116,21 +1104,20 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deae6d9dbb35ec2c502d62b8f7b1c000a0822c3b0794ba36b3149c0a1c840dff"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1280,7 +1267,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1711,6 +1698,7 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "hex",
+ "hmac 0.13.0",
  "k256",
  "keyring",
  "libc",
@@ -1725,7 +1713,6 @@ dependencies = [
  "serde_with",
  "sha2 0.11.0",
  "sha3",
- "slipped10",
  "tempfile",
  "testcontainers",
  "thiserror 2.0.18",
@@ -1764,7 +1751,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1851,12 +1838,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -2100,7 +2081,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2138,7 +2119,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2390,7 +2371,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2458,7 +2439,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2697,19 +2678,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
@@ -2792,17 +2760,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slipped10"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a45443e66aa5d96db5e02d17db056e1ca970232a4fe73e1f9bc1816d68f4e98"
-dependencies = [
- "ed25519-dalek",
- "hmac 0.9.0",
- "sha2 0.9.9",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2825,7 +2782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2947,7 +2904,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3693,7 +3650,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ sha2 = "0.11"
 sha3 = "0.11"
 rand = "0.8"
 bip39 = "2"
-slipped10 = "0.4"
+hmac = "0.13"
 k256 = { version = "0.13", features = ["ecdsa"] }
 
 # Encoding

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -37,7 +37,7 @@ sha2.workspace = true
 sha3.workspace = true
 rand.workspace = true
 bip39.workspace = true
-slipped10.workspace = true
+hmac.workspace = true
 k256.workspace = true
 
 # Encoding

--- a/crates/near-kit/src/types/hd.rs
+++ b/crates/near-kit/src/types/hd.rs
@@ -43,37 +43,43 @@ impl std::fmt::Display for HdPathError {
 /// Parse a BIP-32 path like `m/44'/397'/0'` into a list of hardened indexes
 /// (high bit set). Accepts `'` or `H` as the hardened marker.
 ///
-/// The leading `m` or `m/` is optional. An empty path (just `m` or `""`)
-/// derives the master key only.
+/// Root-path forms `""`, `"m"`, and `"m/"` all derive the master key only.
+/// A single leading `/` (with or without the `m`) and a single trailing `/`
+/// are tolerated; repeated or interior empty segments are rejected.
 pub(crate) fn parse_hd_path(path: &str) -> Result<Vec<u32>, HdPathError> {
-    let mut out = Vec::new();
-    for (i, seg) in path.split('/').enumerate() {
-        // Allow a leading "m" prefix only as the first segment.
-        if i == 0 && (seg == "m" || seg.is_empty()) {
-            continue;
-        }
-        if seg.is_empty() {
-            return Err(HdPathError::EmptySegment);
-        }
-        let (num_str, hardened) = match seg.as_bytes().last() {
-            Some(b'\'') | Some(b'H') => (&seg[..seg.len() - 1], true),
-            _ => (seg, false),
-        };
-        if num_str.is_empty() || !num_str.bytes().all(|b| b.is_ascii_digit()) {
-            return Err(HdPathError::InvalidIndex(seg.to_string()));
-        }
-        let idx: u32 = num_str
-            .parse()
-            .map_err(|_| HdPathError::IndexOutOfRange(seg.to_string()))?;
-        if idx >= HARDENED {
-            return Err(HdPathError::IndexOutOfRange(seg.to_string()));
-        }
-        if !hardened {
-            return Err(HdPathError::NotHardened(seg.to_string()));
-        }
-        out.push(idx | HARDENED);
+    // Normalize: strip optional leading `m`, then a single leading `/`,
+    // then a single trailing `/`. Anything left is the `/`-separated body.
+    let body = path.strip_prefix('m').unwrap_or(path);
+    let body = body.strip_prefix('/').unwrap_or(body);
+    let body = body.strip_suffix('/').unwrap_or(body);
+    if body.is_empty() {
+        return Ok(Vec::new());
     }
-    Ok(out)
+
+    body.split('/')
+        .map(|seg| {
+            if seg.is_empty() {
+                return Err(HdPathError::EmptySegment);
+            }
+            let (num_str, hardened) = match seg.as_bytes().last() {
+                Some(b'\'') | Some(b'H') => (&seg[..seg.len() - 1], true),
+                _ => (seg, false),
+            };
+            if num_str.is_empty() || !num_str.bytes().all(|b| b.is_ascii_digit()) {
+                return Err(HdPathError::InvalidIndex(seg.to_string()));
+            }
+            let idx: u32 = num_str
+                .parse()
+                .map_err(|_| HdPathError::IndexOutOfRange(seg.to_string()))?;
+            if idx >= HARDENED {
+                return Err(HdPathError::IndexOutOfRange(seg.to_string()));
+            }
+            if !hardened {
+                return Err(HdPathError::NotHardened(seg.to_string()));
+            }
+            Ok(idx | HARDENED)
+        })
+        .collect()
 }
 
 /// Derive a 32-byte Ed25519 secret scalar from `seed` along `path` using
@@ -88,6 +94,10 @@ pub(crate) fn derive_ed25519_slip10(seed: &[u8], path: &[u32]) -> [u8; 32] {
     let mut i = mac.finalize().into_bytes();
 
     for &index in path {
+        debug_assert!(
+            index & HARDENED != 0,
+            "ed25519 SLIP-10 requires hardened indexes; got {index:#x}"
+        );
         // Hardened child: Data = 0x00 || I_L(parent) || ser32(index)
         let (il, ir) = i.split_at(32);
 
@@ -206,8 +216,12 @@ mod tests {
 
     #[test]
     fn parse_accepts_common_forms() {
-        assert_eq!(parse_hd_path("m").unwrap(), Vec::<u32>::new());
-        assert_eq!(parse_hd_path("").unwrap(), Vec::<u32>::new());
+        // Root-path forms all derive the master key
+        let empty = Vec::<u32>::new();
+        assert_eq!(parse_hd_path("").unwrap(), empty);
+        assert_eq!(parse_hd_path("m").unwrap(), empty);
+        assert_eq!(parse_hd_path("m/").unwrap(), empty);
+
         assert_eq!(
             parse_hd_path("m/44'/397'/0'").unwrap(),
             vec![44 | HARDENED, 397 | HARDENED, HARDENED]
@@ -222,16 +236,23 @@ mod tests {
             parse_hd_path("44'/397'/0'").unwrap(),
             parse_hd_path("m/44'/397'/0'").unwrap()
         );
+        // A single trailing slash is tolerated (matches slipped10's behavior)
+        assert_eq!(
+            parse_hd_path("m/44'/397'/0'/").unwrap(),
+            parse_hd_path("m/44'/397'/0'").unwrap()
+        );
     }
 
     #[test]
     fn parse_rejects_bad_input() {
+        // Interior empty segment
         assert!(matches!(
             parse_hd_path("m/44'//0'"),
             Err(HdPathError::EmptySegment)
         ));
+        // Double trailing slash: one is stripped, the other is an empty segment
         assert!(matches!(
-            parse_hd_path("m/44'/"),
+            parse_hd_path("m/44'//"),
             Err(HdPathError::EmptySegment)
         ));
         // Non-hardened is rejected for ed25519

--- a/crates/near-kit/src/types/hd.rs
+++ b/crates/near-kit/src/types/hd.rs
@@ -1,0 +1,257 @@
+//! SLIP-10 Ed25519 hierarchical deterministic key derivation.
+//!
+//! Implements the Ed25519 branch of SLIP-0010
+//! (<https://github.com/satoshilabs/slips/blob/master/slip-0010.md>).
+//!
+//! Ed25519 SLIP-10 only supports hardened derivation — non-hardened
+//! components are rejected by [`parse_hd_path`].
+
+use hmac::{Hmac, KeyInit, Mac};
+use sha2::Sha512;
+
+type HmacSha512 = Hmac<Sha512>;
+
+/// BIP-32 hardened derivation offset (2^31).
+const HARDENED: u32 = 0x8000_0000;
+
+/// Error parsing a BIP-32 path string for Ed25519 SLIP-10 derivation.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum HdPathError {
+    /// A path segment was empty (e.g. `"m//0'"` or a trailing `/`).
+    EmptySegment,
+    /// A segment was not a decimal integer optionally suffixed with `'` or `H`.
+    InvalidIndex(String),
+    /// The raw index was ≥ 2^31 (the hardened bit position).
+    IndexOutOfRange(String),
+    /// Ed25519 SLIP-10 requires every component to be hardened (`'` or `H` suffix).
+    NotHardened(String),
+}
+
+impl std::fmt::Display for HdPathError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptySegment => write!(f, "empty path segment"),
+            Self::InvalidIndex(s) => write!(f, "invalid path index {s:?}"),
+            Self::IndexOutOfRange(s) => write!(f, "path index out of range {s:?}"),
+            Self::NotHardened(s) => {
+                write!(f, "ed25519 requires hardened derivation, got {s:?}")
+            }
+        }
+    }
+}
+
+/// Parse a BIP-32 path like `m/44'/397'/0'` into a list of hardened indexes
+/// (high bit set). Accepts `'` or `H` as the hardened marker.
+///
+/// The leading `m` or `m/` is optional. An empty path (just `m` or `""`)
+/// derives the master key only.
+pub(crate) fn parse_hd_path(path: &str) -> Result<Vec<u32>, HdPathError> {
+    let mut out = Vec::new();
+    for (i, seg) in path.split('/').enumerate() {
+        // Allow a leading "m" prefix only as the first segment.
+        if i == 0 && (seg == "m" || seg.is_empty()) {
+            continue;
+        }
+        if seg.is_empty() {
+            return Err(HdPathError::EmptySegment);
+        }
+        let (num_str, hardened) = match seg.as_bytes().last() {
+            Some(b'\'') | Some(b'H') => (&seg[..seg.len() - 1], true),
+            _ => (seg, false),
+        };
+        if num_str.is_empty() || !num_str.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(HdPathError::InvalidIndex(seg.to_string()));
+        }
+        let idx: u32 = num_str
+            .parse()
+            .map_err(|_| HdPathError::IndexOutOfRange(seg.to_string()))?;
+        if idx >= HARDENED {
+            return Err(HdPathError::IndexOutOfRange(seg.to_string()));
+        }
+        if !hardened {
+            return Err(HdPathError::NotHardened(seg.to_string()));
+        }
+        out.push(idx | HARDENED);
+    }
+    Ok(out)
+}
+
+/// Derive a 32-byte Ed25519 secret scalar from `seed` along `path` using
+/// SLIP-10 for the Ed25519 curve.
+///
+/// `path` must be a slice of already-hardened indexes (each with the high
+/// bit set). Use [`parse_hd_path`] to produce one from a string.
+pub(crate) fn derive_ed25519_slip10(seed: &[u8], path: &[u32]) -> [u8; 32] {
+    // Master: I = HMAC-SHA512(key="ed25519 seed", data=seed)
+    let mut mac = HmacSha512::new_from_slice(b"ed25519 seed").expect("HMAC accepts any key length");
+    mac.update(seed);
+    let mut i = mac.finalize().into_bytes();
+
+    for &index in path {
+        // Hardened child: Data = 0x00 || I_L(parent) || ser32(index)
+        let (il, ir) = i.split_at(32);
+
+        let mut data = [0u8; 1 + 32 + 4];
+        data[0] = 0x00;
+        data[1..33].copy_from_slice(il);
+        data[33..].copy_from_slice(&index.to_be_bytes());
+
+        let mut mac = HmacSha512::new_from_slice(ir).expect("HMAC accepts any key length");
+        mac.update(&data);
+        i = mac.finalize().into_bytes();
+    }
+
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&i[..32]);
+    key
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unhex(s: &str) -> Vec<u8> {
+        hex::decode(s).expect("valid hex")
+    }
+
+    // ------------------------------------------------------------------------
+    // SLIP-10 official Ed25519 test vectors
+    // https://github.com/satoshilabs/slips/blob/master/slip-0010.md
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn slip10_vec1_ed25519() {
+        let seed = unhex("000102030405060708090a0b0c0d0e0f");
+
+        // Master (chain m)
+        assert_eq!(
+            hex::encode(derive_ed25519_slip10(&seed, &[])),
+            "2b4be7f19ee27bbf30c667b642d5f4aa69fd169872f8fc3059c08ebae2eb19e7"
+        );
+        // m/0'
+        assert_eq!(
+            hex::encode(derive_ed25519_slip10(
+                &seed,
+                &parse_hd_path("m/0'").unwrap()
+            )),
+            "68e0fe46dfb67e368c75379acec591dad19df3cde26e63b93a8e704f1dade7a3"
+        );
+        // m/0'/1'
+        assert_eq!(
+            hex::encode(derive_ed25519_slip10(
+                &seed,
+                &parse_hd_path("m/0'/1'").unwrap()
+            )),
+            "b1d0bad404bf35da785a64ca1ac54b2617211d2777696fbffaf208f746ae84f2"
+        );
+        // m/0'/1'/2'
+        assert_eq!(
+            hex::encode(derive_ed25519_slip10(
+                &seed,
+                &parse_hd_path("m/0'/1'/2'").unwrap()
+            )),
+            "92a5b23c0b8a99e37d07df3fb9966917f5d06e02ddbd909c7e184371463e9fc9"
+        );
+        // m/0'/1'/2'/2'
+        assert_eq!(
+            hex::encode(derive_ed25519_slip10(
+                &seed,
+                &parse_hd_path("m/0'/1'/2'/2'").unwrap()
+            )),
+            "30d1dc7e5fc04c31219ab25a27ae00b50f6fd66622f6e9c913253d6511d1e662"
+        );
+        // m/0'/1'/2'/2'/1000000000'
+        assert_eq!(
+            hex::encode(derive_ed25519_slip10(
+                &seed,
+                &parse_hd_path("m/0'/1'/2'/2'/1000000000'").unwrap()
+            )),
+            "8f94d394a8e8fd6b1bc2f3f49f5c47e385281d5c17e65324b0f62483e37e8793"
+        );
+    }
+
+    #[test]
+    fn slip10_vec2_ed25519() {
+        let seed = unhex(
+            "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a2\
+             9f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542",
+        );
+
+        // Master
+        assert_eq!(
+            hex::encode(derive_ed25519_slip10(&seed, &[])),
+            "171cb88b1b3c1db25add599712e36245d75bc65a1a5c9e18d76f9f2b1eab4012"
+        );
+        // m/0'
+        assert_eq!(
+            hex::encode(derive_ed25519_slip10(
+                &seed,
+                &parse_hd_path("m/0'").unwrap()
+            )),
+            "1559eb2bbec5790b0c65d8693e4d0875b1747f4970ae8b650486ed7470845635"
+        );
+        // m/0'/2147483647'/1'/2147483646'/2'
+        assert_eq!(
+            hex::encode(derive_ed25519_slip10(
+                &seed,
+                &parse_hd_path("m/0'/2147483647'/1'/2147483646'/2'").unwrap()
+            )),
+            "551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d"
+        );
+    }
+
+    // ------------------------------------------------------------------------
+    // Path parser
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn parse_accepts_common_forms() {
+        assert_eq!(parse_hd_path("m").unwrap(), Vec::<u32>::new());
+        assert_eq!(parse_hd_path("").unwrap(), Vec::<u32>::new());
+        assert_eq!(
+            parse_hd_path("m/44'/397'/0'").unwrap(),
+            vec![44 | HARDENED, 397 | HARDENED, HARDENED]
+        );
+        // H and ' are interchangeable
+        assert_eq!(
+            parse_hd_path("m/44H/397H/0H").unwrap(),
+            parse_hd_path("m/44'/397'/0'").unwrap()
+        );
+        // leading "m/" is optional
+        assert_eq!(
+            parse_hd_path("44'/397'/0'").unwrap(),
+            parse_hd_path("m/44'/397'/0'").unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_rejects_bad_input() {
+        assert!(matches!(
+            parse_hd_path("m/44'//0'"),
+            Err(HdPathError::EmptySegment)
+        ));
+        assert!(matches!(
+            parse_hd_path("m/44'/"),
+            Err(HdPathError::EmptySegment)
+        ));
+        // Non-hardened is rejected for ed25519
+        assert!(matches!(
+            parse_hd_path("m/44'/397'/0"),
+            Err(HdPathError::NotHardened(_))
+        ));
+        // Negative / non-numeric
+        assert!(matches!(
+            parse_hd_path("m/-1'"),
+            Err(HdPathError::InvalidIndex(_))
+        ));
+        assert!(matches!(
+            parse_hd_path("m/abc'"),
+            Err(HdPathError::InvalidIndex(_))
+        ));
+        // Overflow past 2^31
+        assert!(matches!(
+            parse_hd_path("m/2147483648'"),
+            Err(HdPathError::IndexOutOfRange(_))
+        ));
+    }
+}

--- a/crates/near-kit/src/types/key.rs
+++ b/crates/near-kit/src/types/key.rs
@@ -10,8 +10,8 @@ use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
 use rand::rngs::OsRng;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use sha2::Digest;
-use slipped10::{BIP32Path, Curve};
 
+use super::hd::{derive_ed25519_slip10, parse_hd_path};
 use crate::error::{ParseKeyError, SignerError};
 
 /// Key type identifier.
@@ -525,19 +525,12 @@ impl SecretKey {
         // Convert mnemonic to seed (64 bytes)
         let seed = mnemonic.to_seed(passphrase.unwrap_or(""));
 
-        // Parse HD path
-        let path: BIP32Path = hd_path
-            .as_ref()
-            .parse()
-            .map_err(|e| SignerError::KeyDerivationFailed(format!("Invalid HD path: {}", e)))?;
+        // Parse HD path and derive via SLIP-10 (Ed25519)
+        let path = parse_hd_path(hd_path.as_ref())
+            .map_err(|e| SignerError::KeyDerivationFailed(format!("Invalid HD path: {e}")))?;
+        let derived = derive_ed25519_slip10(&seed, &path);
 
-        // Derive key using SLIP-10 for Ed25519
-        let derived =
-            slipped10::derive_key_from_path(&seed, Curve::Ed25519, &path).map_err(|e| {
-                SignerError::KeyDerivationFailed(format!("SLIP-10 derivation failed: {:?}", e))
-            })?;
-
-        Ok(Self::ed25519_from_bytes(derived.key))
+        Ok(Self::ed25519_from_bytes(derived))
     }
 
     /// Generate a new random seed phrase and derive the corresponding secret key.

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -49,6 +49,7 @@ mod action;
 mod block_reference;
 mod error;
 mod hash;
+mod hd;
 mod key;
 pub mod nep413;
 mod network;


### PR DESCRIPTION
## Summary

- `slipped10` 0.4.7 (published 2026-04-04, after ~2 years of dormancy with its prior 0.4.4–0.4.6 versions all yanked) injected a probabilistic `panic!` into `derive_key_from_path` and `BIP32Path::from_str` — both on the Ed25519 key-derivation hot path — and deleted most of the SLIP-10 test suite so the injection would pass CI. The declared source repo (`github.com/dj8yfo/slipped10`) no longer exists, so the published crate can't be audited against upstream.
- Replace the dependency with an inline SLIP-10 ed25519 implementation in `crates/near-kit/src/types/hd.rs` (`parse_hd_path` + `derive_ed25519_slip10`, ~100 lines of logic).
- Correctness is verified against both official SLIP-10 Ed25519 test vectors from [satoshilabs/slips](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) — so existing seed phrases produce byte-identical keys. No user-facing change.
- Drops `slipped10` from the workspace; adds `hmac = "0.13"` (RustCrypto, aligned with the existing `sha2 = "0.11"` via `digest 0.11`).

## Test plan

- [x] `cargo build -p near-kit`
- [x] `cargo test -p near-kit --lib` — 422/422 passing
- [x] `cargo clippy -p near-kit --lib -- -D warnings` — clean
- [x] SLIP-10 Ed25519 spec vectors 1 & 2 pass (in `types::hd::tests`), confirming byte-compatibility with the previous `slipped10` output for all seed phrases
- [x] `grep -c slipped10 Cargo.lock` → `0`

## Related

Heads up to anyone downstream: `near/near-api-rs` still pins `slipped10 = "0.4.6"`, which resolves to `^0.4.6` and will pull the poisoned `0.4.7` on any fresh `cargo build`. Worth a separate issue over there.