### PR TITLE
fix: handle new nearcore 2.12 error variants and add forward-compat fallbacks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ futures = "0.3"
 reqwest = { version = "0.13", features = ["json"] }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1.0.181", features = ["derive"] }
 serde_json = "1"
 borsh = { version = "1", features = ["derive"] }
 base64 = "0.22"

--- a/crates/near-kit/src/types/error.rs
+++ b/crates/near-kit/src/types/error.rs
@@ -149,7 +149,9 @@ pub enum ActionErrorKind {
         #[serde(default)]
         public_key: Option<PublicKey>,
     },
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -381,7 +383,9 @@ pub enum InvalidTxError {
         reason: DepositCostFailureReason,
         signer_id: AccountId,
     },
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -532,7 +536,9 @@ pub enum InvalidAccessKeyError {
         public_key: PublicKey,
     },
     DepositWithFunctionCall,
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -597,7 +603,9 @@ pub enum FunctionCallError {
     WasmTrap(WasmTrap),
     HostError(HostError),
     ExecutionError(String),
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -628,7 +636,9 @@ pub enum CompilationError {
     WasmerCompileError {
         msg: String,
     },
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -668,7 +678,9 @@ pub enum PrepareError {
     TooManyParamsPerFunction,
     TooManyParamsPerContract,
     OperandStackTooLarge,
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -726,7 +738,9 @@ pub enum MethodResolveError {
     MethodEmptyName,
     MethodNotFound,
     MethodInvalidSignature,
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -755,7 +769,9 @@ pub enum WasmTrap {
     IndirectCallToNull,
     StackOverflow,
     GenericTrap,
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -868,7 +884,9 @@ pub enum HostError {
     P256VerifyInvalidInput {
         msg: String,
     },
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -1039,7 +1057,9 @@ pub enum ActionsValidationError {
         limit: u64,
         number_of_deploy_actions: u64,
     },
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -1188,7 +1208,9 @@ pub enum ReceiptValidationError {
     InvalidRefundTo {
         account_id: String,
     },
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -1244,7 +1266,9 @@ pub enum StorageError {
     StorageInconsistentState(String),
     FlatStorageBlockNotSupported(String),
     MemTrieLoadingError(String),
-    /// Unrecognized variant from a newer nearcore version.
+    /// Error variant that this version of near-kit does not recognize, or
+    /// whose field shape differs from what it expects. The raw JSON is
+    /// preserved.
     #[serde(untagged)]
     Unknown(serde_json::Value),
 }
@@ -1396,6 +1420,22 @@ mod tests {
         let err: ActionErrorKind = serde_json::from_value(json).unwrap();
         assert!(matches!(err, ActionErrorKind::Unknown(_)));
         assert!(err.to_string().contains("SomeFutureError"));
+    }
+
+    #[test]
+    fn test_known_tag_with_incompatible_shape_falls_back_to_unknown() {
+        // A known tag whose payload no longer matches the expected field
+        // shape (here a required field is missing) is captured by the
+        // untagged `Unknown` fallback rather than failing the whole parse.
+        // The raw JSON is preserved so callers can still inspect it. This is
+        // the same forward-compat behavior we want when nearcore changes a
+        // known variant's field shape between releases.
+        let json = serde_json::json!({ "AccountAlreadyExists": {} });
+        let err: ActionErrorKind = serde_json::from_value(json.clone()).unwrap();
+        match err {
+            ActionErrorKind::Unknown(raw) => assert_eq!(raw, json),
+            other => panic!("Expected Unknown, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/near-kit/src/types/error.rs
+++ b/crates/near-kit/src/types/error.rs
@@ -9,6 +9,32 @@ use super::rpc::GlobalContractIdentifierView;
 use super::{AccountId, CryptoHash, Gas, NearToken, PublicKey};
 
 // ============================================================================
+// Unknown fallback
+// ============================================================================
+
+/// Raw JSON payload of an error this version of near-kit could not parse
+/// into a typed variant.
+///
+/// Emits a `tracing::warn!` when constructed during deserialization so
+/// fallback misclassification is observable.
+#[derive(Debug, Clone)]
+pub struct UnknownError(pub serde_json::Value);
+
+impl<'de> serde::Deserialize<'de> for UnknownError {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        tracing::warn!(raw = %value, "unrecognized error variant from RPC, falling back to Unknown");
+        Ok(Self(value))
+    }
+}
+
+impl std::fmt::Display for UnknownError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// ============================================================================
 // Top-level error
 // ============================================================================
 
@@ -153,7 +179,7 @@ pub enum ActionErrorKind {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl std::fmt::Display for ActionErrorKind {
@@ -387,7 +413,7 @@ pub enum InvalidTxError {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl InvalidTxError {
@@ -540,7 +566,7 @@ pub enum InvalidAccessKeyError {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl std::fmt::Display for InvalidAccessKeyError {
@@ -607,7 +633,7 @@ pub enum FunctionCallError {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl std::fmt::Display for FunctionCallError {
@@ -640,7 +666,7 @@ pub enum CompilationError {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl std::fmt::Display for CompilationError {
@@ -682,7 +708,7 @@ pub enum PrepareError {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl std::fmt::Display for PrepareError {
@@ -742,7 +768,7 @@ pub enum MethodResolveError {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl std::fmt::Display for MethodResolveError {
@@ -773,7 +799,7 @@ pub enum WasmTrap {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl std::fmt::Display for WasmTrap {
@@ -888,7 +914,7 @@ pub enum HostError {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl std::fmt::Display for HostError {
@@ -1061,7 +1087,7 @@ pub enum ActionsValidationError {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl std::fmt::Display for ActionsValidationError {
@@ -1212,7 +1238,7 @@ pub enum ReceiptValidationError {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 impl std::fmt::Display for ReceiptValidationError {
@@ -1270,7 +1296,7 @@ pub enum StorageError {
     /// whose field shape differs from what it expects. The raw JSON is
     /// preserved.
     #[serde(untagged)]
-    Unknown(serde_json::Value),
+    Unknown(UnknownError),
 }
 
 /// Details about a missing trie value.
@@ -1433,7 +1459,7 @@ mod tests {
         let json = serde_json::json!({ "AccountAlreadyExists": {} });
         let err: ActionErrorKind = serde_json::from_value(json.clone()).unwrap();
         match err {
-            ActionErrorKind::Unknown(raw) => assert_eq!(raw, json),
+            ActionErrorKind::Unknown(raw) => assert_eq!(raw.0, json),
             other => panic!("Expected Unknown, got {other:?}"),
         }
     }

--- a/crates/near-kit/src/types/error.rs
+++ b/crates/near-kit/src/types/error.rs
@@ -149,6 +149,9 @@ pub enum ActionErrorKind {
         #[serde(default)]
         public_key: Option<PublicKey>,
     },
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl std::fmt::Display for ActionErrorKind {
@@ -304,6 +307,7 @@ impl std::fmt::Display for ActionErrorKind {
                     balance.exact_amount_display()
                 )
             }
+            Self::Unknown(value) => write!(f, "unknown action error: {value}"),
         }
     }
 }
@@ -377,6 +381,9 @@ pub enum InvalidTxError {
         reason: DepositCostFailureReason,
         signer_id: AccountId,
     },
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl InvalidTxError {
@@ -494,6 +501,7 @@ impl std::fmt::Display for InvalidTxError {
                 balance.exact_amount_display(),
                 cost.exact_amount_display()
             ),
+            Self::Unknown(value) => write!(f, "unknown transaction error: {value}"),
         }
     }
 }
@@ -524,6 +532,9 @@ pub enum InvalidAccessKeyError {
         public_key: PublicKey,
     },
     DepositWithFunctionCall,
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl std::fmt::Display for InvalidAccessKeyError {
@@ -563,6 +574,7 @@ impl std::fmt::Display for InvalidAccessKeyError {
             Self::DepositWithFunctionCall => {
                 write!(f, "deposits are not allowed with function call access keys")
             }
+            Self::Unknown(value) => write!(f, "unknown access key error: {value}"),
         }
     }
 }
@@ -585,6 +597,9 @@ pub enum FunctionCallError {
     WasmTrap(WasmTrap),
     HostError(HostError),
     ExecutionError(String),
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl std::fmt::Display for FunctionCallError {
@@ -598,6 +613,7 @@ impl std::fmt::Display for FunctionCallError {
             Self::WasmTrap(e) => write!(f, "Wasm trap: {e}"),
             Self::HostError(e) => write!(f, "host error: {e}"),
             Self::ExecutionError(msg) => write!(f, "execution error: {msg}"),
+            Self::Unknown(value) => write!(f, "unknown function call error: {value}"),
         }
     }
 }
@@ -605,9 +621,16 @@ impl std::fmt::Display for FunctionCallError {
 /// Wasm compilation error.
 #[derive(Debug, Clone, Deserialize)]
 pub enum CompilationError {
-    CodeDoesNotExist { account_id: AccountId },
+    CodeDoesNotExist {
+        account_id: AccountId,
+    },
     PrepareError(PrepareError),
-    WasmerCompileError { msg: String },
+    WasmerCompileError {
+        msg: String,
+    },
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl std::fmt::Display for CompilationError {
@@ -618,6 +641,7 @@ impl std::fmt::Display for CompilationError {
             }
             Self::PrepareError(e) => write!(f, "{e}"),
             Self::WasmerCompileError { msg } => write!(f, "Wasmer compilation error: {msg}"),
+            Self::Unknown(value) => write!(f, "unknown compilation error: {value}"),
         }
     }
 }
@@ -636,6 +660,17 @@ pub enum PrepareError {
     TooManyLocals,
     TooManyTables,
     TooManyTableElements,
+    FunctionBodyTooLarge,
+    InstrumentedCodeTooLarge,
+    TooManyBlocksPerFunction,
+    TooManyBlocksPerContract,
+    TooManyTypes,
+    TooManyParamsPerFunction,
+    TooManyParamsPerContract,
+    OperandStackTooLarge,
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl std::fmt::Display for PrepareError {
@@ -658,6 +693,29 @@ impl std::fmt::Display for PrepareError {
             Self::TooManyTableElements => {
                 write!(f, "too many table elements in Wasm module")
             }
+            Self::FunctionBodyTooLarge => {
+                write!(f, "a function body in the Wasm module is too large")
+            }
+            Self::InstrumentedCodeTooLarge => {
+                write!(f, "instrumented Wasm code exceeds the size limit")
+            }
+            Self::TooManyBlocksPerFunction => {
+                write!(f, "too many basic blocks in a Wasm function")
+            }
+            Self::TooManyBlocksPerContract => {
+                write!(f, "too many basic blocks in Wasm module")
+            }
+            Self::TooManyTypes => write!(f, "too many types in Wasm module"),
+            Self::TooManyParamsPerFunction => {
+                write!(f, "too many parameters in a Wasm function")
+            }
+            Self::TooManyParamsPerContract => {
+                write!(f, "too many parameters in Wasm module")
+            }
+            Self::OperandStackTooLarge => {
+                write!(f, "operand stack of a Wasm function is too large")
+            }
+            Self::Unknown(value) => write!(f, "unknown prepare error: {value}"),
         }
     }
 }
@@ -668,6 +726,9 @@ pub enum MethodResolveError {
     MethodEmptyName,
     MethodNotFound,
     MethodInvalidSignature,
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl std::fmt::Display for MethodResolveError {
@@ -676,6 +737,7 @@ impl std::fmt::Display for MethodResolveError {
             Self::MethodEmptyName => write!(f, "method name is empty"),
             Self::MethodNotFound => write!(f, "method not found in contract"),
             Self::MethodInvalidSignature => write!(f, "method has an invalid signature"),
+            Self::Unknown(value) => write!(f, "unknown method resolve error: {value}"),
         }
     }
 }
@@ -693,6 +755,9 @@ pub enum WasmTrap {
     IndirectCallToNull,
     StackOverflow,
     GenericTrap,
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl std::fmt::Display for WasmTrap {
@@ -709,6 +774,7 @@ impl std::fmt::Display for WasmTrap {
             Self::IndirectCallToNull => write!(f, "indirect call to null"),
             Self::StackOverflow => write!(f, "stack overflow"),
             Self::GenericTrap => write!(f, "generic trap"),
+            Self::Unknown(value) => write!(f, "unknown Wasm trap: {value}"),
         }
     }
 }
@@ -799,6 +865,12 @@ pub enum HostError {
     Ed25519VerifyInvalidInput {
         msg: String,
     },
+    P256VerifyInvalidInput {
+        msg: String,
+    },
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl std::fmt::Display for HostError {
@@ -886,6 +958,10 @@ impl std::fmt::Display for HostError {
             Self::Ed25519VerifyInvalidInput { msg } => {
                 write!(f, "Ed25519 verification invalid input: {msg}")
             }
+            Self::P256VerifyInvalidInput { msg } => {
+                write!(f, "P-256 verification invalid input: {msg}")
+            }
+            Self::Unknown(value) => write!(f, "unknown host error: {value}"),
         }
     }
 }
@@ -959,6 +1035,13 @@ pub enum ActionsValidationError {
         balance: NearToken,
     },
     GasKeyFunctionCallAllowanceNotAllowed,
+    TotalNumberOfDeployActionsExceeded {
+        limit: u64,
+        number_of_deploy_actions: u64,
+    },
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl std::fmt::Display for ActionsValidationError {
@@ -1058,6 +1141,14 @@ impl std::fmt::Display for ActionsValidationError {
                 f,
                 "gas keys with function call permission cannot have an allowance"
             ),
+            Self::TotalNumberOfDeployActionsExceeded {
+                number_of_deploy_actions,
+                limit,
+            } => write!(
+                f,
+                "number of deploy actions ({number_of_deploy_actions}) exceeded the limit ({limit})"
+            ),
+            Self::Unknown(value) => write!(f, "unknown actions validation error: {value}"),
         }
     }
 }
@@ -1097,6 +1188,9 @@ pub enum ReceiptValidationError {
     InvalidRefundTo {
         account_id: String,
     },
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 impl std::fmt::Display for ReceiptValidationError {
@@ -1132,6 +1226,7 @@ impl std::fmt::Display for ReceiptValidationError {
             Self::InvalidRefundTo { account_id } => {
                 write!(f, "invalid refund-to account ID {account_id}")
             }
+            Self::Unknown(value) => write!(f, "unknown receipt validation error: {value}"),
         }
     }
 }
@@ -1149,6 +1244,9 @@ pub enum StorageError {
     StorageInconsistentState(String),
     FlatStorageBlockNotSupported(String),
     MemTrieLoadingError(String),
+    /// Unrecognized variant from a newer nearcore version.
+    #[serde(untagged)]
+    Unknown(serde_json::Value),
 }
 
 /// Details about a missing trie value.
@@ -1196,6 +1294,7 @@ impl std::fmt::Display for StorageError {
             Self::MemTrieLoadingError(msg) => {
                 write!(f, "trie is not loaded in memory: {msg}")
             }
+            Self::Unknown(value) => write!(f, "unknown storage error: {value}"),
         }
     }
 }
@@ -1216,6 +1315,129 @@ impl std::fmt::Display for DepositCostFailureReason {
         match self {
             Self::NotEnoughBalance => write!(f, "not enough balance"),
             Self::LackBalanceForState => write!(f, "not enough balance for state"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ------------------------------------------------------------------
+    // New error variants introduced in nearcore 2.12
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_prepare_error_2_12_variants() {
+        for (json, expected) in [
+            ("\"FunctionBodyTooLarge\"", "function body"),
+            ("\"InstrumentedCodeTooLarge\"", "instrumented"),
+            ("\"TooManyBlocksPerFunction\"", "basic blocks"),
+            ("\"TooManyBlocksPerContract\"", "basic blocks"),
+            ("\"TooManyTypes\"", "types"),
+            ("\"TooManyParamsPerFunction\"", "parameters"),
+            ("\"TooManyParamsPerContract\"", "parameters"),
+            ("\"OperandStackTooLarge\"", "operand stack"),
+        ] {
+            let err: PrepareError = serde_json::from_str(json).unwrap();
+            assert!(
+                !matches!(err, PrepareError::Unknown(_)),
+                "{json} fell through to Unknown"
+            );
+            assert!(err.to_string().contains(expected), "{json}: {err}");
+        }
+    }
+
+    #[test]
+    fn test_host_error_p256_verify_invalid_input() {
+        let json = serde_json::json!({
+            "P256VerifyInvalidInput": { "msg": "signature must be 64 bytes" }
+        });
+        let err: HostError = serde_json::from_value(json).unwrap();
+        match &err {
+            HostError::P256VerifyInvalidInput { msg } => {
+                assert_eq!(msg, "signature must be 64 bytes");
+            }
+            other => panic!("Expected P256VerifyInvalidInput, got {other:?}"),
+        }
+        assert!(err.to_string().contains("P-256"));
+    }
+
+    #[test]
+    fn test_actions_validation_total_deploy_actions_exceeded() {
+        let json = serde_json::json!({
+            "TotalNumberOfDeployActionsExceeded": {
+                "number_of_deploy_actions": 5,
+                "limit": 4
+            }
+        });
+        let err: ActionsValidationError = serde_json::from_value(json).unwrap();
+        match &err {
+            ActionsValidationError::TotalNumberOfDeployActionsExceeded {
+                number_of_deploy_actions,
+                limit,
+            } => {
+                assert_eq!(*number_of_deploy_actions, 5);
+                assert_eq!(*limit, 4);
+            }
+            other => panic!("Expected TotalNumberOfDeployActionsExceeded, got {other:?}"),
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Unknown-variant fallbacks (forward compatibility)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn test_unknown_struct_variant_falls_back() {
+        let json = serde_json::json!({
+            "SomeFutureError": { "limit": 1, "actual": 2 }
+        });
+        let err: ActionErrorKind = serde_json::from_value(json).unwrap();
+        assert!(matches!(err, ActionErrorKind::Unknown(_)));
+        assert!(err.to_string().contains("SomeFutureError"));
+    }
+
+    #[test]
+    fn test_unknown_unit_variant_falls_back() {
+        let err: HostError = serde_json::from_str("\"SomeFutureHostError\"").unwrap();
+        assert!(matches!(err, HostError::Unknown(_)));
+
+        let err: PrepareError = serde_json::from_str("\"SomeFuturePrepareError\"").unwrap();
+        assert!(matches!(err, PrepareError::Unknown(_)));
+
+        let err: WasmTrap = serde_json::from_str("\"SomeFutureTrap\"").unwrap();
+        assert!(matches!(err, WasmTrap::Unknown(_)));
+    }
+
+    #[test]
+    fn test_known_variants_not_shadowed_by_fallback() {
+        let err: PrepareError = serde_json::from_str("\"GasInstrumentation\"").unwrap();
+        assert!(matches!(err, PrepareError::GasInstrumentation));
+
+        let json = serde_json::json!({ "GuestPanic": { "panic_msg": "boom" } });
+        let err: HostError = serde_json::from_value(json).unwrap();
+        assert!(matches!(err, HostError::GuestPanic { .. }));
+    }
+
+    #[test]
+    fn test_unknown_nested_variant_preserves_outer_structure() {
+        // A failed receipt whose kind comes from a future nearcore version
+        // must still deserialize as an ActionError instead of failing the
+        // whole response parse.
+        let json = serde_json::json!({
+            "ActionError": {
+                "index": 0,
+                "kind": { "BrandNewErrorKind": { "foo": "bar" } }
+            }
+        });
+        let err: TxExecutionError = serde_json::from_value(json).unwrap();
+        match err {
+            TxExecutionError::ActionError(action_error) => {
+                assert_eq!(action_error.index, Some(0));
+                assert!(matches!(action_error.kind, ActionErrorKind::Unknown(_)));
+            }
+            other => panic!("Expected ActionError, got {other:?}"),
         }
     }
 }

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -75,7 +75,7 @@ pub use error::{
     ActionError, ActionErrorKind, ActionsValidationError, CompilationError,
     DepositCostFailureReason, FunctionCallError, HostError, InvalidAccessKeyError, InvalidTxError,
     MethodResolveError, PrepareError, ReceiptValidationError, StorageError, TxExecutionError,
-    WasmTrap,
+    UnknownError, WasmTrap,
 };
 pub use hash::CryptoHash;
 pub use key::{


### PR DESCRIPTION
## What changed in nearcore 2.12

nearcore 2.12.0 added new variants to its JSON-RPC error types, verified by diffing `chain/jsonrpc/openapi/openapi.json` between tags `2.11.1` and `2.12.0`:

- **`PrepareError`** (new Cranelift compile limits): `FunctionBodyTooLarge`, `InstrumentedCodeTooLarge`, `TooManyBlocksPerFunction`, `TooManyBlocksPerContract`, `TooManyTypes`, `TooManyParamsPerFunction`, `TooManyParamsPerContract`, `OperandStackTooLarge`
- **`HostError`**: `P256VerifyInvalidInput { msg }` (the new `p256_verify` host function)
- **`ActionsValidationError`**: `TotalNumberOfDeployActionsExceeded { limit, number_of_deploy_actions }`

## Why this matters

near-kit's error enums in `crates/near-kit/src/types/error.rs` are exhaustive `serde` enums with no fallback, and they're nested inside `FinalExecutionOutcome` / `ExecutionStatus`. When a 2.12 node returns one of these new variants, serde can't match it and the **entire RPC response** fails to deserialize, not just the error field. That turns a perfectly readable transaction outcome into a hard parse failure.

## The fix

1. Add the new 2.12 variants listed above, with matching `Display` arms (lowercase prose, consistent with the existing style).
2. Add a forward-compat catch-all as the **last** variant of each grow-prone enum (`ActionErrorKind`, `InvalidTxError`, `InvalidAccessKeyError`, `FunctionCallError`, `CompilationError`, `PrepareError`, `MethodResolveError`, `WasmTrap`, `HostError`, `ActionsValidationError`, `ReceiptValidationError`, `StorageError`):

   ```rust
   /// Unrecognized variant from a newer nearcore version.
   #[serde(untagged)]
   Unknown(serde_json::Value),
   ```

   The `Unknown` fallback captures any unrecognized variant (struct or unit) as raw JSON instead of failing, so future nearcore releases degrade gracefully and the surrounding response still parses. Variant-level `#[serde(untagged)]` requires serde >= 1.0.181 (lockfile has 1.0.228), and untagged variants must be last in the enum. It is intentionally **not** added to `TxExecutionError` itself, whose two variants are structural and matched in `ExecutionStatus`'s custom deserializer.

## Tests

Added `#[cfg(test)] mod tests` covering: all 8 new `PrepareError` variants, `P256VerifyInvalidInput`, `TotalNumberOfDeployActionsExceeded`, unknown struct/unit variants falling back to `Unknown`, known variants not being shadowed by the fallback, and a nested unknown `ActionErrorKind` still deserializing as a `TxExecutionError::ActionError`.

- `cargo fmt`: clean
- `cargo clippy --all-features`: no warnings
- `cargo test -p near-kit`: 439 unit + 127 doctests pass (incl. the 7 new tests)