### PR TITLE
feat: add nonce_mode and validator_reward_paid_prev_epoch from nearcore 2.12

### DIFF
--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -90,7 +90,7 @@ pub use rpc::{
     ChunkHeaderView, CongestionInfoView, DataReceiptData, DataReceiverView, DelegateActionView,
     ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus,
     FinalExecutionOutcome, FinalExecutionStatus, GasPrice, GasProfileEntry,
-    GlobalContractIdentifierView, MerkleDirection, MerklePathItem, NodeVersion,
+    GlobalContractIdentifierView, MerkleDirection, MerklePathItem, NodeVersion, NonceMode,
     RawTransactionResponse, Receipt, ReceiptContent, STORAGE_AMOUNT_PER_BYTE, SendTxResponse,
     SlashedValidator, StatusResponse, SyncInfo, TransactionView, TrieSplit, ValidatorInfo,
     ValidatorStakeView, ValidatorStakeViewV1, ViewFunctionResult,

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -754,6 +754,16 @@ impl<'de> serde::Deserialize<'de> for ExecutionStatus {
     }
 }
 
+/// Controls how the transaction nonce is validated against the access key nonce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum NonceMode {
+    /// Any nonce strictly greater than the current access key nonce (default behavior).
+    Monotonic,
+    /// Nonce must be exactly `ak_nonce + 1` (sequential ordering).
+    Strict,
+}
+
 /// Transaction view in outcome.
 #[derive(Debug, Clone, Deserialize)]
 pub struct TransactionView {
@@ -778,6 +788,9 @@ pub struct TransactionView {
     /// Nonce index (for gas key multi-nonce support).
     #[serde(default)]
     pub nonce_index: Option<u16>,
+    /// Nonce validation mode (`None` from nodes older than nearcore 2.12; means monotonic).
+    #[serde(default)]
+    pub nonce_mode: Option<NonceMode>,
 }
 
 // ============================================================================
@@ -2023,5 +2036,29 @@ mod tests {
         let tx: TransactionView = serde_json::from_value(json).unwrap();
         assert_eq!(tx.signer_id.as_str(), "alice.near");
         assert!(tx.signature.to_string().starts_with("ed25519:"));
+        // Fixture has no `nonce_mode` (older node); should deserialize to `None`.
+        assert_eq!(tx.nonce_mode, None);
+    }
+
+    #[test]
+    fn test_transaction_view_nonce_mode_strict() {
+        let json = serde_json::json!({
+            "signer_id": "alice.near",
+            "public_key": "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp",
+            "nonce": 1,
+            "receiver_id": "bob.near",
+            "hash": "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8U",
+            "actions": [{"Transfer": {"deposit": "1000000000000000000000000"}}],
+            "signature": "ed25519:3s1dvMqNDCByoMnDnkhB4GPjTSXCRt4nt3Af5n1RX8W7aJ2FC6MfRf5BNXZ52EBifNJnNVBsGvke6GRYuaEYJXt5",
+            "nonce_mode": "strict"
+        });
+        let tx: TransactionView = serde_json::from_value(json).unwrap();
+        assert_eq!(tx.nonce_mode, Some(NonceMode::Strict));
+    }
+
+    #[test]
+    fn test_nonce_mode_monotonic() {
+        let mode: NonceMode = serde_json::from_value(serde_json::json!("monotonic")).unwrap();
+        assert_eq!(mode, NonceMode::Monotonic);
     }
 }

--- a/crates/near-kit/src/types/rpc_extra.rs
+++ b/crates/near-kit/src/types/rpc_extra.rs
@@ -1,5 +1,7 @@
 //! Additional RPC response types for validators, light client, and state changes.
 
+use std::collections::HashMap;
+
 use serde::Deserialize;
 
 use super::rpc::{AccessKeyDetails, ValidatorStakeView};
@@ -32,6 +34,10 @@ pub struct EpochValidatorInfo {
     pub epoch_start_height: u64,
     /// Epoch height.
     pub epoch_height: u64,
+    /// Per-validator rewards paid out at the start of the previous epoch
+    /// (rewards earned in epoch E-2). Empty on nodes older than nearcore 2.12.
+    #[serde(default)]
+    pub validator_reward_paid_prev_epoch: HashMap<AccountId, NearToken>,
 }
 
 /// Current epoch validator information.
@@ -573,5 +579,39 @@ mod tests {
             }
             _ => panic!("expected ContractCodeUpdate"),
         }
+    }
+
+    #[test]
+    fn test_epoch_validator_info_validator_reward_paid_prev_epoch() {
+        let json = serde_json::json!({
+            "current_validators": [],
+            "next_validators": [],
+            "epoch_start_height": 100,
+            "epoch_height": 10,
+            "validator_reward_paid_prev_epoch": {
+                "alice.near": "1000000000000000000000000"
+            }
+        });
+        let info: EpochValidatorInfo = serde_json::from_value(json).unwrap();
+        assert_eq!(info.validator_reward_paid_prev_epoch.len(), 1);
+        let alice: AccountId = "alice.near".parse().unwrap();
+        assert_eq!(
+            info.validator_reward_paid_prev_epoch.get(&alice),
+            Some(&NearToken::from_yoctonear(
+                1_000_000_000_000_000_000_000_000
+            ))
+        );
+    }
+
+    #[test]
+    fn test_epoch_validator_info_validator_reward_paid_prev_epoch_default_empty() {
+        let json = serde_json::json!({
+            "current_validators": [],
+            "next_validators": [],
+            "epoch_start_height": 100,
+            "epoch_height": 10
+        });
+        let info: EpochValidatorInfo = serde_json::from_value(json).unwrap();
+        assert!(info.validator_reward_paid_prev_epoch.is_empty());
     }
 }


### PR DESCRIPTION
Adds two additive JSON-RPC response fields introduced in nearcore 2.12, found by diffing `chain/jsonrpc/openapi/openapi.json` between tags `2.11.1` and `2.12.0`.

## Fields

- **`TransactionView::nonce_mode`** (`Option<NonceMode>`) — `SignedTransactionView` gained an optional nullable `nonce_mode` referencing a new `NonceMode` enum. Serialized lowercase: `monotonic` (any nonce strictly greater than the current access key nonce, the default) and `strict` (nonce must be exactly `ak_nonce + 1`). Controls how the transaction nonce is validated against the access key nonce.
- **`EpochValidatorInfo::validator_reward_paid_prev_epoch`** (`HashMap<AccountId, NearToken>`) — the `validators` RPC response gained a map of AccountId to yoctoNEAR rewards paid out at the start of the previous epoch. For epoch E, this contains rewards earned in epoch E-2, added to validator and treasury balances at the first block of epoch E-1.

## Compatibility

Both fields are purely additive. Old nodes (pre-2.12) simply omit them, so both use `#[serde(default)]`: `nonce_mode` deserializes to `None` and the reward map to an empty `HashMap`.

## Tests

Added unit tests covering `nonce_mode` strict/monotonic parsing, the existing fixture yielding `None`, and `validator_reward_paid_prev_epoch` populated vs. defaulted-empty.