### PR TITLE
feat(rpc): thin wrappers for stabilized 2.13 RPC methods

### DIFF
--- a/crates/near-kit/CHANGELOG.md
+++ b/crates/near-kit/CHANGELOG.md
@@ -38,6 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AccountContractView`), `ActionView::TransferToGasKey`/`WithdrawFromGasKey`,
   and `AccessKeyPermissionView::GasKeyFunctionCall`/`GasKeyFullAccess`. JSON wire
   format stays back-compatible (V1–V3 metadata omit `contracts`) (protocol 2.13).
+- *(rpc)* thin wrappers for the stabilized 2.13 methods: `RpcClient::block_effects`
+  (→ `BlockEffects`), `RpcClient::genesis_config` (raw JSON), and
+  `RpcClient::maintenance_windows` (→ `Vec<MaintenanceWindow>`). The renamed
+  methods replace the `EXPERIMENTAL_` aliases, which the node still accepts.
 
 ### Changed
 

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -9,9 +9,10 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use crate::error::RpcError;
 use crate::types::rpc::RawTransactionResponse;
 use crate::types::{
-    AccessKeyListView, AccessKeyView, AccountId, AccountView, BlockReference, BlockView,
-    CryptoHash, EpochValidatorInfo, GasPrice, PublicKey, ReceiptToTxResponse, SignedTransaction,
-    StateItem, StatusResponse, TxExecutionStatus, ViewFunctionResult, ViewStateResult,
+    AccessKeyListView, AccessKeyView, AccountId, AccountView, BlockEffects, BlockReference,
+    BlockView, CryptoHash, EpochValidatorInfo, GasPrice, MaintenanceWindow, PublicKey,
+    ReceiptToTxResponse, SignedTransaction, StateItem, StatusResponse, TxExecutionStatus,
+    ViewFunctionResult, ViewStateResult,
 };
 
 /// Network configuration presets.
@@ -668,6 +669,40 @@ impl RpcClient {
     pub async fn block(&self, block: BlockReference) -> Result<BlockView, RpcError> {
         let params = block.to_rpc_params();
         self.call("block", params).await
+    }
+
+    /// Get all state changes that occurred in a block.
+    ///
+    /// Uses the stabilized `block_effects` method (protocol 2.13), the new name
+    /// for `EXPERIMENTAL_changes_in_block`.
+    #[tracing::instrument(skip(self, block))]
+    pub async fn block_effects(&self, block: BlockReference) -> Result<BlockEffects, RpcError> {
+        let params = block.to_rpc_params();
+        self.call("block_effects", params).await
+    }
+
+    /// Get the network's genesis configuration as raw JSON.
+    ///
+    /// Uses the stabilized `genesis_config` method (protocol 2.13), the new name
+    /// for `EXPERIMENTAL_genesis_config`. The genesis config is a large,
+    /// network-specific document, so it is returned as untyped JSON.
+    #[tracing::instrument(skip(self))]
+    pub async fn genesis_config(&self) -> Result<serde_json::Value, RpcError> {
+        self.call("genesis_config", serde_json::json!(null)).await
+    }
+
+    /// Get the upcoming maintenance windows for a validator account.
+    ///
+    /// Each window is a half-open block-height range during which the validator
+    /// has no block/chunk production duties. Uses the stabilized
+    /// `maintenance_windows` method (protocol 2.13).
+    #[tracing::instrument(skip(self), fields(%account_id))]
+    pub async fn maintenance_windows(
+        &self,
+        account_id: &AccountId,
+    ) -> Result<Vec<MaintenanceWindow>, RpcError> {
+        let params = serde_json::json!({ "account_id": account_id.to_string() });
+        self.call("maintenance_windows", params).await
     }
 
     /// Get node status.

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -688,7 +688,10 @@ impl RpcClient {
     /// network-specific document, so it is returned as untyped JSON.
     #[tracing::instrument(skip(self))]
     pub async fn genesis_config(&self) -> Result<serde_json::Value, RpcError> {
-        self.call("genesis_config", serde_json::json!(null)).await
+        // Send an empty params array (not `null`) — this is what the other
+        // no-arg methods here use, and some JSON-RPC servers require `params` to
+        // be an array/object.
+        self.call("genesis_config", serde_json::json!([])).await
     }
 
     /// Get the upcoming maintenance windows for a validator account.

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -89,16 +89,16 @@ pub use network::ChainId;
 pub use rpc::{
     AccessKeyDetails, AccessKeyInfoView, AccessKeyListView, AccessKeyPermissionView, AccessKeyView,
     AccountBalance, AccountContractView, AccountView, ActionReceiptData, ActionView,
-    BandwidthRequest, BandwidthRequestBitmap, BandwidthRequests, BandwidthRequestsV1,
+    BandwidthRequest, BandwidthRequestBitmap, BandwidthRequests, BandwidthRequestsV1, BlockEffects,
     BlockHeaderView, BlockView, ChunkHeaderView, CongestionInfoView, DataReceiptData,
     DataReceiverView, DelegateActionV2View, DelegateActionView, ExecutionMetadata,
     ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus, FinalExecutionOutcome,
-    FinalExecutionStatus, GasPrice, GasProfileEntry, GlobalContractIdentifierView, MerkleDirection,
-    MerklePathItem, NodeVersion, NonceMode, RawTransactionResponse, Receipt, ReceiptContent,
-    ReceiptToTxResponse, STORAGE_AMOUNT_PER_BYTE, SendTxResponse, SlashedValidator, StateItem,
-    StatusResponse, SyncInfo, TransactionNonceView, TransactionView, TrieSplit, ValidatorInfo,
-    ValidatorStakeView, ValidatorStakeViewV1, VersionedDelegateActionPayloadView,
-    ViewFunctionResult, ViewStateResult,
+    FinalExecutionStatus, GasPrice, GasProfileEntry, GlobalContractIdentifierView, MaintenanceWindow,
+    MerkleDirection, MerklePathItem, NodeVersion, NonceMode, RawTransactionResponse, Receipt,
+    ReceiptContent, ReceiptToTxResponse, STORAGE_AMOUNT_PER_BYTE, SendTxResponse, SlashedValidator,
+    StateChangeKindView, StateItem, StatusResponse, SyncInfo, TransactionNonceView, TransactionView,
+    TrieSplit, ValidatorInfo, ValidatorStakeView, ValidatorStakeViewV1,
+    VersionedDelegateActionPayloadView, ViewFunctionResult, ViewStateResult,
 };
 pub use rpc_extra::{
     BlockHeaderInnerLiteView, CurrentEpochValidatorInfo, EpochValidatorInfo,

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -93,12 +93,12 @@ pub use rpc::{
     BlockHeaderView, BlockView, ChunkHeaderView, CongestionInfoView, DataReceiptData,
     DataReceiverView, DelegateActionV2View, DelegateActionView, ExecutionMetadata,
     ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus, FinalExecutionOutcome,
-    FinalExecutionStatus, GasPrice, GasProfileEntry, GlobalContractIdentifierView, MaintenanceWindow,
-    MerkleDirection, MerklePathItem, NodeVersion, NonceMode, RawTransactionResponse, Receipt,
-    ReceiptContent, ReceiptToTxResponse, STORAGE_AMOUNT_PER_BYTE, SendTxResponse, SlashedValidator,
-    StateChangeKindView, StateItem, StatusResponse, SyncInfo, TransactionNonceView, TransactionView,
-    TrieSplit, ValidatorInfo, ValidatorStakeView, ValidatorStakeViewV1,
-    VersionedDelegateActionPayloadView, ViewFunctionResult, ViewStateResult,
+    FinalExecutionStatus, GasPrice, GasProfileEntry, GlobalContractIdentifierView,
+    MaintenanceWindow, MerkleDirection, MerklePathItem, NodeVersion, NonceMode,
+    RawTransactionResponse, Receipt, ReceiptContent, ReceiptToTxResponse, STORAGE_AMOUNT_PER_BYTE,
+    SendTxResponse, SlashedValidator, StateChangeKindView, StateItem, StatusResponse, SyncInfo,
+    TransactionNonceView, TransactionView, TrieSplit, ValidatorInfo, ValidatorStakeView,
+    ValidatorStakeViewV1, VersionedDelegateActionPayloadView, ViewFunctionResult, ViewStateResult,
 };
 pub use rpc_extra::{
     BlockHeaderInnerLiteView, CurrentEpochValidatorInfo, EpochValidatorInfo,

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -8,6 +8,7 @@ use serde_with::{base64::Base64, serde_as};
 
 use super::block_reference::TxExecutionStatus;
 use super::error::{ActionError, TxExecutionError};
+use super::rpc_extra::StateChangeWithCauseView;
 use super::{AccountId, CryptoHash, Gas, NearToken, PublicKey, Signature};
 
 // ============================================================================
@@ -244,6 +245,31 @@ pub struct ViewStateResult {
     #[serde_as(as = "Option<Base64>")]
     #[serde(default)]
     pub last_key: Option<Vec<u8>>,
+}
+
+// ============================================================================
+// Stabilized RPC method responses (protocol 2.13)
+// ============================================================================
+
+/// All state changes within a single block, from the `block_effects` RPC
+/// (stabilized name for `EXPERIMENTAL_changes_in_block`).
+#[derive(Debug, Clone, Deserialize)]
+pub struct BlockEffects {
+    /// Hash of the block these changes belong to.
+    pub block_hash: CryptoHash,
+    /// The state changes applied in this block.
+    pub changes: Vec<StateChangeWithCauseView>,
+}
+
+/// A single maintenance window — a half-open block-height range
+/// `[start, end)` during which a validator has no chunk/block production
+/// duties. Returned by the `maintenance_windows` RPC.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub struct MaintenanceWindow {
+    /// First block height of the window (inclusive).
+    pub start: u64,
+    /// Block height the window ends at (exclusive).
+    pub end: u64,
 }
 
 // ============================================================================

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -8,7 +8,6 @@ use serde_with::{base64::Base64, serde_as};
 
 use super::block_reference::TxExecutionStatus;
 use super::error::{ActionError, TxExecutionError};
-use super::rpc_extra::StateChangeWithCauseView;
 use super::{AccountId, CryptoHash, Gas, NearToken, PublicKey, Signature};
 
 // ============================================================================
@@ -251,14 +250,46 @@ pub struct ViewStateResult {
 // Stabilized RPC method responses (protocol 2.13)
 // ============================================================================
 
+/// One entry in a [`BlockEffects`] response: which kind of state was touched
+/// for an account in the block.
+///
+/// `block_effects` reports only the *kind* of change per account (no cause or
+/// value), so this is a lighter view than the per-account
+/// `StateChangeWithCauseView`.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum StateChangeKindView {
+    /// The account itself (balance, etc.) was touched.
+    AccountTouched {
+        /// The account that was touched.
+        account_id: AccountId,
+    },
+    /// One of the account's access keys was touched.
+    AccessKeyTouched {
+        /// The account that was touched.
+        account_id: AccountId,
+    },
+    /// The account's contract data (storage) was touched.
+    DataTouched {
+        /// The account that was touched.
+        account_id: AccountId,
+    },
+    /// The account's contract code was touched.
+    ContractCodeTouched {
+        /// The account that was touched.
+        account_id: AccountId,
+    },
+}
+
 /// All state changes within a single block, from the `block_effects` RPC
 /// (stabilized name for `EXPERIMENTAL_changes_in_block`).
 #[derive(Debug, Clone, Deserialize)]
 pub struct BlockEffects {
     /// Hash of the block these changes belong to.
     pub block_hash: CryptoHash,
-    /// The state changes applied in this block.
-    pub changes: Vec<StateChangeWithCauseView>,
+    /// The kinds of state change applied in this block (one entry per touched
+    /// account/state-kind).
+    pub changes: Vec<StateChangeKindView>,
 }
 
 /// A single maintenance window — a half-open block-height range

--- a/crates/near-kit/tests/integration/main.rs
+++ b/crates/near-kit/tests/integration/main.rs
@@ -20,6 +20,7 @@ mod offline_signing_integration;
 mod rpc_types_integration;
 mod sandbox_integration;
 mod signer_edge_cases_integration;
+mod stabilized_rpc_integration;
 mod token_error_integration;
 mod token_integration;
 mod tracing_integration;

--- a/crates/near-kit/tests/integration/stabilized_rpc_integration.rs
+++ b/crates/near-kit/tests/integration/stabilized_rpc_integration.rs
@@ -1,0 +1,55 @@
+//! Integration tests for the stabilized 2.13 RPC method wrappers:
+//! `block_effects`, `genesis_config`, and `maintenance_windows`.
+
+use near_kit::sandbox::{SANDBOX_ROOT_ACCOUNT, SandboxConfig};
+use near_kit::*;
+
+#[tokio::test]
+async fn test_genesis_config_returns_chain_config() {
+    let sandbox = SandboxConfig::shared().await;
+    let near = sandbox.client();
+
+    let config = near.rpc().genesis_config().await.expect("genesis_config");
+    // The genesis document always carries a chain id and a protocol version.
+    assert!(
+        config.get("chain_id").and_then(|v| v.as_str()).is_some(),
+        "genesis_config should include chain_id, got: {config}"
+    );
+    assert!(
+        config.get("protocol_version").is_some(),
+        "genesis_config should include protocol_version"
+    );
+}
+
+#[tokio::test]
+async fn test_block_effects_returns_changes_for_latest_block() {
+    let sandbox = SandboxConfig::shared().await;
+    let near = sandbox.client();
+
+    let effects = near
+        .rpc()
+        .block_effects(BlockReference::final_())
+        .await
+        .expect("block_effects");
+    // block_hash is always present; `changes` may be empty for an idle block.
+    assert_ne!(effects.block_hash, CryptoHash::default());
+}
+
+#[tokio::test]
+async fn test_maintenance_windows_for_account() {
+    let sandbox = SandboxConfig::shared().await;
+    let near = sandbox.client();
+
+    let account: AccountId = SANDBOX_ROOT_ACCOUNT.parse().unwrap();
+    // The root account is the sandbox's sole validator, so this must not error.
+    // Windows may be empty depending on the epoch; the call succeeding and the
+    // ranges being well-formed (start <= end) is the contract under test.
+    let windows = near
+        .rpc()
+        .maintenance_windows(&account)
+        .await
+        .expect("maintenance_windows");
+    for w in &windows {
+        assert!(w.start <= w.end, "window range must be well-formed: {w:?}");
+    }
+}

--- a/crates/near-kit/tests/integration/stabilized_rpc_integration.rs
+++ b/crates/near-kit/tests/integration/stabilized_rpc_integration.rs
@@ -26,13 +26,23 @@ async fn test_block_effects_returns_changes_for_latest_block() {
     let sandbox = SandboxConfig::shared().await;
     let near = sandbox.client();
 
+    // Resolve a concrete finalized block first, then ask for its effects by
+    // hash. Requesting effects for a specific block (rather than the moving
+    // `final` reference) avoids a finality-resolution race under load.
+    let block = near
+        .rpc()
+        .block(BlockReference::final_())
+        .await
+        .expect("block");
+    let block_hash = block.header.hash;
+
     let effects = near
         .rpc()
-        .block_effects(BlockReference::final_())
+        .block_effects(BlockReference::at_hash(block_hash))
         .await
         .expect("block_effects");
-    // block_hash is always present; `changes` may be empty for an idle block.
-    assert_ne!(effects.block_hash, CryptoHash::default());
+    // The response echoes the queried block; `changes` may be empty for an idle block.
+    assert_eq!(effects.block_hash, block_hash);
 }
 
 #[tokio::test]

--- a/crates/near-kit/tests/integration/stabilized_rpc_integration.rs
+++ b/crates/near-kit/tests/integration/stabilized_rpc_integration.rs
@@ -1,8 +1,19 @@
 //! Integration tests for the stabilized 2.13 RPC method wrappers:
 //! `block_effects`, `genesis_config`, and `maintenance_windows`.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use near_kit::sandbox::{SANDBOX_ROOT_ACCOUNT, SandboxConfig};
 use near_kit::*;
+
+static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_account() -> AccountId {
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("blockfx{n}.{SANDBOX_ROOT_ACCOUNT}")
+        .parse()
+        .unwrap()
+}
 
 #[tokio::test]
 async fn test_genesis_config_returns_chain_config() {
@@ -25,27 +36,48 @@ async fn test_genesis_config_returns_chain_config() {
 }
 
 #[tokio::test]
-async fn test_block_effects_returns_changes_for_latest_block() {
+async fn test_block_effects_returns_changes_for_block() {
     let sandbox = SandboxConfig::shared().await;
     let near = sandbox.client();
 
-    // Resolve a concrete finalized block first, then ask for its effects by
-    // hash. Requesting effects for a specific block (rather than the moving
-    // `final` reference) avoids a finality-resolution race under load.
-    let block = near
-        .rpc()
-        .block(BlockReference::final_())
+    // Produce a block we know contains state changes: create an account. Then
+    // query that exact block's effects by hash (a fixed block, not the moving
+    // `final` reference) and assert the kind-changes parse — this exercises the
+    // non-empty path that an idle `final` block would not.
+    let key = SecretKey::generate_ed25519();
+    let account_id = unique_account();
+    let outcome = near
+        .transaction(&account_id)
+        .create_account()
+        .transfer(NearToken::from_near(3))
+        .add_full_access_key(key.public_key())
+        .send()
+        .wait_until(Final)
         .await
-        .expect("block");
-    let block_hash = block.header.hash;
+        .expect("create_account must execute");
 
+    let block_hash = outcome.transaction_outcome.block_hash;
     let effects = near
         .rpc()
         .block_effects(BlockReference::at_hash(block_hash))
         .await
-        .expect("block_effects");
-    // The response echoes the queried block; `changes` may be empty for an idle block.
+        .expect("block_effects must parse");
+
     assert_eq!(effects.block_hash, block_hash);
+    assert!(
+        !effects.changes.is_empty(),
+        "a block that created an account should report touched state"
+    );
+    // Every change kind exposes the account it touched.
+    for change in &effects.changes {
+        let touched = match change {
+            StateChangeKindView::AccountTouched { account_id }
+            | StateChangeKindView::AccessKeyTouched { account_id }
+            | StateChangeKindView::DataTouched { account_id }
+            | StateChangeKindView::ContractCodeTouched { account_id } => account_id,
+        };
+        let _ = touched;
+    }
 }
 
 #[tokio::test]

--- a/crates/near-kit/tests/integration/stabilized_rpc_integration.rs
+++ b/crates/near-kit/tests/integration/stabilized_rpc_integration.rs
@@ -16,8 +16,11 @@ async fn test_genesis_config_returns_chain_config() {
         "genesis_config should include chain_id, got: {config}"
     );
     assert!(
-        config.get("protocol_version").is_some(),
-        "genesis_config should include protocol_version"
+        config
+            .get("protocol_version")
+            .and_then(|v| v.as_u64())
+            .is_some(),
+        "genesis_config should include a numeric protocol_version, got: {config}"
     );
 }
 


### PR DESCRIPTION
## Cause
Protocol 2.13 stabilizes three `EXPERIMENTAL_` RPC methods under new names (the old aliases still work). near-kit-rs had no typed wrappers for them, so callers had to use the raw `call()` API.

## Change
- `RpcClient::block_effects(block)` → `BlockEffects { block_hash, changes: Vec<StateChangeWithCauseView> }` (stabilized `EXPERIMENTAL_changes_in_block`).
- `RpcClient::genesis_config()` → `serde_json::Value` (stabilized `EXPERIMENTAL_genesis_config`; the genesis document is large and network-specific, so it's returned as raw JSON rather than a partial typed struct).
- `RpcClient::maintenance_windows(account_id)` → `Vec<MaintenanceWindow { start, end }>` (half-open block-height ranges).

## How tested
- Integration tests against the sandbox: `genesis_config` carries `chain_id` + `protocol_version`; `block_effects` returns a real `block_hash`; `maintenance_windows` returns well-formed ranges (`start <= end`). These stabilized names work on the default `2.13.0-rc.2` image (they're renames of methods already in the binary).
- `cargo build/clippy/test --all-features` + fmt clean.