### PR TITLE
feat(client): surface partial tx outcome at early wait levels

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -898,7 +898,12 @@ impl Near {
     ///   (with `receipts` populated)
     /// - Non-executed levels ([`Submitted`](crate::types::Submitted),
     ///   [`Included`](crate::types::Included), [`IncludedFinal`](crate::types::IncludedFinal))
-    ///   → [`SendTxResponse`](crate::types::SendTxResponse)
+    ///   → [`SendTxResponse`](crate::types::SendTxResponse), whose
+    ///   [`outcome`](crate::types::SendTxResponse::outcome) carries the *partial*
+    ///   execution outcome (`receipts_outcome`/`receipts`) as soon as the node
+    ///   has it. Unlike `send_tx`, `EXPERIMENTAL_tx_status` returns receipt data
+    ///   even at these early levels, so a frontend can poll here to drive a
+    ///   progressive UI without blocking for finality.
     ///
     /// # Example
     ///
@@ -908,6 +913,12 @@ impl Near {
     /// let outcome = near.tx_status(&tx_hash, "alice.testnet", Final).await?;
     /// println!("Gas used: {}", outcome.total_gas_used());
     /// println!("Receipts: {}", outcome.receipts.len());
+    ///
+    /// // Poll at an early level for progressive per-receipt status:
+    /// let status = near.tx_status(&tx_hash, "alice.testnet", Included).await?;
+    /// if let Some(partial) = &status.outcome {
+    ///     println!("Receipts so far: {}", partial.receipts_outcome.len());
+    /// }
     /// # Ok(())
     /// # }
     /// ```

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1619,8 +1619,10 @@ impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
                         Ok(response) => {
                             // W::convert handles the response appropriately:
                             // - Executed levels: extract outcome, check for InvalidTxError
-                            // - Non-executed levels: build SendTxResponse with hash + sender
-                            //   (send_tx returns no outcome at these levels, so it stays None)
+                            // - Non-executed levels: build SendTxResponse (hash + sender,
+                            //   plus SendTxResponse::outcome). On this send_tx path the
+                            //   node returns no outcome at early levels, so it stays None;
+                            //   the tx_status path is where outcome can be Some.
                             return W::convert(response, &signer_id);
                         }
                         Err(RpcError::InvalidTx(

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1620,6 +1620,7 @@ impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
                             // W::convert handles the response appropriately:
                             // - Executed levels: extract outcome, check for InvalidTxError
                             // - Non-executed levels: build SendTxResponse with hash + sender
+                            //   (send_tx returns no outcome at these levels, so it stays None)
                             return W::convert(response, &signer_id);
                         }
                         Err(RpcError::InvalidTx(

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -640,9 +640,28 @@ pub enum FinalExecutionStatus {
 ///
 /// When you use a non-executed wait level ([`Submitted`](crate::types::Submitted),
 /// [`Included`](crate::types::Included), [`IncludedFinal`](crate::types::IncludedFinal)),
-/// the transaction hasn't been executed yet so there's no outcome to return.
-/// This type gives you the information needed to poll for the result later
-/// via [`Near::tx_status`](crate::Near::tx_status).
+/// the transaction hasn't finished executing, so this type carries the
+/// information needed to poll for the final result later via
+/// [`Near::tx_status`](crate::Near::tx_status).
+///
+/// # The `outcome` field
+///
+/// Whether a (partial) execution outcome is available depends on which RPC
+/// produced the response, not on the wait level alone:
+///
+/// - Via [`Near::send`](crate::Near::send) / `.send()` (the `send_tx` RPC): the
+///   node returns no execution outcome at these early levels, so `outcome` is
+///   [`None`].
+/// - Via [`Near::tx_status`](crate::Near::tx_status) (the `EXPERIMENTAL_tx_status`
+///   RPC): the node returns the *partial* outcome as soon as it has one — its
+///   `receipts_outcome` (per-receipt status) and `receipts` (so a receiver_id
+///   can be mapped to a UI stage) — even at `Submitted`/`Included`. `outcome` is
+///   [`Some`] once that data exists. This is what lets a frontend poll
+///   `tx_status` at an early wait level to drive a progressive UI without
+///   blocking for finality.
+///
+/// The outcome is exposed as-is (not validated); inspect
+/// [`FinalExecutionOutcome::status`] to see how far execution has progressed.
 ///
 /// # Example
 ///
@@ -653,12 +672,18 @@ pub enum FinalExecutionStatus {
 ///     .wait_until(Included)
 ///     .await?;
 ///
-/// // Later, poll for the full outcome:
-/// let outcome = near.tx_status(
+/// // Later, poll for progress without waiting for finality. At early wait
+/// // levels EXPERIMENTAL_tx_status still returns per-receipt data:
+/// let status = near.tx_status(
 ///     &response.transaction_hash,
 ///     &response.sender_id,
-///     Final,
+///     Included,
 /// ).await?;
+/// if let Some(outcome) = &status.outcome {
+///     for receipt_outcome in &outcome.receipts_outcome {
+///         // drive a progressive UI from each receipt's status
+///     }
+/// }
 /// # Ok(())
 /// # }
 /// ```
@@ -668,6 +693,13 @@ pub struct SendTxResponse {
     pub transaction_hash: CryptoHash,
     /// Account ID of the transaction signer.
     pub sender_id: AccountId,
+    /// Partial execution outcome, when the RPC returned one.
+    ///
+    /// Populated (with `receipts_outcome`/`receipts`) when this response comes
+    /// from [`Near::tx_status`](crate::Near::tx_status) and the node already has
+    /// outcome data; [`None`] for the `send_tx` path at these early wait levels.
+    /// See the [type-level docs](SendTxResponse) for details.
+    pub outcome: Option<FinalExecutionOutcome>,
 }
 
 /// Response from `EXPERIMENTAL_receipt_to_tx`: the transaction that produced a receipt.

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -653,12 +653,13 @@ pub enum FinalExecutionStatus {
 ///   node returns no execution outcome at these early levels, so `outcome` is
 ///   [`None`].
 /// - Via [`Near::tx_status`](crate::Near::tx_status) (the `EXPERIMENTAL_tx_status`
-///   RPC): the node returns the *partial* outcome as soon as it has one — its
+///   RPC): the node returns the execution outcome as soon as it has one — its
 ///   `receipts_outcome` (per-receipt status) and `receipts` (so a receiver_id
 ///   can be mapped to a UI stage) — even at `Submitted`/`Included`. `outcome` is
-///   [`Some`] once that data exists. This is what lets a frontend poll
-///   `tx_status` at an early wait level to drive a progressive UI without
-///   blocking for finality.
+///   [`Some`] once that data exists. It is *partial* while the transaction is
+///   still running and *complete* once it has finished (e.g. when polling a tx
+///   that already settled). This is what lets a frontend poll `tx_status` at an
+///   early wait level to drive a progressive UI without blocking for finality.
 ///
 /// The outcome is exposed as-is (not validated); inspect
 /// [`FinalExecutionOutcome::status`] to see how far execution has progressed.
@@ -693,10 +694,12 @@ pub struct SendTxResponse {
     pub transaction_hash: CryptoHash,
     /// Account ID of the transaction signer.
     pub sender_id: AccountId,
-    /// Partial execution outcome, when the RPC returned one.
+    /// Execution outcome, when the RPC returned one.
     ///
-    /// Populated (with `receipts_outcome`/`receipts`) when this response comes
-    /// from [`Near::tx_status`](crate::Near::tx_status) and the node already has
+    /// May be partial (while the transaction is still executing) or complete
+    /// (when polling a tx that has already finished). Populated (with
+    /// `receipts_outcome`/`receipts`) when this response comes from
+    /// [`Near::tx_status`](crate::Near::tx_status) and the node already has
     /// outcome data; [`None`] for the `send_tx` path at these early wait levels.
     /// See the [type-level docs](SendTxResponse) for details.
     pub outcome: Option<FinalExecutionOutcome>,

--- a/crates/near-kit/src/types/wait_level.rs
+++ b/crates/near-kit/src/types/wait_level.rs
@@ -15,7 +15,8 @@
 //!     .wait_until(Final)
 //!     .await?;
 //!
-//! // Non-executed levels — returns SendTxResponse (hash + sender)
+//! // Non-executed levels — returns SendTxResponse (hash + sender, plus any
+//! // partial outcome the RPC has already produced)
 //! let response = near.transfer("bob.testnet", NearToken::from_near(1))
 //!     .wait_until(Included)
 //!     .await?;
@@ -53,7 +54,9 @@ pub trait WaitLevel: sealed::Sealed + Send + Sync + 'static {
     ///
     /// For executed levels, this extracts the outcome and checks for
     /// `InvalidTxError`. For non-executed levels, this builds a
-    /// [`SendTxResponse`] with the transaction hash and sender ID.
+    /// [`SendTxResponse`] with the transaction hash, sender ID, and any partial
+    /// execution outcome the RPC returned (present from `EXPERIMENTAL_tx_status`,
+    /// absent from `send_tx`).
     #[doc(hidden)]
     fn convert(
         response: RawTransactionResponse,
@@ -65,9 +68,26 @@ pub trait WaitLevel: sealed::Sealed + Send + Sync + 'static {
 // Non-executed wait levels → SendTxResponse
 // =============================================================================
 
+/// Build a [`SendTxResponse`], carrying through any partial execution outcome.
+///
+/// The outcome is present when the response comes from `EXPERIMENTAL_tx_status`
+/// (which returns `receipts_outcome`/`receipts` even at early wait levels) and
+/// absent when it comes from `send_tx` (which returns no outcome at these
+/// levels). The outcome is passed through as-is — not validated — so callers can
+/// inspect partial progress; final-status validation happens at executed levels.
+fn send_tx_response(response: RawTransactionResponse, sender_id: &AccountId) -> SendTxResponse {
+    SendTxResponse {
+        transaction_hash: response.transaction_hash,
+        sender_id: sender_id.clone(),
+        outcome: response.outcome,
+    }
+}
+
 /// Don't wait, return immediately after the RPC accepts the transaction.
 ///
-/// Returns [`SendTxResponse`] (no execution outcome available).
+/// Returns [`SendTxResponse`]. Its `outcome` is populated when polled via
+/// [`Near::tx_status`](crate::Near::tx_status) and the node already has receipt
+/// data; it is [`None`] on the `send_tx` path.
 ///
 /// Named `Submitted` instead of `None` to avoid shadowing `Option::None`.
 #[derive(Clone, Copy, Debug)]
@@ -83,16 +103,15 @@ impl WaitLevel for Submitted {
         response: RawTransactionResponse,
         sender_id: &AccountId,
     ) -> Result<Self::Response, Error> {
-        Ok(SendTxResponse {
-            transaction_hash: response.transaction_hash,
-            sender_id: sender_id.clone(),
-        })
+        Ok(send_tx_response(response, sender_id))
     }
 }
 
 /// Wait for the transaction to be included in a block.
 ///
-/// Returns [`SendTxResponse`] (no execution outcome available).
+/// Returns [`SendTxResponse`]. Its `outcome` is populated when polled via
+/// [`Near::tx_status`](crate::Near::tx_status) and the node already has receipt
+/// data; it is [`None`] on the `send_tx` path.
 #[derive(Clone, Copy, Debug)]
 pub struct Included;
 
@@ -106,16 +125,15 @@ impl WaitLevel for Included {
         response: RawTransactionResponse,
         sender_id: &AccountId,
     ) -> Result<Self::Response, Error> {
-        Ok(SendTxResponse {
-            transaction_hash: response.transaction_hash,
-            sender_id: sender_id.clone(),
-        })
+        Ok(send_tx_response(response, sender_id))
     }
 }
 
 /// Wait for the transaction's block to reach finality.
 ///
-/// Returns [`SendTxResponse`] (no execution outcome available).
+/// Returns [`SendTxResponse`]. Its `outcome` is populated when polled via
+/// [`Near::tx_status`](crate::Near::tx_status) and the node already has receipt
+/// data; it is [`None`] on the `send_tx` path.
 #[derive(Clone, Copy, Debug)]
 pub struct IncludedFinal;
 
@@ -129,10 +147,7 @@ impl WaitLevel for IncludedFinal {
         response: RawTransactionResponse,
         sender_id: &AccountId,
     ) -> Result<Self::Response, Error> {
-        Ok(SendTxResponse {
-            transaction_hash: response.transaction_hash,
-            sender_id: sender_id.clone(),
-        })
+        Ok(send_tx_response(response, sender_id))
     }
 }
 

--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -431,6 +431,68 @@ async fn test_tx_status_with_receipts() {
     }
 }
 
+/// At an early wait level, `tx_status` must surface the partial execution
+/// outcome (receipts_outcome/receipts) instead of dropping it.
+///
+/// `EXPERIMENTAL_tx_status` returns receipt data even at `Included`/`Submitted`
+/// (the wait level only controls how long the server blocks, not whether it
+/// returns an outcome), so a frontend can poll here to drive a progressive UI.
+/// The transaction is settled first so the outcome is deterministically present.
+#[tokio::test]
+async fn test_tx_status_early_wait_level_surfaces_receipts() {
+    let sandbox = SandboxConfig::shared().await;
+    let near = sandbox.client();
+
+    let root_account: AccountId = SANDBOX_ROOT_ACCOUNT.parse().unwrap();
+
+    // Execute a transaction and let it settle.
+    let receiver_key = SecretKey::generate_ed25519();
+    let receiver_id = unique_account();
+
+    let outcome = near
+        .transaction(&receiver_id)
+        .create_account()
+        .transfer(NearToken::from_near(2))
+        .add_full_access_key(receiver_key.public_key())
+        .send()
+        .wait_until(Final)
+        .await
+        .unwrap();
+
+    let tx_hash = outcome.transaction_hash();
+
+    // Poll at an early wait level (Included). Previously this dropped the
+    // outcome and returned only hash + sender; now it carries the partial
+    // outcome so the receipts are reachable.
+    let response: SendTxResponse = near
+        .tx_status(tx_hash, &root_account, Included)
+        .await
+        .unwrap();
+
+    assert_eq!(&response.transaction_hash, tx_hash);
+    assert_eq!(response.sender_id, root_account);
+
+    let partial = response
+        .outcome
+        .expect("tx_status at Included should surface the partial outcome, not drop it");
+
+    assert!(
+        !partial.receipts_outcome.is_empty(),
+        "early-level tx_status should expose receipts_outcome for progressive UI"
+    );
+    // EXPERIMENTAL_tx_status also populates full receipt details.
+    assert!(
+        !partial.receipts.is_empty(),
+        "early-level tx_status should expose receipts (receiver_id -> stage mapping)"
+    );
+
+    println!(
+        "Included-level tx_status surfaced {} receipt outcomes / {} receipts",
+        partial.receipts_outcome.len(),
+        partial.receipts.len()
+    );
+}
+
 // ============================================================================
 // Gas Price Tests
 // ============================================================================


### PR DESCRIPTION
## Cause

At the early wait levels (`Submitted`/`Included`/`IncludedFinal`), `WaitLevel::convert` built `SendTxResponse` from just the hash + sender and **dropped `response.outcome`**. So polling `Near::tx_status(hash, sender, Included)` — e.g. to drive a progressive wallet UI — could never reach the per-receipt data (`receipts_outcome`, `receipts`), even though `EXPERIMENTAL_tx_status` returns it at those levels. (`.send()`/`send_tx` genuinely returns no outcome there; `tx_status`/`EXPERIMENTAL_tx_status` returns the partial one — `wait_until` only controls blocking, not whether receipts come back.)

## Fix

Stop dropping it — add an optional `outcome` to `SendTxResponse` and pass it through:

```rust
pub struct SendTxResponse {
    pub transaction_hash: CryptoHash,
    pub sender_id: AccountId,
    pub outcome: Option<FinalExecutionOutcome>, // new
}
```

`None` on the `send_tx` path; `Some(partial)` on the `tx_status` path once the node has receipt data. No poll loop or subscribe helper — the caller owns the loop and the `receiver_id` → stage mapping.

## Example

Poll at `Included` and map receipts to UI stages as they execute:

```rust
use near_kit::*;

loop {
    let resp = near.tx_status(&tx_hash, &sender_id, Included).await?;
    let Some(outcome) = resp.outcome else { continue }; // not on chain yet

    // receiver_id tells you which stage a receipt belongs to (wallet contract vs. MPC signer, …)
    for r in &outcome.receipts {
        stage_for(&r.receiver_id);
    }
    // each receipt's status: Success / Failure / still pending → which stage is live
    for o in &outcome.receipts_outcome {
        update_ui(&o.outcome.status);
    }

    if outcome.is_success() { break }
    // sleep, then poll again
}
```

## API-shape decision (veto welcome)

Kept `WaitLevel::Response = SendTxResponse` and **added a field** rather than changing the associated `Response` type. Least-invasive: existing `transaction_hash`/`sender_id` reads compile untouched, and `Option<FinalExecutionOutcome>` models both paths (absent for send, present-and-partial for status) without a second type. One break: external struct-literal construction now needs the new field — but it's a response type (consumed, not constructed), and it's additive so it's a `feat:` minor. Happy to switch to a dedicated partial-outcome type if you'd prefer.

## Verification

`cargo build` / `test --lib` (500) / `test --doc` / `fmt --check` / `clippy --all-targets --all-features -D warnings` all green. New sandbox test `test_tx_status_early_wait_level_surfaces_receipts` polls `tx_status(.., Included)` and asserts `outcome` is `Some` with non-empty `receipts_outcome` **and** `receipts`; the send-path early-level tests still return `outcome: None`.
