### PR TITLE
feat: add EXPERIMENTAL_receipt_to_tx RPC method

### DIFF
--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -10,8 +10,8 @@ use crate::error::RpcError;
 use crate::types::rpc::RawTransactionResponse;
 use crate::types::{
     AccessKeyListView, AccessKeyView, AccountId, AccountView, BlockReference, BlockView,
-    CryptoHash, EpochValidatorInfo, GasPrice, PublicKey, SignedTransaction, StatusResponse,
-    TxExecutionStatus, ViewFunctionResult,
+    CryptoHash, EpochValidatorInfo, GasPrice, PublicKey, ReceiptToTxResponse, SignedTransaction,
+    StatusResponse, TxExecutionStatus, ViewFunctionResult,
 };
 
 /// Network configuration presets.
@@ -663,6 +663,20 @@ impl RpcClient {
         Ok(response)
     }
 
+    /// Look up the transaction that produced a receipt.
+    ///
+    /// Uses `EXPERIMENTAL_receipt_to_tx`, available on nodes running
+    /// nearcore 2.12 or later. Returns [`RpcError::UnknownReceipt`] if the
+    /// node does not know the receipt.
+    #[tracing::instrument(skip(self), fields(%receipt_id))]
+    pub async fn receipt_to_tx(
+        &self,
+        receipt_id: &CryptoHash,
+    ) -> Result<ReceiptToTxResponse, RpcError> {
+        let params = serde_json::json!({ "receipt_id": receipt_id.to_string() });
+        self.call("EXPERIMENTAL_receipt_to_tx", params).await
+    }
+
     /// Merge block reference parameters into a JSON object.
     fn merge_block_reference(&self, params: &mut serde_json::Value, block: &BlockReference) {
         if let serde_json::Value::Object(block_params) = block.to_rpc_params() {
@@ -1223,6 +1237,67 @@ mod tests {
         };
         let result = client.parse_rpc_error(&error);
         assert!(matches!(result, RpcError::UnknownReceipt(_)));
+    }
+
+    // ========================================================================
+    // EXPERIMENTAL_receipt_to_tx tests
+    //
+    // There is no HTTP mock harness in this crate, so the success path is
+    // exercised by decoding a real-shape `result` envelope into the
+    // user-facing type (the same step `try_call` performs), and the error
+    // path is exercised through `parse_rpc_error` on the real error envelope.
+    // ========================================================================
+
+    #[test]
+    fn test_receipt_to_tx_decodes_success_body() {
+        // Real-shape success body nearcore returns for EXPERIMENTAL_receipt_to_tx.
+        let body = r#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": {
+                "transaction_hash": "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8U",
+                "sender_account_id": "alice.near"
+            }
+        }"#;
+        let parsed: JsonRpcResponse = serde_json::from_str(body).expect("valid envelope");
+        assert!(parsed.error.is_none(), "no error envelope expected");
+        let result = parsed.result.expect("result present");
+        let response: ReceiptToTxResponse =
+            serde_json::from_value(result).expect("decodes into ReceiptToTxResponse");
+        assert_eq!(
+            response.transaction_hash.to_string(),
+            "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8U"
+        );
+        assert_eq!(response.sender_account_id.as_str(), "alice.near");
+    }
+
+    #[test]
+    fn test_receipt_to_tx_maps_unknown_receipt() {
+        // Real-shape error body nearcore returns for an unknown receipt.
+        let body = r#"{
+            "jsonrpc": "2.0",
+            "id": 1,
+            "error": {
+                "code": -32000,
+                "message": "Server error",
+                "cause": {
+                    "name": "UNKNOWN_RECEIPT",
+                    "info": {
+                        "receipt_id": "3GTGoiN3FEoJenSw5ob4YMmFEV2Fbiichj3FDBnM78xK"
+                    }
+                },
+                "name": "HANDLER_ERROR"
+            }
+        }"#;
+        let parsed: JsonRpcResponse = serde_json::from_str(body).expect("valid envelope");
+        let error = parsed.error.expect("error envelope present");
+        let client = RpcClient::new("https://example.com");
+        let result = client.parse_rpc_error(&error);
+        assert!(
+            matches!(result, RpcError::UnknownReceipt(_)),
+            "expected UnknownReceipt, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -91,9 +91,9 @@ pub use rpc::{
     ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus,
     FinalExecutionOutcome, FinalExecutionStatus, GasPrice, GasProfileEntry,
     GlobalContractIdentifierView, MerkleDirection, MerklePathItem, NodeVersion,
-    RawTransactionResponse, Receipt, ReceiptContent, STORAGE_AMOUNT_PER_BYTE, SendTxResponse,
-    SlashedValidator, StatusResponse, SyncInfo, TransactionView, TrieSplit, ValidatorInfo,
-    ValidatorStakeView, ValidatorStakeViewV1, ViewFunctionResult,
+    RawTransactionResponse, Receipt, ReceiptContent, ReceiptToTxResponse, STORAGE_AMOUNT_PER_BYTE,
+    SendTxResponse, SlashedValidator, StatusResponse, SyncInfo, TransactionView, TrieSplit,
+    ValidatorInfo, ValidatorStakeView, ValidatorStakeViewV1, ViewFunctionResult,
 };
 pub use rpc_extra::{
     BlockHeaderInnerLiteView, CurrentEpochValidatorInfo, EpochValidatorInfo,

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -579,6 +579,15 @@ pub struct SendTxResponse {
     pub sender_id: AccountId,
 }
 
+/// Response from `EXPERIMENTAL_receipt_to_tx`: the transaction that produced a receipt.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReceiptToTxResponse {
+    /// Hash of the transaction that produced the receipt.
+    pub transaction_hash: CryptoHash,
+    /// Account that signed the transaction.
+    pub sender_account_id: AccountId,
+}
+
 /// Raw RPC response for transaction submission/status (internal).
 ///
 /// Used internally to deserialize responses from `send_tx` and
@@ -2023,5 +2032,19 @@ mod tests {
         let tx: TransactionView = serde_json::from_value(json).unwrap();
         assert_eq!(tx.signer_id.as_str(), "alice.near");
         assert!(tx.signature.to_string().starts_with("ed25519:"));
+    }
+
+    #[test]
+    fn test_receipt_to_tx_response() {
+        let json = serde_json::json!({
+            "transaction_hash": "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8U",
+            "sender_account_id": "alice.near"
+        });
+        let response: ReceiptToTxResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            response.transaction_hash.to_string(),
+            "9FtHUFBQsZ2MG77K3x3MJ9wjX3UT8zE1TczCrhZEcG8U"
+        );
+        assert_eq!(response.sender_account_id.as_str(), "alice.near");
     }
 }


### PR DESCRIPTION
## What

Adds `RpcClient::receipt_to_tx`, a wrapper for the `EXPERIMENTAL_receipt_to_tx` JSON-RPC method introduced in nearcore 2.12. It maps a receipt back to the transaction that produced it.

Requires a node running **nearcore >= 2.12**.

## Request / Response

- Request: `{ "receipt_id": "<CryptoHash base58>" }`
- Response (`ReceiptToTxResponse`, both fields required):
  - `transaction_hash: CryptoHash` — hash of the originating transaction
  - `sender_account_id: AccountId` — account that signed it

## Errors

`UNKNOWN_RECEIPT` is already handled by `parse_rpc_error` and maps to the existing typed `RpcError::UnknownReceipt`, so no error-mapping changes were needed. Other causes (`DEPTH_EXCEEDED`, `INTERNAL_ERROR`) fall through to the generic handler.

## Changes

- `types/rpc.rs`: new public `ReceiptToTxResponse` struct (near `SendTxResponse`).
- `types/mod.rs`: re-export `ReceiptToTxResponse`.
- `client/rpc.rs`: `receipt_to_tx` method after `tx_status`.

## Tests

- Serde decode test for `ReceiptToTxResponse`.
- Client-side success-body decode test and `UNKNOWN_RECEIPT` -> `RpcError::UnknownReceipt` mapping test, following the existing synthetic-envelope test pattern (this crate has no HTTP mock harness).

`cargo fmt`, `cargo clippy --all-features`, and `cargo test -p near-kit` all pass.