### PR TITLE
ci: group dependabot patch/minor bumps, ignore MSRV toolchain action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,20 @@ updates:
   - package-ecosystem: cargo
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      # Batch semver-compatible (lockfile-only) bumps into a single weekly PR.
+      # Major bumps still get individual PRs since they change Cargo.toml.
+      patch-and-minor:
+        update-types: ["minor", "patch"]
 
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      # The MSRV CI job pins this action to the MSRV version on purpose;
+      # bumping it would silently turn the MSRV check into a stable check.
+      - dependency-name: "dtolnay/rust-toolchain"


### PR DESCRIPTION
## Summary
- Batch semver-compatible (lockfile-only) cargo bumps into a single weekly `patch-and-minor` group PR — major bumps still get individual PRs since they change `Cargo.toml`
- Switch both ecosystems from daily to weekly
- Ignore `dtolnay/rust-toolchain` action updates: the MSRV CI job pins it to 1.86 on purpose, so bumping it (e.g. #4) would silently turn the MSRV check into a stable check

## Context
Most dependabot PR volume here is lockfile-only patch bumps (e.g. #197, #199, #200) that exist only because `Cargo.lock` is committed. Committing the lockfile is the right call per current Cargo guidance, so this reduces the noise instead.