### PR TITLE
feat(types): impl IntoGlobalContractId for GlobalContractId

### DIFF
--- a/crates/near-kit/CHANGELOG.md
+++ b/crates/near-kit/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- *(types)* `impl IntoGlobalContractId for GlobalContractId` so an
+  already-constructed `GlobalContractId` can be passed directly to `deploy_from`
+  (identity conversion).
 - *(types)* gas-key transacting: `TransactionV1` with `TransactionNonce`
   (incl. `GasKeyNonce { nonce, nonce_index }`) and `NonceMode`, the
   backward-compatible custom borsh scheme (V0 tag-less, V1 `0x01`-tagged),

--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -40,7 +40,8 @@ pub enum PublishMode {
 ///
 /// This allows `deploy_from` to accept either a `CryptoHash` (for immutable
 /// contracts) or an account ID string/`AccountId` (for publisher-updatable contracts),
-/// converting into the canonical [`GlobalContractId`].
+/// converting into the canonical [`GlobalContractId`]. An already-constructed
+/// [`GlobalContractId`] is accepted as-is (identity conversion).
 ///
 /// # Panics
 ///
@@ -48,6 +49,12 @@ pub enum PublishMode {
 /// valid NEAR account ID.
 pub trait IntoGlobalContractId {
     fn into_identifier(self) -> GlobalContractId;
+}
+
+impl IntoGlobalContractId for GlobalContractId {
+    fn into_identifier(self) -> GlobalContractId {
+        self
+    }
 }
 
 impl IntoGlobalContractId for CryptoHash {
@@ -1466,6 +1473,17 @@ mod tests {
         let json = serde_json::to_string(&id).unwrap();
         let decoded: GlobalContractId = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded, id);
+    }
+
+    #[test]
+    fn test_global_contract_id_into_identifier_is_identity() {
+        // An already-constructed `GlobalContractId` is accepted by `deploy_from`
+        // and passes through unchanged.
+        let by_hash = GlobalContractId::CodeHash(*CryptoHash::hash(&[1, 2, 3]).as_bytes());
+        assert_eq!(by_hash.clone().into_identifier(), by_hash);
+
+        let by_account = GlobalContractId::AccountId("publisher.near".parse().unwrap());
+        assert_eq!(by_account.clone().into_identifier(), by_account);
     }
 
     #[test]


### PR DESCRIPTION
Adds `impl IntoGlobalContractId for GlobalContractId` — an identity conversion so an already-constructed `GlobalContractId` can be passed straight to `deploy_from(...)`, alongside the existing `CryptoHash` / `AccountId` / `&str` / `String` impls.

## Why

From the [Slack thread](https://nearone.slack.com/archives/C0A64SAMDNG/p1782824069721549?thread_ts=1778510239.791719&cid=C0A64SAMDNG) (defuse / intents tests). Their sandbox helpers publish a contract globally and hand back a `GlobalContractId`; they then want to deploy an account from it via `deploy_from(global_id)`. Previously `deploy_from` accepted `CryptoHash` / `AccountId` / `&str` but not a `GlobalContractId` already in hand, forcing a manual `add_action(Action::UseGlobalContract(UseGlobalContractAction { … }))` workaround. This closes that gap.

## Notes

- Trait doc updated to mention the identity case.
- Added `test_global_contract_id_into_identifier_is_identity` covering both variants.
- CHANGELOG entry under `[Unreleased] / Added`.