### PR TITLE
feat!: replace custom NEP-616 types with near-global-contracts 0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,11 +53,11 @@ jobs:
           files: lcov.info
 
   msrv:
-    name: MSRV (1.86)
+    name: MSRV (1.88)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.86
+      - uses: dtolnay/rust-toolchain@1.88
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -374,6 +374,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cfg_eval"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -560,11 +571,10 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
@@ -574,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
@@ -667,7 +677,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -790,7 +800,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1569,12 +1579,11 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -1706,6 +1715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-crypto-hash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fd0822ff3a82bdccda49b787cb11530512a929bfd13fd0d9fbd510b6360200"
+
+[[package]]
 name = "near-gas"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1714,6 +1729,23 @@ dependencies = [
  "borsh",
  "interactive-clap",
  "serde",
+]
+
+[[package]]
+name = "near-global-contracts"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9124fca52251d3ecf714ddb50937c39cc3e2b6f4ee03f85e272fa73eb588920e"
+dependencies = [
+ "borsh",
+ "cfg_eval",
+ "hex",
+ "near-account-id",
+ "near-crypto-hash",
+ "near-sdk-env",
+ "serde",
+ "serde_with",
+ "sha3",
 ]
 
 [[package]]
@@ -1734,6 +1766,7 @@ dependencies = [
  "libc",
  "near-account-id",
  "near-gas",
+ "near-global-contracts",
  "near-kit-macros",
  "near-token",
  "rand 0.8.5",
@@ -1742,7 +1775,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.11.0",
- "sha3",
  "tempfile",
  "testcontainers",
  "thiserror 2.0.18",
@@ -1766,6 +1798,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-sdk-env"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4f4bf153cf88eadafff20c6d82b16e3cab3fc4d636d3530473079044ddb9bf3"
+dependencies = [
+ "near-sys",
+ "ripemd",
+ "sha2 0.10.9",
+ "sha3",
+]
+
+[[package]]
+name = "near-sys"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c212278351251aa342eab33a9d64f99294bc5784cda10107867a72dda699bb"
+
+[[package]]
 name = "near-token"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,7 +1832,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1820,9 +1870,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2176,7 +2226,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2402,6 +2452,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2426,7 +2485,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2494,7 +2553,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2702,11 +2761,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2721,9 +2781,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2755,13 +2815,12 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.12.0"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.10.7",
  "keccak",
- "sponge-cursor",
 ]
 
 [[package]]
@@ -2850,12 +2909,6 @@ dependencies = [
  "base64ct",
  "der",
 ]
-
-[[package]]
-name = "sponge-cursor"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"
@@ -2999,7 +3052,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3094,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -3109,15 +3162,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3745,7 +3798,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.10.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/r-near/near-kit-rs"
-rust-version = "1.86"
+rust-version = "1.88"
 
 # Shared dependencies - crates can use `workspace = true` to inherit these
 [workspace.dependencies]
@@ -19,6 +19,7 @@ rust-version = "1.86"
 near-account-id = { version = "2.6", features = ["serde", "borsh"] }
 near-token = { version = "0.3", features = ["serde", "borsh"] }
 near-gas = { version = "0.3", features = ["serde", "borsh"] }
+near-global-contracts = { version = "0.2", features = ["serde", "borsh"] }
 
 # Async runtime
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "time"] }
@@ -36,7 +37,6 @@ base64 = "0.22"
 # Cryptography
 ed25519-dalek = { version = "2", features = ["rand_core"] }
 sha2 = "0.11"
-sha3 = "0.12"
 rand = "0.8"
 bip39 = "2"
 hmac = "0.13"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Documentation](https://docs.rs/near-kit/badge.svg)](https://docs.rs/near-kit)
 [![CI](https://github.com/r-near/near-kit-rs/actions/workflows/ci.yml/badge.svg)](https://github.com/r-near/near-kit-rs/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/r-near/near-kit-rs/graph/badge.svg)](https://codecov.io/gh/r-near/near-kit-rs)
-[![MSRV](https://img.shields.io/badge/MSRV-1.86-blue.svg)](https://github.com/r-near/near-kit-rs)
+[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue.svg)](https://github.com/r-near/near-kit-rs)
 
 [API Docs](https://docs.rs/near-kit) · [Examples](crates/near-kit/examples/) · [Changelog](CHANGELOG.md)
 

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -17,6 +17,7 @@ rust-version.workspace = true
 near-account-id.workspace = true
 near-token.workspace = true
 near-gas.workspace = true
+near-global-contracts.workspace = true
 
 # Async runtime
 tokio.workspace = true
@@ -34,7 +35,6 @@ base64.workspace = true
 # Cryptography
 ed25519-dalek.workspace = true
 sha2.workspace = true
-sha3.workspace = true
 rand.workspace = true
 bip39.workspace = true
 hmac.workspace = true
@@ -62,7 +62,7 @@ near-kit-macros.workspace = true
 # Optional: Sandbox integration (via Docker/testcontainers)
 testcontainers = { workspace = true, optional = true, features = ["watchdog"] }
 libc = { version = "0.2", optional = true }
-serde_with = { version = "3.17.0", features = ["hex", "base64"] }
+serde_with = { version = "3.20", features = ["hex", "base64"] }
 
 [features]
 default = ["keyring"]

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -7,8 +7,8 @@ use serde::de::DeserializeOwned;
 use crate::contract::ContractClient;
 use crate::error::Error;
 use crate::types::{
-    AccountId, ChainId, Gas, GlobalContractRef, IntoNearToken, NearToken, PublicKey, PublishMode,
-    SecretKey, TryIntoAccountId,
+    AccountId, ChainId, Gas, IntoGlobalContractId, IntoNearToken, NearToken, PublicKey,
+    PublishMode, SecretKey, StateInit, TryIntoAccountId,
 };
 
 use super::query::{AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, ViewCall};
@@ -695,7 +695,7 @@ impl Near {
     /// # Panics
     ///
     /// Panics if no signer is configured.
-    pub fn deploy_from(&self, contract_ref: impl GlobalContractRef) -> TransactionBuilder {
+    pub fn deploy_from(&self, contract_ref: impl IntoGlobalContractId) -> TransactionBuilder {
         let account_id = self.account_id().clone();
         self.transaction(account_id).deploy_from(contract_ref)
     }
@@ -810,7 +810,7 @@ impl Near {
     /// ```rust,no_run
     /// # use near_kit::*;
     /// # async fn example(near: Near, code_hash: CryptoHash) -> Result<(), near_kit::Error> {
-    /// let si = DeterministicAccountStateInit::by_hash(code_hash, Default::default());
+    /// let si = StateInit::by_hash(code_hash, Default::default());
     /// let outcome = near.state_init(si, NearToken::from_near(5))
     ///     .send()
     ///     .await?;
@@ -823,7 +823,7 @@ impl Near {
     /// Panics if the deposit amount string cannot be parsed.
     pub fn state_init(
         &self,
-        state_init: crate::types::DeterministicAccountStateInit,
+        state_init: StateInit,
         deposit: impl IntoNearToken,
     ) -> TransactionBuilder {
         // Derive once and pass directly to avoid TransactionBuilder::state_init()

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -201,10 +201,10 @@ impl RpcClient {
         &self,
         request: &JsonRpcRequest<'_, impl Serialize>,
     ) -> Result<R, RpcError> {
-        if tracing::enabled!(tracing::Level::TRACE) {
-            if let Ok(json) = serde_json::to_string(request) {
-                tracing::trace!(payload = %json, "RPC request");
-            }
+        if tracing::enabled!(tracing::Level::TRACE)
+            && let Ok(json) = serde_json::to_string(request)
+        {
+            tracing::trace!(payload = %json, "RPC request");
         }
 
         let response = self
@@ -225,15 +225,15 @@ impl RpcClient {
             // a well-formed JSON-RPC error body — try to decode that first so callers
             // get typed variants instead of an opaque Network error. Falls back to the
             // original Network error for non-JSON bodies (HTML error pages, etc.).
-            if let Ok(parsed) = serde_json::from_str::<JsonRpcResponse>(&body) {
-                if let Some(error) = parsed.error {
-                    let parsed_err = self.parse_rpc_error(&error);
-                    return Err(preserve_http_retry_classification(
-                        parsed_err,
-                        status.as_u16(),
-                        &body,
-                    ));
-                }
+            if let Ok(parsed) = serde_json::from_str::<JsonRpcResponse>(&body)
+                && let Some(error) = parsed.error
+            {
+                let parsed_err = self.parse_rpc_error(&error);
+                return Err(preserve_http_retry_classification(
+                    parsed_err,
+                    status.as_u16(),
+                    &body,
+                ));
             }
             let retryable = is_retryable_status(status.as_u16());
             return Err(RpcError::network(
@@ -257,19 +257,19 @@ impl RpcClient {
         // object (with an "error" field) instead of in the JSON-RPC error
         // envelope. Only check for this on the `query` method to avoid
         // misclassifying legitimate results from other methods.
-        if request.method == "query" {
-            if let Some(error_str) = result_value.get("error").and_then(|e| e.as_str()) {
-                let synthetic = JsonRpcError {
-                    // Use -32600 (Invalid Request) rather than -32000 (Server Error)
-                    // so deterministic failures don't get retried.
-                    code: -32600,
-                    message: error_str.to_string(),
-                    data: Some(serde_json::Value::String(error_str.to_string())),
-                    cause: None,
-                    name: None,
-                };
-                return Err(self.parse_rpc_error(&synthetic));
-            }
+        if request.method == "query"
+            && let Some(error_str) = result_value.get("error").and_then(|e| e.as_str())
+        {
+            let synthetic = JsonRpcError {
+                // Use -32600 (Invalid Request) rather than -32000 (Server Error)
+                // so deterministic failures don't get retried.
+                code: -32600,
+                message: error_str.to_string(),
+                data: Some(serde_json::Value::String(error_str.to_string())),
+                cause: None,
+                name: None,
+            };
+            return Err(self.parse_rpc_error(&synthetic));
         }
 
         serde_json::from_value(result_value).map_err(RpcError::Json)
@@ -288,10 +288,9 @@ impl RpcClient {
                     if let Some(account_id) = info
                         .and_then(|i| i.get("requested_account_id"))
                         .and_then(|a| a.as_str())
+                        && let Ok(account_id) = account_id.parse()
                     {
-                        if let Ok(account_id) = account_id.parse() {
-                            return RpcError::AccountNotFound(account_id);
-                        }
+                        return RpcError::AccountNotFound(account_id);
                     }
                 }
                 "INVALID_ACCOUNT" => {
@@ -374,18 +373,15 @@ impl RpcClient {
                 "CONTRACT_EXECUTION_ERROR" => {
                     // Check for CodeDoesNotExist inside vm_error
                     // (EXPERIMENTAL_call_function wraps this as CONTRACT_EXECUTION_ERROR)
-                    if let Some(vm_error) = info.and_then(|i| i.get("vm_error")) {
-                        if let Some(compilation_err) = vm_error.get("CompilationError") {
-                            if let Some(code_not_exist) = compilation_err.get("CodeDoesNotExist") {
-                                if let Some(account_id) = code_not_exist
-                                    .get("account_id")
-                                    .and_then(|a| a.as_str())
-                                    .and_then(|a| a.parse().ok())
-                                {
-                                    return RpcError::ContractNotDeployed(account_id);
-                                }
-                            }
-                        }
+                    if let Some(vm_error) = info.and_then(|i| i.get("vm_error"))
+                        && let Some(compilation_err) = vm_error.get("CompilationError")
+                        && let Some(code_not_exist) = compilation_err.get("CodeDoesNotExist")
+                        && let Some(account_id) = code_not_exist
+                            .get("account_id")
+                            .and_then(|a| a.as_str())
+                            .and_then(|a| a.parse().ok())
+                    {
+                        return RpcError::ContractNotDeployed(account_id);
                     }
 
                     // Legacy `query` includes contract_id/method_name;
@@ -454,19 +450,17 @@ impl RpcClient {
         }
 
         // Fallback: check for string error messages in data field
-        if let Some(data) = &error.data {
-            if let Some(error_str) = data.as_str() {
-                if error_str.contains("does not exist") {
-                    // Try to extract account ID from error message
-                    // Format: "account X does not exist while viewing"
-                    if let Some(start) = error_str.strip_prefix("account ") {
-                        if let Some(account_str) = start.split_whitespace().next() {
-                            if let Ok(account_id) = account_str.parse() {
-                                return RpcError::AccountNotFound(account_id);
-                            }
-                        }
-                    }
-                }
+        if let Some(data) = &error.data
+            && let Some(error_str) = data.as_str()
+            && error_str.contains("does not exist")
+        {
+            // Try to extract account ID from error message
+            // Format: "account X does not exist while viewing"
+            if let Some(start) = error_str.strip_prefix("account ")
+                && let Some(account_str) = start.split_whitespace().next()
+                && let Ok(account_id) = account_str.parse()
+            {
+                return RpcError::AccountNotFound(account_id);
             }
         }
 
@@ -679,10 +673,10 @@ impl RpcClient {
 
     /// Merge block reference parameters into a JSON object.
     fn merge_block_reference(&self, params: &mut serde_json::Value, block: &BlockReference) {
-        if let serde_json::Value::Object(block_params) = block.to_rpc_params() {
-            if let serde_json::Value::Object(map) = params {
-                map.extend(block_params);
-            }
+        if let serde_json::Value::Object(block_params) = block.to_rpc_params()
+            && let serde_json::Value::Object(map) = params
+        {
+            map.extend(block_params);
         }
     }
 

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -37,10 +37,10 @@ use tracing::Instrument;
 
 use crate::error::{Error, RpcError};
 use crate::types::{
-    AccountId, Action, BlockReference, CryptoHash, DelegateAction, DeterministicAccountStateInit,
-    FinalExecutionOutcome, Finality, Gas, GlobalContractIdentifier, GlobalContractRef, IntoGas,
-    IntoNearToken, NearToken, NonDelegateAction, PublicKey, PublishMode, SignedDelegateAction,
-    SignedTransaction, Transaction, TryIntoAccountId, WaitLevel,
+    AccountId, Action, BlockReference, CryptoHash, DelegateAction, FinalExecutionOutcome, Finality,
+    Gas, GlobalContractId, IntoGas, IntoGlobalContractId, IntoNearToken, NearToken,
+    NonDelegateAction, PublicKey, PublishMode, SignedDelegateAction, SignedTransaction, StateInit,
+    Transaction, TryIntoAccountId, UseGlobalContractAction, WaitLevel,
 };
 
 use super::nonce_manager::NonceManager;
@@ -583,7 +583,7 @@ impl TransactionBuilder {
 
     /// Deploy a contract from the global registry.
     ///
-    /// Accepts any [`GlobalContractRef`] (such as a [`CryptoHash`] or an account ID
+    /// Accepts any [`IntoGlobalContractId`] (such as a [`CryptoHash`] or an account ID
     /// string/[`AccountId`]) to reference a previously published contract.
     ///
     /// # Example
@@ -598,12 +598,12 @@ impl TransactionBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn deploy_from(mut self, contract_ref: impl GlobalContractRef) -> Self {
-        let identifier = contract_ref.into_identifier();
-        self.actions.push(match identifier {
-            GlobalContractIdentifier::CodeHash(hash) => Action::deploy_from_hash(hash),
-            GlobalContractIdentifier::AccountId(id) => Action::deploy_from_account(id),
-        });
+    pub fn deploy_from(mut self, contract_ref: impl IntoGlobalContractId) -> Self {
+        let identifier: GlobalContractId = contract_ref.into_identifier();
+        self.actions
+            .push(Action::UseGlobalContract(UseGlobalContractAction {
+                contract_identifier: identifier,
+            }));
         self
     }
 
@@ -617,7 +617,7 @@ impl TransactionBuilder {
     /// ```rust,no_run
     /// # use near_kit::*;
     /// # async fn example(near: Near, code_hash: CryptoHash) -> Result<(), near_kit::Error> {
-    /// let si = DeterministicAccountStateInit::by_hash(code_hash, Default::default());
+    /// let si = StateInit::by_hash(code_hash, Default::default());
     /// let outcome = near.transaction("alice.testnet")
     ///     .state_init(si, NearToken::from_near(1))
     ///     .send()
@@ -629,11 +629,7 @@ impl TransactionBuilder {
     /// # Panics
     ///
     /// Panics if the deposit amount string cannot be parsed.
-    pub fn state_init(
-        mut self,
-        state_init: DeterministicAccountStateInit,
-        deposit: impl IntoNearToken,
-    ) -> Self {
+    pub fn state_init(mut self, state_init: StateInit, deposit: impl IntoNearToken) -> Self {
         let deposit = deposit
             .into_near_token()
             .expect("invalid deposit amount - use NearToken::from_str() for user input");
@@ -1404,14 +1400,14 @@ impl CallBuilder {
     }
 
     /// Deploy a contract from the global registry.
-    pub fn deploy_from(self, contract_ref: impl GlobalContractRef) -> TransactionBuilder {
+    pub fn deploy_from(self, contract_ref: impl IntoGlobalContractId) -> TransactionBuilder {
         self.finish().deploy_from(contract_ref)
     }
 
     /// Create a NEP-616 deterministic state init action.
     pub fn state_init(
         self,
-        state_init: DeterministicAccountStateInit,
+        state_init: StateInit,
         deposit: impl IntoNearToken,
     ) -> TransactionBuilder {
         self.finish().state_init(state_init, deposit)

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -325,10 +325,10 @@ impl RpcError {
         details: Option<serde_json::Value>,
     ) -> Self {
         // Try to deserialize the structured error from the data field
-        if let Some(ref data) = details {
-            if let Some(invalid_tx) = Self::try_parse_invalid_tx(data) {
-                return RpcError::InvalidTx(invalid_tx);
-            }
+        if let Some(ref data) = details
+            && let Some(invalid_tx) = Self::try_parse_invalid_tx(data)
+        {
+            return RpcError::InvalidTx(invalid_tx);
         }
 
         RpcError::InvalidTransaction {
@@ -343,19 +343,18 @@ impl RpcError {
     /// `{"TxExecutionError": {"InvalidTxError": {"InvalidNonce": {...}}}}`
     fn try_parse_invalid_tx(data: &serde_json::Value) -> Option<crate::types::InvalidTxError> {
         // Nested form: data.TxExecutionError.InvalidTxError
-        if let Some(tx_err) = data.get("TxExecutionError") {
-            if let Some(invalid_tx_value) = tx_err.get("InvalidTxError") {
-                if let Ok(parsed) = serde_json::from_value(invalid_tx_value.clone()) {
-                    return Some(parsed);
-                }
-            }
+        if let Some(tx_err) = data.get("TxExecutionError")
+            && let Some(invalid_tx_value) = tx_err.get("InvalidTxError")
+            && let Ok(parsed) = serde_json::from_value(invalid_tx_value.clone())
+        {
+            return Some(parsed);
         }
 
         // Fallback: InvalidTxError at the top level (some RPC versions)
-        if let Some(invalid_tx_value) = data.get("InvalidTxError") {
-            if let Ok(parsed) = serde_json::from_value(invalid_tx_value.clone()) {
-                return Some(parsed);
-            }
+        if let Some(invalid_tx_value) = data.get("InvalidTxError")
+            && let Ok(parsed) = serde_json::from_value(invalid_tx_value.clone())
+        {
+            return Some(parsed);
         }
 
         None

--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -5,11 +5,20 @@ use std::collections::BTreeMap;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
-use serde_with::base64::Base64;
-use serde_with::serde_as;
-use sha3::{Digest, Keccak256};
 
 use super::{AccountId, CryptoHash, Gas, NearToken, PublicKey, Signature, TryIntoAccountId};
+
+/// NEP-616 deterministic account types, re-exported from the
+/// [`near-global-contracts`](https://crates.io/crates/near-global-contracts) crate.
+///
+/// These are the canonical NEP-616 wire types (borsh/JSON byte-identical to nearcore):
+///
+/// - [`GlobalContractId`] — references a global contract by code hash or publisher account.
+/// - [`StateInit`] / [`StateInitV1`] — state initialization for a deterministic account.
+///
+/// Construct a [`StateInit`] ergonomically via the [`StateInitExt`] extension trait
+/// (`StateInit::by_hash(...)` / `StateInit::by_publisher(...)`).
+pub use near_global_contracts::{GlobalContractId, StateInit, StateInitV1};
 
 /// Publish mode for global contracts.
 ///
@@ -27,55 +36,56 @@ pub enum PublishMode {
 /// Trait for types that can identify a global contract.
 ///
 /// This allows `deploy_from` to accept either a `CryptoHash` (for immutable
-/// contracts) or an account ID string/`AccountId` (for publisher-updatable contracts).
+/// contracts) or an account ID string/`AccountId` (for publisher-updatable contracts),
+/// converting into the canonical [`GlobalContractId`].
 ///
 /// # Panics
 ///
 /// String-based implementations (`&str`, `String`, `&String`) panic if the string is not a
 /// valid NEAR account ID.
-pub trait GlobalContractRef {
-    fn into_identifier(self) -> GlobalContractIdentifier;
+pub trait IntoGlobalContractId {
+    fn into_identifier(self) -> GlobalContractId;
 }
 
-impl GlobalContractRef for CryptoHash {
-    fn into_identifier(self) -> GlobalContractIdentifier {
-        GlobalContractIdentifier::CodeHash(self)
+impl IntoGlobalContractId for CryptoHash {
+    fn into_identifier(self) -> GlobalContractId {
+        GlobalContractId::CodeHash(*self.as_bytes())
     }
 }
 
-impl GlobalContractRef for AccountId {
-    fn into_identifier(self) -> GlobalContractIdentifier {
-        GlobalContractIdentifier::AccountId(self)
+impl IntoGlobalContractId for AccountId {
+    fn into_identifier(self) -> GlobalContractId {
+        GlobalContractId::AccountId(self)
     }
 }
 
-impl GlobalContractRef for &AccountId {
-    fn into_identifier(self) -> GlobalContractIdentifier {
-        GlobalContractIdentifier::AccountId(self.clone())
+impl IntoGlobalContractId for &AccountId {
+    fn into_identifier(self) -> GlobalContractId {
+        GlobalContractId::AccountId(self.clone())
     }
 }
 
-impl GlobalContractRef for &str {
-    fn into_identifier(self) -> GlobalContractIdentifier {
+impl IntoGlobalContractId for &str {
+    fn into_identifier(self) -> GlobalContractId {
         let account_id: AccountId = self.try_into_account_id().expect("invalid account ID");
-        GlobalContractIdentifier::AccountId(account_id)
+        GlobalContractId::AccountId(account_id)
     }
 }
 
-impl GlobalContractRef for String {
-    fn into_identifier(self) -> GlobalContractIdentifier {
+impl IntoGlobalContractId for String {
+    fn into_identifier(self) -> GlobalContractId {
         let account_id: AccountId = self.try_into_account_id().expect("invalid account ID");
-        GlobalContractIdentifier::AccountId(account_id)
+        GlobalContractId::AccountId(account_id)
     }
 }
 
-impl GlobalContractRef for &String {
-    fn into_identifier(self) -> GlobalContractIdentifier {
+impl IntoGlobalContractId for &String {
+    fn into_identifier(self) -> GlobalContractId {
         let account_id: AccountId = self
             .as_str()
             .try_into_account_id()
             .expect("invalid account ID");
-        GlobalContractIdentifier::AccountId(account_id)
+        GlobalContractId::AccountId(account_id)
     }
 }
 
@@ -286,22 +296,6 @@ pub struct DeleteAccountAction {
 // Global Contract Actions
 // ============================================================================
 
-/// How a global contract is identified in the registry.
-///
-/// Global contracts can be referenced either by their code hash (immutable)
-/// or by the account that published them (updatable).
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
-pub enum GlobalContractIdentifier {
-    /// Reference by code hash (32-byte SHA-256 hash of the WASM code).
-    /// This creates an immutable reference - the contract cannot be updated.
-    #[serde(rename = "hash")]
-    CodeHash(CryptoHash),
-    /// Reference by the account ID that published the contract.
-    /// The publisher can update the contract, and all users will get the new version.
-    #[serde(rename = "account_id")]
-    AccountId(AccountId),
-}
-
 /// Deploy mode for global contracts.
 ///
 /// Determines how the contract will be identified in the global registry.
@@ -336,34 +330,16 @@ pub struct DeployGlobalContractAction {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct UseGlobalContractAction {
     /// Reference to the published contract.
-    pub contract_identifier: GlobalContractIdentifier,
+    pub contract_identifier: GlobalContractId,
 }
 
 // ============================================================================
 // NEP-616 Deterministic Account Actions
 // ============================================================================
-
-/// State initialization data for NEP-616 deterministic accounts.
-///
-/// The account ID is derived from: `"0s" + hex(keccak256(borsh(state_init))[12..32])`
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
-#[repr(u8)]
-pub enum DeterministicAccountStateInit {
-    /// Version 1 of the state init format.
-    V1(DeterministicAccountStateInitV1),
-}
-
-/// Version 1 of deterministic account state initialization.
-#[serde_as]
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
-pub struct DeterministicAccountStateInitV1 {
-    /// Reference to the contract code (from global registry).
-    pub code: GlobalContractIdentifier,
-    /// Initial key-value pairs to populate in the contract's storage.
-    /// Keys and values are Borsh-serialized bytes.
-    #[serde_as(as = "BTreeMap<Base64, Base64>")]
-    pub data: BTreeMap<Vec<u8>, Vec<u8>>,
-}
+//
+// The NEP-616 wire types ([`StateInit`], [`StateInitV1`], [`GlobalContractId`]) live in the
+// upstream `near-global-contracts` crate and are re-exported above. The action wrapper and the
+// `by_hash`/`by_publisher` construction ergonomics stay in near-kit.
 
 /// Deploy a contract with a deterministically derived account ID (NEP-616).
 ///
@@ -372,72 +348,44 @@ pub struct DeterministicAccountStateInitV1 {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub struct DeterministicStateInitAction {
     /// The state initialization data.
-    pub state_init: DeterministicAccountStateInit,
+    pub state_init: StateInit,
     /// Amount to attach for storage costs.
     pub deposit: NearToken,
 }
 
-impl DeterministicAccountStateInit {
+/// Ergonomic constructors for the upstream [`StateInit`] type.
+///
+/// `near-global-contracts` exposes [`StateInitV1::code`] / [`StateInitV1::with_data_entry`], but
+/// near-kit prefers the `by_hash`/`by_publisher` shape. This extension trait restores those
+/// constructors so call sites can write `StateInit::by_hash(...)`.
+pub trait StateInitExt {
     /// Create a state init referencing a global contract by its code hash (immutable).
-    pub fn by_hash(code_hash: CryptoHash, data: BTreeMap<Vec<u8>, Vec<u8>>) -> Self {
-        Self::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::CodeHash(code_hash),
-            data,
-        })
-    }
+    fn by_hash(code_hash: CryptoHash, data: BTreeMap<Vec<u8>, Vec<u8>>) -> StateInit;
 
     /// Create a state init referencing a global contract by its publisher account (updatable).
-    pub fn by_publisher(publisher_id: AccountId, data: BTreeMap<Vec<u8>, Vec<u8>>) -> Self {
-        Self::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::AccountId(publisher_id),
+    fn by_publisher(publisher_id: AccountId, data: BTreeMap<Vec<u8>, Vec<u8>>) -> StateInit;
+}
+
+impl StateInitExt for StateInit {
+    fn by_hash(code_hash: CryptoHash, data: BTreeMap<Vec<u8>, Vec<u8>>) -> StateInit {
+        StateInit::V1(StateInitV1 {
+            code: GlobalContractId::CodeHash(*code_hash.as_bytes()),
             data,
         })
     }
 
-    /// Derive the deterministic account ID from this state init.
-    ///
-    /// The account ID is derived as: `"0s" + hex(keccak256(borsh(state_init))[12..32])`
-    ///
-    /// This produces a 42-character account ID that:
-    /// - Starts with "0s" prefix (distinguishes from Ethereum implicit accounts "0x")
-    /// - Followed by 40 hex characters (20 bytes from the keccak256 hash)
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// use near_kit::types::{DeterministicAccountStateInit, CryptoHash};
-    /// use std::collections::BTreeMap;
-    ///
-    /// let state_init = DeterministicAccountStateInit::by_hash(CryptoHash::default(), BTreeMap::new());
-    ///
-    /// let account_id = state_init.derive_account_id();
-    /// assert!(account_id.as_str().starts_with("0s"));
-    /// assert_eq!(account_id.as_str().len(), 42);
-    /// ```
-    pub fn derive_account_id(&self) -> AccountId {
-        // Borsh-serialize the state init
-        let serialized = borsh::to_vec(self).expect("StateInit serialization should not fail");
-
-        // Compute keccak256 hash
-        let hash = Keccak256::digest(&serialized);
-
-        // Take last 20 bytes (indices 12-32) of the hash
-        let suffix = &hash[12..32];
-
-        // Format as "0s" + hex
-        let account_str = format!("0s{}", hex::encode(suffix));
-
-        // This is a valid deterministic account ID by construction
-        account_str
-            .parse()
-            .expect("deterministic account ID should always be valid")
+    fn by_publisher(publisher_id: AccountId, data: BTreeMap<Vec<u8>, Vec<u8>>) -> StateInit {
+        StateInit::V1(StateInitV1 {
+            code: GlobalContractId::AccountId(publisher_id),
+            data,
+        })
     }
 }
 
 impl DeterministicStateInitAction {
     /// Derive the deterministic account ID for this action.
     ///
-    /// Convenience method that delegates to `DeterministicAccountStateInit::derive_account_id`.
+    /// Convenience method that delegates to [`StateInit::derive_account_id`].
     pub fn derive_account_id(&self) -> AccountId {
         self.state_init.derive_account_id()
     }
@@ -611,7 +559,7 @@ impl Action {
     /// References a previously published immutable contract.
     pub fn deploy_from_hash(code_hash: CryptoHash) -> Self {
         Self::UseGlobalContract(UseGlobalContractAction {
-            contract_identifier: GlobalContractIdentifier::CodeHash(code_hash),
+            contract_identifier: GlobalContractId::CodeHash(*code_hash.as_bytes()),
         })
     }
 
@@ -621,7 +569,7 @@ impl Action {
     /// The contract can be updated by the publisher.
     pub fn deploy_from_account(account_id: AccountId) -> Self {
         Self::UseGlobalContract(UseGlobalContractAction {
-            contract_identifier: GlobalContractIdentifier::AccountId(account_id),
+            contract_identifier: GlobalContractId::AccountId(account_id),
         })
     }
 
@@ -629,7 +577,7 @@ impl Action {
     ///
     /// The account ID is derived from the state init data:
     /// `"0s" + hex(keccak256(borsh(state_init))[12..32])`
-    pub fn state_init(state_init: DeterministicAccountStateInit, deposit: NearToken) -> Self {
+    pub fn state_init(state_init: StateInit, deposit: NearToken) -> Self {
         Self::DeterministicStateInit(DeterministicStateInitAction {
             state_init,
             deposit,
@@ -965,7 +913,7 @@ mod tests {
 
         // DeterministicStateInit (discriminant = 11)
         let state_init = Action::state_init(
-            DeterministicAccountStateInit::by_hash(code_hash, BTreeMap::new()),
+            StateInit::by_hash(code_hash, BTreeMap::new()),
             NearToken::from_near(1),
         );
         let bytes = borsh::to_vec(&state_init).unwrap();
@@ -1007,7 +955,7 @@ mod tests {
     fn test_global_contract_identifier_serialization() {
         // Verify identifier serialization
         let hash = CryptoHash::hash(&[1, 2, 3]);
-        let by_hash = GlobalContractIdentifier::CodeHash(hash);
+        let by_hash = GlobalContractId::CodeHash(*hash.as_bytes());
         let bytes = borsh::to_vec(&by_hash).unwrap();
         assert_eq!(
             bytes[0], 0,
@@ -1020,7 +968,7 @@ mod tests {
         );
 
         let account_id: AccountId = "test.near".parse().unwrap();
-        let by_account = GlobalContractIdentifier::AccountId(account_id);
+        let by_account = GlobalContractId::AccountId(account_id);
         let bytes = borsh::to_vec(&by_account).unwrap();
         assert_eq!(
             bytes[0], 1,
@@ -1047,7 +995,7 @@ mod tests {
     fn test_use_global_contract_action_roundtrip() {
         let hash = CryptoHash::hash(&[1, 2, 3, 4]);
         let action = UseGlobalContractAction {
-            contract_identifier: GlobalContractIdentifier::CodeHash(hash),
+            contract_identifier: GlobalContractId::CodeHash(*hash.as_bytes()),
         };
 
         let bytes = borsh::to_vec(&action).unwrap();
@@ -1055,7 +1003,7 @@ mod tests {
 
         assert_eq!(
             decoded.contract_identifier,
-            GlobalContractIdentifier::CodeHash(hash)
+            GlobalContractId::CodeHash(*hash.as_bytes())
         );
     }
 
@@ -1067,8 +1015,8 @@ mod tests {
         data.insert(b"key2".to_vec(), b"value2".to_vec());
 
         let action = DeterministicStateInitAction {
-            state_init: DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-                code: GlobalContractIdentifier::CodeHash(hash),
+            state_init: StateInit::V1(StateInitV1 {
+                code: GlobalContractId::CodeHash(*hash.as_bytes()),
                 data: data.clone(),
             }),
             deposit: NearToken::from_near(5),
@@ -1078,8 +1026,8 @@ mod tests {
         let decoded: DeterministicStateInitAction = borsh::from_slice(&bytes).unwrap();
 
         assert_eq!(decoded.deposit, NearToken::from_near(5));
-        let DeterministicAccountStateInit::V1(v1) = decoded.state_init;
-        assert_eq!(v1.code, GlobalContractIdentifier::CodeHash(hash));
+        let StateInit::V1(v1) = decoded.state_init;
+        assert_eq!(v1.code, GlobalContractId::CodeHash(*hash.as_bytes()));
         assert_eq!(v1.data, data);
     }
 
@@ -1108,7 +1056,7 @@ mod tests {
         if let Action::UseGlobalContract(inner) = action {
             assert_eq!(
                 inner.contract_identifier,
-                GlobalContractIdentifier::CodeHash(hash)
+                GlobalContractId::CodeHash(*hash.as_bytes())
             );
         } else {
             panic!("Expected UseGlobalContract");
@@ -1120,7 +1068,7 @@ mod tests {
         if let Action::UseGlobalContract(inner) = action {
             assert_eq!(
                 inner.contract_identifier,
-                GlobalContractIdentifier::AccountId(account_id)
+                GlobalContractId::AccountId(account_id)
             );
         } else {
             panic!("Expected UseGlobalContract");
@@ -1130,8 +1078,8 @@ mod tests {
     #[test]
     fn test_derive_account_id_format() {
         // Test that derived account ID has the correct format
-        let state_init = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::CodeHash(CryptoHash::default()),
+        let state_init = StateInit::V1(StateInitV1 {
+            code: GlobalContractId::CodeHash([0u8; 32]),
             data: BTreeMap::new(),
         });
 
@@ -1167,13 +1115,13 @@ mod tests {
     #[test]
     fn test_derive_account_id_deterministic() {
         // Same input should produce same output
-        let state_init1 = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::AccountId("publisher.near".parse().unwrap()),
+        let state_init1 = StateInit::V1(StateInitV1 {
+            code: GlobalContractId::AccountId("publisher.near".parse().unwrap()),
             data: BTreeMap::new(),
         });
 
-        let state_init2 = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::AccountId("publisher.near".parse().unwrap()),
+        let state_init2 = StateInit::V1(StateInitV1 {
+            code: GlobalContractId::AccountId("publisher.near".parse().unwrap()),
             data: BTreeMap::new(),
         });
 
@@ -1187,13 +1135,13 @@ mod tests {
     #[test]
     fn test_derive_account_id_different_inputs() {
         // Different code references should produce different account IDs
-        let state_init1 = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::AccountId("publisher1.near".parse().unwrap()),
+        let state_init1 = StateInit::V1(StateInitV1 {
+            code: GlobalContractId::AccountId("publisher1.near".parse().unwrap()),
             data: BTreeMap::new(),
         });
 
-        let state_init2 = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::AccountId("publisher2.near".parse().unwrap()),
+        let state_init2 = StateInit::V1(StateInitV1 {
+            code: GlobalContractId::AccountId("publisher2.near".parse().unwrap()),
             data: BTreeMap::new(),
         });
 
@@ -1246,13 +1194,13 @@ mod tests {
         let mut data = BTreeMap::new();
         data.insert(b"key".to_vec(), b"value".to_vec());
 
-        let state_init1 = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::AccountId("publisher.near".parse().unwrap()),
+        let state_init1 = StateInit::V1(StateInitV1 {
+            code: GlobalContractId::AccountId("publisher.near".parse().unwrap()),
             data: BTreeMap::new(),
         });
 
-        let state_init2 = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::AccountId("publisher.near".parse().unwrap()),
+        let state_init2 = StateInit::V1(StateInitV1 {
+            code: GlobalContractId::AccountId("publisher.near".parse().unwrap()),
             data,
         });
 
@@ -1269,14 +1217,14 @@ mod tests {
 
     #[test]
     fn test_deterministic_state_init_json_roundtrip() {
-        // Build a DeterministicAccountStateInit with non-trivial data
+        // Build a StateInit with non-trivial data
         let hash = CryptoHash::hash(&[1, 2, 3, 4]);
         let mut data = BTreeMap::new();
         data.insert(b"key1".to_vec(), b"value1".to_vec());
         data.insert(b"key2".to_vec(), b"value2".to_vec());
 
-        let state_init = DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-            code: GlobalContractIdentifier::CodeHash(hash),
+        let state_init = StateInit::V1(StateInitV1 {
+            code: GlobalContractId::CodeHash(*hash.as_bytes()),
             data: data.clone(),
         });
 
@@ -1302,9 +1250,12 @@ mod tests {
         );
 
         // Round-trip back
-        let deserialized: DeterministicAccountStateInit = serde_json::from_value(json).unwrap();
-        let DeterministicAccountStateInit::V1(v1_decoded) = deserialized;
-        assert_eq!(v1_decoded.code, GlobalContractIdentifier::CodeHash(hash));
+        let deserialized: StateInit = serde_json::from_value(json).unwrap();
+        let StateInit::V1(v1_decoded) = deserialized;
+        assert_eq!(
+            v1_decoded.code,
+            GlobalContractId::CodeHash(*hash.as_bytes())
+        );
         assert_eq!(v1_decoded.data, data);
     }
 
@@ -1312,24 +1263,24 @@ mod tests {
     fn test_global_contract_identifier_json_roundtrip() {
         // CodeHash variant
         let hash = CryptoHash::hash(&[1, 2, 3]);
-        let id = GlobalContractIdentifier::CodeHash(hash);
+        let id = GlobalContractId::CodeHash(*hash.as_bytes());
         let json = serde_json::to_string(&id).unwrap();
-        let decoded: GlobalContractIdentifier = serde_json::from_str(&json).unwrap();
+        let decoded: GlobalContractId = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded, id);
 
         // AccountId variant
         let account_id: AccountId = "test.near".parse().unwrap();
-        let id = GlobalContractIdentifier::AccountId(account_id);
+        let id = GlobalContractId::AccountId(account_id);
         let json = serde_json::to_string(&id).unwrap();
-        let decoded: GlobalContractIdentifier = serde_json::from_str(&json).unwrap();
+        let decoded: GlobalContractId = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded, id);
     }
 
     #[test]
     fn test_deterministic_state_init_action_json_roundtrip() {
         let action = DeterministicStateInitAction {
-            state_init: DeterministicAccountStateInit::V1(DeterministicAccountStateInitV1 {
-                code: GlobalContractIdentifier::AccountId("publisher.near".parse().unwrap()),
+            state_init: StateInit::V1(StateInitV1 {
+                code: GlobalContractId::AccountId("publisher.near".parse().unwrap()),
                 data: BTreeMap::new(),
             }),
             deposit: NearToken::from_near(5),

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -64,11 +64,10 @@ pub use action::{
     AccessKey, AccessKeyPermission, Action, AddKeyAction, CreateAccountAction,
     DELEGATE_ACTION_PREFIX, DecodeError as DelegateDecodeError, DelegateAction,
     DeleteAccountAction, DeleteKeyAction, DeployContractAction, DeployGlobalContractAction,
-    DeterministicAccountStateInit, DeterministicAccountStateInitV1, DeterministicStateInitAction,
-    FunctionCallAction, FunctionCallPermission, GasKeyInfo, GlobalContractDeployMode,
-    GlobalContractIdentifier, GlobalContractRef, NonDelegateAction, PublishMode,
-    SignedDelegateAction, StakeAction, TransferAction, TransferToGasKeyAction,
-    UseGlobalContractAction, WithdrawFromGasKeyAction,
+    DeterministicStateInitAction, FunctionCallAction, FunctionCallPermission, GasKeyInfo,
+    GlobalContractDeployMode, GlobalContractId, IntoGlobalContractId, NonDelegateAction,
+    PublishMode, SignedDelegateAction, StakeAction, StateInit, StateInitExt, StateInitV1,
+    TransferAction, TransferToGasKeyAction, UseGlobalContractAction, WithdrawFromGasKeyAction,
 };
 pub use block_reference::{BlockReference, Finality, SyncCheckpoint, TxExecutionStatus};
 pub use error::{

--- a/crates/near-kit/src/types/nep413.rs
+++ b/crates/near-kit/src/types/nep413.rs
@@ -452,14 +452,14 @@ where
     let s: String = String::deserialize(deserializer)?;
 
     // Try base64 first (NEP-413 spec)
-    if let Ok(bytes) = BASE64_STANDARD.decode(&s) {
-        if bytes.len() == 64 {
-            return Ok(Signature::ed25519_from_bytes(
-                bytes
-                    .try_into()
-                    .map_err(|_| D::Error::custom("Invalid signature length"))?,
-            ));
-        }
+    if let Ok(bytes) = BASE64_STANDARD.decode(&s)
+        && bytes.len() == 64
+    {
+        return Ok(Signature::ed25519_from_bytes(
+            bytes
+                .try_into()
+                .map_err(|_| D::Error::custom("Invalid signature length"))?,
+        ));
     }
 
     // Try prefixed format (ed25519:base58 or secp256k1:base58)
@@ -477,14 +477,14 @@ where
     }
 
     // Try plain base58
-    if let Ok(bytes) = bs58::decode(&s).into_vec() {
-        if bytes.len() == 64 {
-            return Ok(Signature::ed25519_from_bytes(
-                bytes
-                    .try_into()
-                    .map_err(|_| D::Error::custom("Invalid signature length"))?,
-            ));
-        }
+    if let Ok(bytes) = bs58::decode(&s).into_vec()
+        && bytes.len() == 64
+    {
+        return Ok(Signature::ed25519_from_bytes(
+            bytes
+                .try_into()
+                .map_err(|_| D::Error::custom("Invalid signature length"))?,
+        ));
     }
 
     Err(D::Error::custom(

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -415,7 +415,7 @@ async fn test_state_init_by_hash() {
     let initial_data: BTreeMap<Vec<u8>, Vec<u8>> = BTreeMap::new();
 
     // Use state_init to create a deterministic account
-    let si = near_kit::DeterministicAccountStateInit::by_hash(code_hash, initial_data);
+    let si = near_kit::StateInit::by_hash(code_hash, initial_data);
     let outcome = publisher_near
         .state_init(si, NearToken::from_near(5))
         .send()
@@ -455,8 +455,7 @@ async fn test_state_init_by_publisher() {
     initial_data.insert(b"key1".to_vec(), b"value1".to_vec());
 
     // Use state_init to create a deterministic account
-    let si =
-        near_kit::DeterministicAccountStateInit::by_publisher(publisher_id.clone(), initial_data);
+    let si = near_kit::StateInit::by_publisher(publisher_id.clone(), initial_data);
     let outcome = publisher_near
         .state_init(si, NearToken::from_near(5))
         .send()


### PR DESCRIPTION
## Summary

Replaces near-kit's hand-rolled NEP-616 deterministic-account types with the newly published [`near-global-contracts` 0.2.0](https://crates.io/crates/near-global-contracts) crate. This is a **type-surface swap, not a behavior change** — borsh, JSON, and derived account IDs are byte-identical to before (and to nearcore).

## Rename map (breaking)

| Old (near-kit) | New (re-exported from `near-global-contracts`) |
|---|---|
| `DeterministicAccountStateInit` | `StateInit` |
| `DeterministicAccountStateInitV1` | `StateInitV1` |
| `GlobalContractIdentifier` | `GlobalContractId` |
| `GlobalContractRef` (trait) | `IntoGlobalContractId` (trait) |

- `DeterministicStateInitAction` **stays** in near-kit (upstream has no action types); its `state_init` field is now a `StateInit`, and its `derive_account_id()` convenience method delegates to upstream's.
- `by_hash` / `by_publisher` ergonomics are preserved via a new `StateInitExt` extension trait, so call sites still read `StateInit::by_hash(...)`. It's exported from `types` and surfaces through the crate-root glob (`use near_kit::*`).
- `GlobalContractId::CodeHash` now holds a raw `[u8; 32]` (upstream's `near_crypto_hash::CryptoHash` is a `[u8; 32]` alias) rather than near-kit's `CryptoHash`; conversion is `*hash.as_bytes()`.
- RPC view types (`GlobalContractIdentifierView`) are **untouched**.

## MSRV bump 1.86 → 1.88

`near-global-contracts` has `rust-version = 1.88`, and it pulls `serde_with` up to 3.20 (whose base58 support is the version floor). CI MSRV job and the README badge are updated accordingly.

## Other

- Dropped near-kit's direct `sha3` dependency. Keccak hashing for `derive_account_id` now flows through `near-global-contracts` (which uses `sha3 0.10` on the off-chain `cfg(not(near))` path).
- `Cargo.lock`: minimal resolution — adds `near-global-contracts` + its deps and bumps `serde_with` 3.17 → 3.20 (and the few crates 3.20 requires). No unrelated churn.

## Wire-format verification

The borsh discriminant tests, JSON roundtrip tests, and account-ID derivation tests are kept and pass unchanged. The full sandbox integration suite (publish / use-global-contract / deterministic state-init, end-to-end) passes against a real NEAR sandbox.