### PR TITLE
fix(sandbox): update default image to 2.12.0

### DIFF
--- a/crates/near-kit/src/sandbox.rs
+++ b/crates/near-kit/src/sandbox.rs
@@ -87,7 +87,7 @@ use crate::client::Near;
 // ============================================================================
 
 const DEFAULT_IMAGE: &str = "nearprotocol/sandbox";
-const DEFAULT_VERSION: &str = "2.11.0";
+const DEFAULT_VERSION: &str = "2.12.0";
 
 /// The RPC port exposed by the NEAR sandbox container.
 const RPC_PORT: ContainerPort = ContainerPort::Tcp(3030);


### PR DESCRIPTION
Bumps the default NEAR sandbox image from 2.11.0 to 2.12.0. Requested by a consumer team that hit a wasm deserialization error on 2.11.0 after cargo-near enabled the wasm bulk-memory proposal.