### PR TITLE
ci: lint all features and keep clippy clean on Rust 1.96

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           save-if: false
           cache-on-failure: "true"
       - run: cargo fmt --all -- --check
-      - run: cargo clippy --workspace --all-targets
+      - run: cargo clippy --workspace --all-targets --all-features
 
   test:
     name: Test

--- a/crates/near-kit/src/sandbox.rs
+++ b/crates/near-kit/src/sandbox.rs
@@ -219,13 +219,12 @@ static SHARED_SANDBOX: OnceCell<Sandbox> = OnceCell::const_new();
 /// the time `atexit` fires, so we spawn a new thread with fresh TLS.
 extern "C" fn cleanup_shared_sandbox() {
     let handle = std::thread::spawn(|| {
-        if let Some(sandbox) = SHARED_SANDBOX.get() {
-            if let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+        if let Some(sandbox) = SHARED_SANDBOX.get()
+            && let Ok(rt) = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-            {
-                let _ = rt.block_on(sandbox.container.stop_with_timeout(Some(0)));
-            }
+        {
+            let _ = rt.block_on(sandbox.container.stop_with_timeout(Some(0)));
         }
     });
     let _ = handle.join();


### PR DESCRIPTION
clippy 1.96 flags `collapsible_if` in the sandbox-feature cleanup code, but CI lints without `--all-features`, so feature-gated code was never checked. Collapse the nested `if let` into a let-chain (stable since our 1.88 MSRV) and run clippy with `--all-features` in CI so feature-gated lints are caught going forward. No behavior change.