### PR TITLE
feat(rpc): view_state with pagination

### DIFF
--- a/crates/near-kit/CHANGELOG.md
+++ b/crates/near-kit/CHANGELOG.md
@@ -28,6 +28,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ml-dsa-65-hash:` view handle so `view_access_key_list` parses without panicking.
   `SecretKey` accepts both the 32-byte seed and the 4032-byte expanded
   private key that NEAR tooling exports under the `ml-dsa-65:` prefix.
+- *(rpc)* `view_state` RPC method with pagination (`after_key_base64` / `limit`
+  / `last_key`): `RpcClient::view_state` for a single page and
+  `RpcClient::view_state_all` to read a contract's full state across pages.
+  Adds `StateItem` / `ViewStateResult` types.
 
 ### Changed
 

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -627,6 +627,20 @@ impl RpcClient {
         page_size: u32,
         block: BlockReference,
     ) -> Result<Vec<StateItem>, RpcError> {
+        // Pin a fixed block for the whole scan so every page reads a consistent
+        // snapshot. A moving finality reference (`Final`/`Optimistic`/
+        // `NearFinal`) would re-resolve to a possibly different block on each
+        // page, which can drop or duplicate entries across the cursor; resolve
+        // it to a concrete block hash once up front. Already-fixed references
+        // (`Height`/`Hash`/`SyncCheckpoint`) are used as-is.
+        let fixed_block = match block {
+            BlockReference::Finality(_) => {
+                let header_hash = self.block(block).await?.header.hash;
+                BlockReference::at_hash(header_hash)
+            }
+            already_fixed => already_fixed,
+        };
+
         let limit = (page_size > 0).then_some(page_size);
         let mut all = Vec::new();
         let mut after_key: Option<Vec<u8>> = None;
@@ -637,7 +651,7 @@ impl RpcClient {
                     prefix,
                     after_key.as_deref(),
                     limit,
-                    block.clone(),
+                    fixed_block.clone(),
                 )
                 .await?;
             all.extend(page.values);

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -11,7 +11,7 @@ use crate::types::rpc::RawTransactionResponse;
 use crate::types::{
     AccessKeyListView, AccessKeyView, AccountId, AccountView, BlockReference, BlockView,
     CryptoHash, EpochValidatorInfo, GasPrice, PublicKey, ReceiptToTxResponse, SignedTransaction,
-    StatusResponse, TxExecutionStatus, ViewFunctionResult,
+    StateItem, StatusResponse, TxExecutionStatus, ViewFunctionResult, ViewStateResult,
 };
 
 /// Network configuration presets.
@@ -568,6 +568,85 @@ impl RpcClient {
             block_height: response.block_height,
             block_hash: response.block_hash,
         })
+    }
+
+    /// View a single page of a contract's state (raw key/value trie entries).
+    ///
+    /// Only entries whose key starts with `prefix` are returned (pass an empty
+    /// slice for all keys). `after_key` is the continuation cursor from a
+    /// previous page's [`ViewStateResult::last_key`], and `limit` caps the
+    /// number of entries returned. When the result's `last_key` is `Some`, more
+    /// entries remain — call again with `after_key = last_key`.
+    ///
+    /// Prefer [`RpcClient::view_state_all`] to collect every entry without
+    /// managing the cursor yourself.
+    #[tracing::instrument(skip(self, prefix, after_key, block), fields(%account_id))]
+    pub async fn view_state(
+        &self,
+        account_id: &AccountId,
+        prefix: &[u8],
+        after_key: Option<&[u8]>,
+        limit: Option<u32>,
+        block: BlockReference,
+    ) -> Result<ViewStateResult, RpcError> {
+        let mut params = serde_json::json!({
+            "request_type": "view_state",
+            "account_id": account_id.to_string(),
+            "prefix_base64": STANDARD.encode(prefix),
+        });
+        if let Some(obj) = params.as_object_mut() {
+            if let Some(after) = after_key {
+                obj.insert(
+                    "after_key_base64".to_string(),
+                    STANDARD.encode(after).into(),
+                );
+            }
+            // nearcore requires a non-zero limit; omit it otherwise.
+            if let Some(limit) = limit.filter(|&l| l > 0) {
+                obj.insert("limit".to_string(), limit.into());
+            }
+        }
+        self.merge_block_reference(&mut params, &block);
+        self.call("query", params).await
+    }
+
+    /// Read a contract's entire state, transparently following pagination.
+    ///
+    /// Repeatedly calls [`RpcClient::view_state`] with `page_size` per request,
+    /// following the `last_key` cursor until the node reports no more entries,
+    /// and returns all matching [`StateItem`]s. Pass an empty `prefix` for the
+    /// whole state. `page_size` of `0` lets the node choose its default.
+    ///
+    /// All pages are read against the same `block` so the result is a
+    /// consistent snapshot.
+    #[tracing::instrument(skip(self, prefix, block), fields(%account_id))]
+    pub async fn view_state_all(
+        &self,
+        account_id: &AccountId,
+        prefix: &[u8],
+        page_size: u32,
+        block: BlockReference,
+    ) -> Result<Vec<StateItem>, RpcError> {
+        let limit = (page_size > 0).then_some(page_size);
+        let mut all = Vec::new();
+        let mut after_key: Option<Vec<u8>> = None;
+        loop {
+            let page = self
+                .view_state(
+                    account_id,
+                    prefix,
+                    after_key.as_deref(),
+                    limit,
+                    block.clone(),
+                )
+                .await?;
+            all.extend(page.values);
+            match page.last_key {
+                Some(cursor) => after_key = Some(cursor),
+                None => break,
+            }
+        }
+        Ok(all)
     }
 
     /// Get block information.

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -95,9 +95,9 @@ pub use rpc::{
     ExecutionStatus, FinalExecutionOutcome, FinalExecutionStatus, GasPrice, GasProfileEntry,
     GlobalContractIdentifierView, MerkleDirection, MerklePathItem, NodeVersion, NonceMode,
     RawTransactionResponse, Receipt, ReceiptContent, ReceiptToTxResponse, STORAGE_AMOUNT_PER_BYTE,
-    SendTxResponse, SlashedValidator, StatusResponse, SyncInfo, TransactionNonceView,
+    SendTxResponse, SlashedValidator, StateItem, StatusResponse, SyncInfo, TransactionNonceView,
     TransactionView, TrieSplit, ValidatorInfo, ValidatorStakeView, ValidatorStakeViewV1,
-    VersionedDelegateActionPayloadView, ViewFunctionResult,
+    VersionedDelegateActionPayloadView, ViewFunctionResult, ViewStateResult,
 };
 pub use rpc_extra::{
     BlockHeaderInnerLiteView, CurrentEpochValidatorInfo, EpochValidatorInfo,

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -213,6 +213,40 @@ pub struct AccessKeyInfoView {
 }
 
 // ============================================================================
+// view_state
+// ============================================================================
+
+/// A single contract state entry (key/value), as returned by `view_state`.
+///
+/// `key` and `value` are raw bytes; they are base64-encoded on the wire.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct StateItem {
+    /// Raw state key bytes.
+    #[serde_as(as = "Base64")]
+    pub key: Vec<u8>,
+    /// Raw state value bytes.
+    #[serde_as(as = "Base64")]
+    pub value: Vec<u8>,
+}
+
+/// Result of a `view_state` query (one page).
+///
+/// When the trie holds more entries than `limit`, [`ViewStateResult::last_key`]
+/// is the continuation cursor: pass it back as `after_key` to fetch the next
+/// page. It is `None` on the last page.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ViewStateResult {
+    /// The contract state entries in this page.
+    pub values: Vec<StateItem>,
+    /// Continuation cursor (raw key bytes). Absent on the last page.
+    #[serde_as(as = "Option<Base64>")]
+    #[serde(default)]
+    pub last_key: Option<Vec<u8>>,
+}
+
+// ============================================================================
 // Block types
 // ============================================================================
 
@@ -1342,6 +1376,35 @@ mod tests {
         assert!(list.keys[0].public_key.is_ml_dsa65_hash());
         assert_eq!(list.keys[0].public_key.key_type(), KeyType::MlDsa65);
         assert_eq!(list.keys[1].public_key.key_type(), KeyType::Ed25519);
+    }
+
+    #[test]
+    fn test_view_state_result_deserializes_with_cursor() {
+        // `key`/`value`/`last_key` are base64 on the wire.
+        let json = serde_json::json!({
+            "values": [
+                { "key": STANDARD.encode(b"STATE"), "value": STANDARD.encode(b"v1") },
+                { "key": STANDARD.encode(b"k2"), "value": STANDARD.encode([0u8, 1, 2]) }
+            ],
+            "last_key": STANDARD.encode(b"k2")
+        });
+        let result: ViewStateResult = serde_json::from_value(json).unwrap();
+        assert_eq!(result.values.len(), 2);
+        assert_eq!(result.values[0].key, b"STATE");
+        assert_eq!(result.values[0].value, b"v1");
+        assert_eq!(result.values[1].value, vec![0u8, 1, 2]);
+        assert_eq!(result.last_key.as_deref(), Some(b"k2".as_slice()));
+    }
+
+    #[test]
+    fn test_view_state_result_last_page_has_no_cursor() {
+        // The final page omits `last_key`.
+        let json = serde_json::json!({
+            "values": [{ "key": STANDARD.encode(b"k"), "value": STANDARD.encode(b"v") }]
+        });
+        let result: ViewStateResult = serde_json::from_value(json).unwrap();
+        assert_eq!(result.values.len(), 1);
+        assert!(result.last_key.is_none());
     }
 
     fn make_account_view(amount: u128, locked: u128, storage_usage: u64) -> AccountView {

--- a/crates/near-kit/tests/integration/main.rs
+++ b/crates/near-kit/tests/integration/main.rs
@@ -27,3 +27,4 @@ mod transaction_outcome_integration;
 mod typed_contract_error_integration;
 mod typed_contract_integration;
 mod typed_error_integration;
+mod view_state_integration;

--- a/crates/near-kit/tests/integration/view_state_integration.rs
+++ b/crates/near-kit/tests/integration/view_state_integration.rs
@@ -1,0 +1,124 @@
+//! Integration tests for the `view_state` RPC method and its pagination.
+//!
+//! # Sandbox image
+//!
+//! `view_state` pagination (`after_key_base64` / `limit` / `last_key`) is newer
+//! than the default `2.13.0-rc.2` image, which ignores `limit` and returns the
+//! whole state in one page. We therefore run against the `pre-release` tag,
+//! which includes pagination. Drop the override once a 2.13 RC ships with it.
+
+use near_kit::sandbox::{Sandbox, SandboxConfig};
+use near_kit::*;
+
+/// Sandbox image tag that supports `view_state` pagination.
+const VIEW_STATE_SANDBOX_VERSION: &str = "pre-release";
+
+/// A fresh sandbox running a node that supports `view_state` pagination.
+async fn paginating_sandbox() -> Sandbox {
+    SandboxConfig::builder()
+        .version(VIEW_STATE_SANDBOX_VERSION)
+        .fresh()
+        .await
+}
+
+/// Deploy the guestbook contract to a fresh account and return its id.
+async fn deploy_guestbook(near: &Near, contract_account: &str) {
+    let wasm_code = std::fs::read("tests/contracts/guestbook.wasm")
+        .expect("guestbook.wasm not found in tests/contracts/");
+    let new_key = SecretKey::generate_ed25519();
+    near.transaction(contract_account)
+        .create_account()
+        .transfer("10 NEAR")
+        .add_full_access_key(new_key.public_key())
+        .deploy(wasm_code)
+        .send()
+        .wait_until(Final)
+        .await
+        .expect("deploy guestbook");
+}
+
+#[tokio::test]
+async fn test_view_state_pagination_reads_all_entries() {
+    let sandbox = paginating_sandbox().await;
+    let near = Near::sandbox(&sandbox);
+
+    let contract_id = format!("vstate.{}", sandbox.root_account_id());
+    deploy_guestbook(&near, &contract_id).await;
+
+    // Populate state: each message extends the on-trie Vector, adding entries.
+    const N: usize = 8;
+    for i in 0..N {
+        near.transaction(&contract_id)
+            .call("add_message")
+            .args(serde_json::json!({ "text": format!("message number {i}") }))
+            .send()
+            .wait_until(Final)
+            .await
+            .expect("add_message");
+    }
+
+    let contract: AccountId = contract_id.parse().unwrap();
+
+    // Single-page call with a small limit must return a continuation cursor.
+    let first = near
+        .rpc()
+        .view_state(&contract, &[], None, Some(2), BlockReference::final_())
+        .await
+        .expect("view_state page");
+    assert!(!first.values.is_empty());
+    assert!(first.values.len() <= 2, "limit must be honored");
+    assert!(
+        first.last_key.is_some(),
+        "with more entries than the limit, a cursor must be returned"
+    );
+
+    // Following the cursor yields different entries than the first page.
+    let second = near
+        .rpc()
+        .view_state(
+            &contract,
+            &[],
+            first.last_key.as_deref(),
+            Some(2),
+            BlockReference::final_(),
+        )
+        .await
+        .expect("view_state page 2");
+    assert!(!second.values.is_empty());
+    assert_ne!(
+        first.values[0].key, second.values[0].key,
+        "second page should start after the first page's cursor"
+    );
+
+    // The paginating helper must collect every entry, matching an unpaginated read.
+    let all_paged = near
+        .rpc()
+        .view_state_all(&contract, &[], 2, BlockReference::final_())
+        .await
+        .expect("view_state_all paged");
+    let all_unpaged = near
+        .rpc()
+        .view_state_all(&contract, &[], 0, BlockReference::final_())
+        .await
+        .expect("view_state_all unpaged");
+
+    assert_eq!(
+        all_paged, all_unpaged,
+        "paginated and single-shot reads must agree"
+    );
+    assert!(
+        all_paged.len() >= N,
+        "expected at least {N} state entries, got {}",
+        all_paged.len()
+    );
+
+    // Prefix filtering: every returned key must start with the requested prefix.
+    let prefix = &all_paged[0].key[..1];
+    let filtered = near
+        .rpc()
+        .view_state_all(&contract, prefix, 0, BlockReference::final_())
+        .await
+        .expect("view_state_all prefix");
+    assert!(!filtered.is_empty());
+    assert!(filtered.iter().all(|item| item.key.starts_with(prefix)));
+}

--- a/crates/near-kit/tests/integration/view_state_integration.rs
+++ b/crates/near-kit/tests/integration/view_state_integration.rs
@@ -21,7 +21,7 @@ async fn paginating_sandbox() -> Sandbox {
         .await
 }
 
-/// Deploy the guestbook contract to a fresh account and return its id.
+/// Deploy the guestbook contract to the given (freshly created) account.
 async fn deploy_guestbook(near: &Near, contract_account: &str) {
     let wasm_code = std::fs::read("tests/contracts/guestbook.wasm")
         .expect("guestbook.wasm not found in tests/contracts/");

--- a/crates/near-kit/tests/integration/view_state_integration.rs
+++ b/crates/near-kit/tests/integration/view_state_integration.rs
@@ -90,30 +90,31 @@ async fn test_view_state_pagination_reads_all_entries() {
         "second page should start after the first page's cursor"
     );
 
-    // The paginating helper must collect every entry, matching an unpaginated read.
-    let all_paged = near
+    // The paginating helper must collect every entry regardless of page size:
+    // a small explicit limit vs. the node-default page size (page_size = 0).
+    let all_small_pages = near
         .rpc()
         .view_state_all(&contract, &[], 2, BlockReference::final_())
         .await
-        .expect("view_state_all paged");
-    let all_unpaged = near
+        .expect("view_state_all with small pages");
+    let all_default_page = near
         .rpc()
         .view_state_all(&contract, &[], 0, BlockReference::final_())
         .await
-        .expect("view_state_all unpaged");
+        .expect("view_state_all with node-default page size");
 
     assert_eq!(
-        all_paged, all_unpaged,
-        "paginated and single-shot reads must agree"
+        all_small_pages, all_default_page,
+        "small-page and node-default-page reads must collect the same entries"
     );
     assert!(
-        all_paged.len() >= N,
+        all_small_pages.len() >= N,
         "expected at least {N} state entries, got {}",
-        all_paged.len()
+        all_small_pages.len()
     );
 
     // Prefix filtering: every returned key must start with the requested prefix.
-    let prefix = &all_paged[0].key[..1];
+    let prefix = &all_small_pages[0].key[..1];
     let filtered = near
         .rpc()
         .view_state_all(&contract, prefix, 0, BlockReference::final_())


### PR DESCRIPTION
## Cause
near-kit-rs had no `view_state` RPC method, so callers couldn't read a contract's raw key/value state. Protocol 2.13 also adds continuation-cursor pagination (`after_key_base64` / `limit` / `last_key`) for large state.

## Change
- `RpcClient::view_state(account_id, prefix, after_key, limit, block)`: one page via the unified `query` method (`request_type: view_state`), sending `prefix_base64` / `after_key_base64` / `limit`, returning a `ViewStateResult` whose `last_key` is the next-page cursor (absent on the last page).
- `RpcClient::view_state_all(account_id, prefix, page_size, block)`: follows the cursor against a fixed block until exhausted, returning all `StateItem`s — a consistent snapshot.
- New `StateItem` / `ViewStateResult` types (base64 key/value, optional `last_key`), exported.

## How tested
- Unit tests: `ViewStateResult` deserialization with and without a cursor.
- On-chain integration test: deploys a contract, writes 9 state entries, then verifies a `limit=2` page returns exactly 2 entries + a cursor, the cursor advances to a different page, `view_state_all` (paged vs single-shot) agree, and prefix filtering only returns matching keys.
- `cargo build/clippy/test --all-features` + fmt clean.

## Sandbox image note
`view_state` pagination is newer than the default `2.13.0-rc.2` image, which ignores `limit` and returns the whole state in one page. The integration test therefore runs against the `pre-release` tag (same v85 protocol line, with pagination). The override can be dropped once a 2.13 RC ships with it.