### PR TITLE
feat(macros): derive Debug and Clone on generated contract clients

### DIFF
--- a/crates/near-kit-macros/src/lib.rs
+++ b/crates/near-kit-macros/src/lib.rs
@@ -492,6 +492,7 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
     // Build the output
     let expanded = quote! {
         #(#trait_attrs)*
+        #[derive(Debug, Clone)]
         #vis struct #trait_name;
 
         impl #trait_name {
@@ -499,6 +500,7 @@ fn contract_impl(args: ContractArgs, input: ItemTrait) -> syn::Result<TokenStrea
         }
 
         // Generated client struct for the simple (non-composed) case.
+        #[derive(Debug, Clone)]
         #vis struct #client_name {
             near: near_kit::Near,
             contract_id: near_kit::AccountId,

--- a/crates/near-kit/tests/macro_derives.rs
+++ b/crates/near-kit/tests/macro_derives.rs
@@ -1,5 +1,5 @@
-//! The `#[near_kit::contract]` macro must derive Debug + Clone on generated clients.
-use near_kit::contract;
+//! The `#[near_kit::contract]` macro must derive `Debug` + `Clone` on the generated marker and client types.
+use near_kit::*;
 
 #[contract]
 pub trait Counter {

--- a/crates/near-kit/tests/macro_derives.rs
+++ b/crates/near-kit/tests/macro_derives.rs
@@ -1,0 +1,17 @@
+//! The `#[near_kit::contract]` macro must derive Debug + Clone on generated clients.
+use near_kit::contract;
+
+#[contract]
+pub trait Counter {
+    fn get_count(&self) -> u64;
+    #[call]
+    fn increment(&mut self);
+}
+
+fn _assert_debug_clone<T: std::fmt::Debug + Clone>() {}
+
+#[test]
+fn generated_client_is_debug_and_clone() {
+    _assert_debug_clone::<CounterClient>();
+    _assert_debug_clone::<Counter>();
+}


### PR DESCRIPTION
Generated `#[near_kit::contract]` clients had no derives, so they could not be used where `Debug`/`Clone` is required (for example embedding a client in a `#[derive(Debug)]` test struct). Derive both on the generated marker and client structs; the field types already support them.

From near-kit UX feedback (nearone Slack).