### PR TITLE
feat(types): ExecutionMetadata V4 typed contracts field

### DIFF
--- a/crates/near-kit/CHANGELOG.md
+++ b/crates/near-kit/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   / `last_key`): `RpcClient::view_state` for a single page and
   `RpcClient::view_state_all` to read a contract's full state across pages.
   Adds `StateItem` / `ViewStateResult` types.
+- *(types)* complete the 2.13 typed read path so node-accepted 2.13 transactions
+  deserialize through the high-level `FinalExecutionOutcome` / `.send()` path
+  instead of forcing raw JSON: `ExecutionMetadata` V4 (`contracts` field +
+  `AccountContractView`), `ActionView::TransferToGasKey`/`WithdrawFromGasKey`,
+  and `AccessKeyPermissionView::GasKeyFunctionCall`/`GasKeyFullAccess`. JSON wire
+  format stays back-compatible (V1–V3 metadata omit `contracts`) (protocol 2.13).
 
 ### Changed
 

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -97,8 +97,8 @@ pub use rpc::{
     MerklePathItem, NodeVersion, NonceMode, RawTransactionResponse, Receipt, ReceiptContent,
     ReceiptToTxResponse, STORAGE_AMOUNT_PER_BYTE, SendTxResponse, SlashedValidator, StateItem,
     StatusResponse, SyncInfo, TransactionNonceView, TransactionView, TrieSplit, ValidatorInfo,
-    ValidatorStakeView, ValidatorStakeViewV1, VersionedDelegateActionPayloadView, ViewFunctionResult,
-    ViewStateResult,
+    ValidatorStakeView, ValidatorStakeViewV1, VersionedDelegateActionPayloadView,
+    ViewFunctionResult, ViewStateResult,
 };
 pub use rpc_extra::{
     BlockHeaderInnerLiteView, CurrentEpochValidatorInfo, EpochValidatorInfo,

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -88,16 +88,17 @@ pub use key::{
 pub use network::ChainId;
 pub use rpc::{
     AccessKeyDetails, AccessKeyInfoView, AccessKeyListView, AccessKeyPermissionView, AccessKeyView,
-    AccountBalance, AccountView, ActionReceiptData, ActionView, BandwidthRequest,
-    BandwidthRequestBitmap, BandwidthRequests, BandwidthRequestsV1, BlockHeaderView, BlockView,
-    ChunkHeaderView, CongestionInfoView, DataReceiptData, DataReceiverView, DelegateActionV2View,
-    DelegateActionView, ExecutionMetadata, ExecutionOutcome, ExecutionOutcomeWithId,
-    ExecutionStatus, FinalExecutionOutcome, FinalExecutionStatus, GasPrice, GasProfileEntry,
-    GlobalContractIdentifierView, MerkleDirection, MerklePathItem, NodeVersion, NonceMode,
-    RawTransactionResponse, Receipt, ReceiptContent, ReceiptToTxResponse, STORAGE_AMOUNT_PER_BYTE,
-    SendTxResponse, SlashedValidator, StateItem, StatusResponse, SyncInfo, TransactionNonceView,
-    TransactionView, TrieSplit, ValidatorInfo, ValidatorStakeView, ValidatorStakeViewV1,
-    VersionedDelegateActionPayloadView, ViewFunctionResult, ViewStateResult,
+    AccountBalance, AccountContractView, AccountView, ActionReceiptData, ActionView,
+    BandwidthRequest, BandwidthRequestBitmap, BandwidthRequests, BandwidthRequestsV1,
+    BlockHeaderView, BlockView, ChunkHeaderView, CongestionInfoView, DataReceiptData,
+    DataReceiverView, DelegateActionV2View, DelegateActionView, ExecutionMetadata,
+    ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus, FinalExecutionOutcome,
+    FinalExecutionStatus, GasPrice, GasProfileEntry, GlobalContractIdentifierView, MerkleDirection,
+    MerklePathItem, NodeVersion, NonceMode, RawTransactionResponse, Receipt, ReceiptContent,
+    ReceiptToTxResponse, STORAGE_AMOUNT_PER_BYTE, SendTxResponse, SlashedValidator, StateItem,
+    StatusResponse, SyncInfo, TransactionNonceView, TransactionView, TrieSplit, ValidatorInfo,
+    ValidatorStakeView, ValidatorStakeViewV1, VersionedDelegateActionPayloadView, ViewFunctionResult,
+    ViewStateResult,
 };
 pub use rpc_extra::{
     BlockHeaderInnerLiteView, CurrentEpochValidatorInfo, EpochValidatorInfo,

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -1099,8 +1099,10 @@ pub struct ExecutionMetadata {
     ///
     /// The inner `Option` is `None` (JSON `null`) when the account had no
     /// contract at that point (no code, or it did not yet exist). The outer
-    /// `Option` is `None` for older metadata versions (V1–V3), which omit the
-    /// field entirely — so this stays backward-compatible.
+    /// `Option` is `None` when the field is absent (older V1–V3 metadata) or
+    /// explicitly `null`. Note this is *wire-format* back-compatibility: adding
+    /// this public field is itself a (minor) Rust API change for code that
+    /// constructs/destructures `ExecutionMetadata`.
     #[serde(default)]
     pub contracts: Option<Vec<Option<AccountContractView>>>,
 }

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -1088,11 +1088,38 @@ pub struct ExecutionOutcome {
 /// Execution metadata with gas profiling.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ExecutionMetadata {
-    /// Metadata version.
+    /// Metadata version (V1=1, V2=2, V3=3, V4=4).
     pub version: u32,
     /// Gas profile entries.
     #[serde(default)]
     pub gas_profile: Option<Vec<GasProfileEntry>>,
+    /// The contract attached to the receiver account immediately before each
+    /// action in the receipt ran — one entry per action, in order
+    /// (`ExecutionMetadata` V4+, protocol 2.13).
+    ///
+    /// The inner `Option` is `None` (JSON `null`) when the account had no
+    /// contract at that point (no code, or it did not yet exist). The outer
+    /// `Option` is `None` for older metadata versions (V1–V3), which omit the
+    /// field entirely — so this stays backward-compatible.
+    #[serde(default)]
+    pub contracts: Option<Vec<Option<AccountContractView>>>,
+}
+
+/// The contract attached to an account, as reported per-action in
+/// [`ExecutionMetadata::contracts`] (V4+).
+///
+/// A receipt action with no contract is represented as `None` in the
+/// surrounding `Option`, so this enum only covers the cases where a contract
+/// was present.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountContractView {
+    /// A regular contract deployed to the account, identified by its code hash.
+    Local(CryptoHash),
+    /// A global contract referenced by its code hash.
+    GlobalHash(CryptoHash),
+    /// A global contract referenced by the account that deployed it.
+    GlobalAccountId(AccountId),
 }
 
 /// Gas profile entry for detailed gas accounting.
@@ -1405,6 +1432,52 @@ mod tests {
         let result: ViewStateResult = serde_json::from_value(json).unwrap();
         assert_eq!(result.values.len(), 1);
         assert!(result.last_key.is_none());
+    }
+
+    #[test]
+    fn test_execution_metadata_v4_contracts_parsed() {
+        // Captured from a 2.13 node: V4 metadata with one contract per action.
+        let json = serde_json::json!({
+            "version": 4,
+            "gas_profile": [],
+            "contracts": [
+                null,
+                { "local": "11111111111111111111111111111111" },
+                { "global_hash": "11111111111111111111111111111111" },
+                { "global_account_id": "contract.near" }
+            ]
+        });
+        let meta: ExecutionMetadata = serde_json::from_value(json).unwrap();
+        assert_eq!(meta.version, 4);
+        let contracts = meta.contracts.expect("V4 carries contracts");
+        assert_eq!(contracts.len(), 4);
+        assert!(contracts[0].is_none());
+        assert!(matches!(contracts[1], Some(AccountContractView::Local(_))));
+        assert!(matches!(
+            contracts[2],
+            Some(AccountContractView::GlobalHash(_))
+        ));
+        match &contracts[3] {
+            Some(AccountContractView::GlobalAccountId(id)) => {
+                assert_eq!(id.as_str(), "contract.near")
+            }
+            other => panic!("expected global_account_id, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_execution_metadata_v3_has_no_contracts() {
+        // V1-V3 omit `contracts`; parsing must stay backward-compatible.
+        let json = serde_json::json!({
+            "version": 3,
+            "gas_profile": [
+                { "cost_category": "WASM_HOST_COST", "cost": "BASE", "gas_used": "100" }
+            ]
+        });
+        let meta: ExecutionMetadata = serde_json::from_value(json).unwrap();
+        assert_eq!(meta.version, 3);
+        assert!(meta.contracts.is_none());
+        assert_eq!(meta.gas_profile.as_ref().unwrap().len(), 1);
     }
 
     fn make_account_view(amount: u128, locked: u128, storage_usage: u64) -> AccountView {

--- a/crates/near-kit/tests/integration/exec_metadata_integration.rs
+++ b/crates/near-kit/tests/integration/exec_metadata_integration.rs
@@ -1,0 +1,69 @@
+//! Integration test for parsing ExecutionMetadata V4 (protocol 2.13) through
+//! the high-level outcome path.
+//!
+//! Before V4 was modeled, a 2.13 receipt's `metadata: {version: 4, contracts:
+//! [...]}` could break `FinalExecutionOutcome` deserialization: the
+//! `#[serde(flatten)] Option<FinalExecutionOutcome>` silently becomes `None`
+//! when any nested field fails to parse, surfacing as "no execution outcome".
+//! This test confirms a real 2.13 outcome round-trips through the typed
+//! `.send().wait_until(Final)` path and exposes the V4 `contracts` field.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use near_kit::sandbox::{SANDBOX_ROOT_ACCOUNT, SandboxConfig};
+use near_kit::*;
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_account() -> AccountId {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("execmeta{}.{}", n, SANDBOX_ROOT_ACCOUNT)
+        .parse()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn test_v4_execution_metadata_parses_through_send() {
+    let sandbox = SandboxConfig::shared().await;
+    let near = sandbox.client();
+
+    // A create_account + transfer produces receipt outcomes on a 2.13 node.
+    // If V4 metadata didn't parse, `.send()` would fail to deserialize the
+    // outcome entirely (the bug this guards against).
+    let key = SecretKey::generate_ed25519();
+    let account_id = unique_account();
+    let outcome = near
+        .transaction(&account_id)
+        .create_account()
+        .transfer(NearToken::from_near(5))
+        .add_full_access_key(key.public_key())
+        .send()
+        .wait_until(Final)
+        .await
+        .expect("create_account outcome must deserialize (incl. V4 metadata)");
+
+    // The transaction-level outcome always carries metadata; assert it parsed.
+    let tx_meta = outcome
+        .transaction_outcome
+        .outcome
+        .metadata
+        .as_ref()
+        .expect("transaction outcome should carry metadata");
+    assert!(tx_meta.version >= 1);
+
+    // On a protocol-v85+ node the receipt outcomes carry V4 metadata, whose
+    // typed `contracts` field must be exposed (one entry per action).
+    let protocol = near.rpc().status().await.expect("status").protocol_version;
+    if protocol >= 85 {
+        let v4 = outcome
+            .receipts_outcome
+            .iter()
+            .filter_map(|r| r.outcome.metadata.as_ref())
+            .find(|m| m.version >= 4);
+        let v4 = v4.expect("expected a V4 ExecutionMetadata on a v85+ node");
+        assert!(
+            v4.contracts.is_some(),
+            "V4 metadata must expose the typed `contracts` field"
+        );
+    }
+}

--- a/crates/near-kit/tests/integration/main.rs
+++ b/crates/near-kit/tests/integration/main.rs
@@ -12,6 +12,7 @@ mod delegate_action_integration;
 mod delegate_v2_integration;
 mod error_consolidation_integration;
 mod error_handling_integration;
+mod exec_metadata_integration;
 mod gas_key_transaction_integration;
 mod global_contracts_integration;
 mod ml_dsa_integration;


### PR DESCRIPTION
## Cause
Protocol 2.13 introduces `ExecutionMetadata` V4, which reports the contract attached to the receiver account immediately before each action in a receipt ran. near-kit-rs parsed metadata generically (`version` + `gas_profile`), so the new per-action `contracts` field was silently dropped.

## Change
- Add `ExecutionMetadata::contracts: Option<Vec<Option<AccountContractView>>>` — one entry per action; inner `None` (JSON `null`) = no contract on that account; outer `None` = pre-V4 metadata.
- Add `AccountContractView { Local(CryptoHash), GlobalHash(CryptoHash), GlobalAccountId(AccountId) }`, a snake_case externally-tagged enum matching nearcore's `AccountContractView`.
- Exported from the crate root.

Back-compatible: V1-V3 metadata omit `contracts` and parse exactly as before.

## How tested
- Unit test from a captured V4 fixture covering all cases: `null`, `local`, `global_hash`, `global_account_id`.
- Unit test for a V3 fixture confirming `contracts` is `None` and existing fields still parse.
- `cargo build/clippy/test --all-features` + fmt clean.