### PR TITLE
feat: add near-cli migration prerequisites

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -2,6 +2,7 @@
 
 use std::sync::Arc;
 
+use reqwest::header::{HeaderMap, HeaderValue};
 use serde::de::DeserializeOwned;
 
 use crate::contract::ContractClient;
@@ -839,7 +840,9 @@ impl Near {
     /// Send a pre-signed transaction.
     ///
     /// Use this with transactions signed via `.sign()` for offline signing
-    /// or inspection before sending.
+    /// or inspection before sending. Both legacy
+    /// [`SignedTransaction`](crate::SignedTransaction) and versioned
+    /// [`SignedTransactionV1`](crate::SignedTransactionV1) values are accepted.
     ///
     /// # Example
     ///
@@ -862,7 +865,7 @@ impl Near {
     /// ```
     pub async fn send(
         &self,
-        signed_tx: &crate::types::SignedTransaction,
+        signed_tx: &(impl crate::types::SignedTransactionPayload + ?Sized),
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
         self.send_with_options(signed_tx, crate::types::ExecutedOptimistic)
             .await
@@ -879,10 +882,10 @@ impl Near {
     ///   → [`SendTxResponse`](crate::types::SendTxResponse)
     pub async fn send_with_options<W: crate::types::WaitLevel>(
         &self,
-        signed_tx: &crate::types::SignedTransaction,
+        signed_tx: &(impl crate::types::SignedTransactionPayload + ?Sized),
         _level: W,
     ) -> Result<W::Response, Error> {
-        let sender_id = &signed_tx.transaction.signer_id;
+        let sender_id = signed_tx.signer_id();
         let response = self.rpc.send_tx(signed_tx, W::status()).await?;
         W::convert(response, sender_id)
     }
@@ -1147,6 +1150,7 @@ impl std::fmt::Debug for Near {
 /// ```
 pub struct NearBuilder {
     rpc_url: String,
+    rpc_headers: HeaderMap,
     signer: Option<Arc<dyn Signer>>,
     retry_config: RetryConfig,
     chain_id: ChainId,
@@ -1158,6 +1162,7 @@ impl NearBuilder {
     fn new(rpc_url: impl Into<String>, chain_id: ChainId) -> Self {
         Self {
             rpc_url: rpc_url.into(),
+            rpc_headers: HeaderMap::new(),
             signer: None,
             retry_config: RetryConfig::default(),
             chain_id,
@@ -1211,6 +1216,34 @@ impl NearBuilder {
         self
     }
 
+    /// Add default HTTP headers to every RPC request.
+    ///
+    /// Existing headers with the same name are replaced. Credential-bearing
+    /// values should be marked sensitive before being passed here so their
+    /// `Debug` representation is redacted.
+    pub fn rpc_headers(mut self, headers: HeaderMap) -> Self {
+        self.rpc_headers.extend(headers);
+        self
+    }
+
+    /// Authenticate RPC requests with an `x-api-key` header.
+    ///
+    /// The key is validated as an HTTP header value and marked sensitive so it
+    /// cannot be exposed through header `Debug` output.
+    pub fn rpc_api_key(mut self, api_key: impl AsRef<str>) -> Result<Self, Error> {
+        let api_key = api_key.as_ref();
+        if api_key.is_empty() {
+            return Err(Error::Config("RPC API key cannot be empty".to_string()));
+        }
+
+        let mut value = HeaderValue::from_bytes(api_key.as_bytes()).map_err(|_| {
+            Error::Config("RPC API key is not a valid HTTP header value".to_string())
+        })?;
+        value.set_sensitive(true);
+        self.rpc_headers.insert("x-api-key", value);
+        Ok(self)
+    }
+
     /// Set the maximum number of transaction send attempts on `InvalidNonce` errors.
     ///
     /// When a transaction fails with `InvalidNonce`, the client automatically
@@ -1227,10 +1260,10 @@ impl NearBuilder {
     /// Build the client.
     pub fn build(self) -> Near {
         Near {
-            rpc: Arc::new(RpcClient::with_retry_config(
-                self.rpc_url,
-                self.retry_config,
-            )),
+            rpc: Arc::new(
+                RpcClient::with_retry_config(self.rpc_url, self.retry_config)
+                    .with_default_headers(self.rpc_headers),
+            ),
             signer: self.signer,
             chain_id: self.chain_id,
             max_nonce_retries: self.max_nonce_retries,

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -840,9 +840,7 @@ impl Near {
     /// Send a pre-signed transaction.
     ///
     /// Use this with transactions signed via `.sign()` for offline signing
-    /// or inspection before sending. Both legacy
-    /// [`SignedTransaction`](crate::SignedTransaction) and versioned
-    /// [`SignedTransactionV1`](crate::SignedTransactionV1) values are accepted.
+    /// or inspection before sending.
     ///
     /// # Example
     ///
@@ -865,7 +863,7 @@ impl Near {
     /// ```
     pub async fn send(
         &self,
-        signed_tx: &(impl crate::types::SignedTransactionPayload + ?Sized),
+        signed_tx: &crate::types::SignedTransaction,
     ) -> Result<crate::types::FinalExecutionOutcome, Error> {
         self.send_with_options(signed_tx, crate::types::ExecutedOptimistic)
             .await
@@ -882,10 +880,10 @@ impl Near {
     ///   → [`SendTxResponse`](crate::types::SendTxResponse)
     pub async fn send_with_options<W: crate::types::WaitLevel>(
         &self,
-        signed_tx: &(impl crate::types::SignedTransactionPayload + ?Sized),
+        signed_tx: &crate::types::SignedTransaction,
         _level: W,
     ) -> Result<W::Response, Error> {
-        let sender_id = signed_tx.signer_id();
+        let sender_id = &signed_tx.transaction.signer_id;
         let response = self.rpc.send_tx(signed_tx, W::status()).await?;
         W::convert(response, sender_id)
     }

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -4,15 +4,16 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
+use reqwest::header::HeaderMap;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::error::RpcError;
 use crate::types::rpc::RawTransactionResponse;
 use crate::types::{
     AccessKeyListView, AccessKeyView, AccountId, AccountView, BlockEffects, BlockReference,
-    BlockView, CryptoHash, EpochValidatorInfo, GasPrice, MaintenanceWindow, PublicKey,
-    ReceiptToTxResponse, SignedTransaction, StateItem, StatusResponse, TxExecutionStatus,
-    ViewFunctionResult, ViewStateResult,
+    BlockView, CryptoHash, EpochValidatorInfo, GasKeyNoncesView, GasPrice, MaintenanceWindow,
+    PublicKey, ReceiptToTxResponse, SignedTransactionPayload, StateItem, StatusResponse,
+    TxExecutionStatus, ViewFunctionResult, ViewStateResult,
 };
 
 /// Platform-appropriate async sleep, used for retry backoff.
@@ -138,6 +139,7 @@ struct CallFunctionResponse {
 pub struct RpcClient {
     url: String,
     client: reqwest::Client,
+    default_headers: HeaderMap,
     retry_config: RetryConfig,
     request_id: AtomicU64,
 }
@@ -148,6 +150,7 @@ impl RpcClient {
         Self {
             url: url.into(),
             client: reqwest::Client::new(),
+            default_headers: HeaderMap::new(),
             retry_config: RetryConfig::default(),
             request_id: AtomicU64::new(0),
         }
@@ -158,9 +161,21 @@ impl RpcClient {
         Self {
             url: url.into(),
             client: reqwest::Client::new(),
+            default_headers: HeaderMap::new(),
             retry_config,
             request_id: AtomicU64::new(0),
         }
+    }
+
+    /// Add default HTTP headers to every RPC request.
+    ///
+    /// This is useful for authenticated RPC providers. Header values that contain
+    /// credentials should be marked sensitive with
+    /// [`HeaderValue::set_sensitive`](reqwest::header::HeaderValue::set_sensitive)
+    /// before being passed here so their `Debug` representation is redacted.
+    pub fn with_default_headers(mut self, headers: HeaderMap) -> Self {
+        self.default_headers = headers;
+        self
     }
 
     /// Get the RPC URL.
@@ -228,6 +243,7 @@ impl RpcClient {
         let response = self
             .client
             .post(&self.url)
+            .headers(self.default_headers.clone())
             .header("Content-Type", "application/json")
             .json(request)
             .send()
@@ -548,6 +564,26 @@ impl RpcClient {
         self.call("EXPERIMENTAL_view_access_key_list", params).await
     }
 
+    /// View the parallel nonces assigned to a gas key.
+    ///
+    /// This uses the stabilized `query` RPC shape with
+    /// `request_type: "view_gas_key_nonces"`.
+    #[tracing::instrument(skip(self, block), fields(%account_id, %public_key))]
+    pub async fn view_gas_key_nonces(
+        &self,
+        account_id: &AccountId,
+        public_key: &PublicKey,
+        block: BlockReference,
+    ) -> Result<GasKeyNoncesView, RpcError> {
+        let mut params = serde_json::json!({
+            "request_type": "view_gas_key_nonces",
+            "account_id": account_id.to_string(),
+            "public_key": public_key.to_string(),
+        });
+        self.merge_block_reference(&mut params, &block);
+        self.call("query", params).await
+    }
+
     /// Call a view function on a contract.
     #[tracing::instrument(skip(self, args, block), fields(contract_id = %account_id, method = method_name))]
     pub async fn view_function(
@@ -756,21 +792,24 @@ impl RpcClient {
     }
 
     /// Send a signed transaction.
+    ///
+    /// Accepts both legacy [`SignedTransaction`](crate::SignedTransaction) values
+    /// and versioned [`SignedTransactionV1`](crate::SignedTransactionV1) values.
     #[tracing::instrument(skip(self, signed_tx), fields(
         tx_hash = tracing::field::Empty,
-        sender = %signed_tx.transaction.signer_id,
-        receiver = %signed_tx.transaction.receiver_id,
+        sender = %signed_tx.signer_id(),
+        receiver = %signed_tx.receiver_id(),
         ?wait_until,
     ))]
     pub async fn send_tx(
         &self,
-        signed_tx: &SignedTransaction,
+        signed_tx: &(impl SignedTransactionPayload + ?Sized),
         wait_until: TxExecutionStatus,
     ) -> Result<RawTransactionResponse, RpcError> {
-        let tx_hash = signed_tx.get_hash();
+        let tx_hash = signed_tx.transaction_hash();
         tracing::Span::current().record("tx_hash", tracing::field::display(&tx_hash));
         let params = serde_json::json!({
-            "signed_tx_base64": signed_tx.to_base64(),
+            "signed_tx_base64": signed_tx.encoded_base64(),
             "wait_until": wait_until.as_str(),
         });
         let mut response: RawTransactionResponse = self.call("send_tx", params).await?;
@@ -916,6 +955,7 @@ impl Clone for RpcClient {
         Self {
             url: self.url.clone(),
             client: self.client.clone(),
+            default_headers: self.default_headers.clone(),
             retry_config: self.retry_config.clone(),
             request_id: AtomicU64::new(0),
         }
@@ -997,7 +1037,112 @@ fn preserve_http_retry_classification(err: RpcError, status: u16, body: &str) ->
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::mpsc;
+
+    use reqwest::header::{HeaderMap, HeaderValue};
+
     use super::*;
+    use crate::{
+        Action, NearToken, SecretKey, SignedTransaction, SignedTransactionPayload,
+        SignedTransactionV1, Transaction, TransactionNonce, TransactionNonceMode, TransactionV1,
+    };
+
+    fn spawn_rpc_capture_server() -> (String, std::thread::JoinHandle<serde_json::Value>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 4096];
+            let header_end = loop {
+                let read = stream.read(&mut buffer).unwrap();
+                assert!(read > 0, "connection closed before request headers");
+                request.extend_from_slice(&buffer[..read]);
+                if let Some(position) = request.windows(4).position(|window| window == b"\r\n\r\n")
+                {
+                    break position + 4;
+                }
+            };
+
+            let headers = std::str::from_utf8(&request[..header_end]).unwrap();
+            let content_length: usize = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse().unwrap())
+                })
+                .expect("request must include content-length");
+
+            while request.len() < header_end + content_length {
+                let read = stream.read(&mut buffer).unwrap();
+                assert!(read > 0, "connection closed before request body");
+                request.extend_from_slice(&buffer[..read]);
+            }
+
+            let request_json: serde_json::Value =
+                serde_json::from_slice(&request[header_end..header_end + content_length]).unwrap();
+            let response_body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": request_json["id"].clone(),
+                "result": { "final_execution_status": "NONE" },
+            })
+            .to_string();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body,
+            )
+            .unwrap();
+
+            request_json
+        });
+
+        (format!("http://{address}"), server)
+    }
+
+    async fn capture_send_tx_request(
+        signed_tx: &(impl SignedTransactionPayload + ?Sized),
+        wait_until: TxExecutionStatus,
+    ) -> (serde_json::Value, RawTransactionResponse) {
+        let (url, server) = spawn_rpc_capture_server();
+        let response = RpcClient::new(url)
+            .send_tx(signed_tx, wait_until)
+            .await
+            .unwrap();
+        (server.join().unwrap(), response)
+    }
+
+    fn sample_signed_v0() -> SignedTransaction {
+        let secret = SecretKey::generate_ed25519();
+        Transaction::new(
+            "alice.testnet".parse().unwrap(),
+            secret.public_key(),
+            7,
+            "bob.testnet".parse().unwrap(),
+            CryptoHash::ZERO,
+            vec![Action::transfer(NearToken::from_near(1))],
+        )
+        .sign(&secret)
+    }
+
+    fn sample_signed_v1() -> SignedTransactionV1 {
+        let secret = SecretKey::generate_ed25519();
+        TransactionV1 {
+            signer_id: "alice.testnet".parse().unwrap(),
+            public_key: secret.public_key(),
+            nonce: TransactionNonce::from_nonce_and_index(11, 2),
+            receiver_id: "bob.testnet".parse().unwrap(),
+            block_hash: CryptoHash::ZERO,
+            actions: vec![Action::transfer(NearToken::from_near(2))],
+            nonce_mode: TransactionNonceMode::Strict,
+        }
+        .sign(&secret)
+    }
 
     // ========================================================================
     // RetryConfig tests
@@ -1066,6 +1211,107 @@ mod tests {
         let debug = format!("{:?}", client);
         assert!(debug.contains("RpcClient"));
         assert!(debug.contains("rpc.testnet.near.org"));
+    }
+
+    #[test]
+    fn test_rpc_client_debug_redacts_default_headers() {
+        let secret = "super-secret-rpc-api-key";
+        let mut value = HeaderValue::from_static(secret);
+        value.set_sensitive(true);
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", value);
+
+        let client = RpcClient::new("https://rpc.testnet.near.org").with_default_headers(headers);
+        let debug = format!("{client:?}");
+
+        assert!(!debug.contains(secret));
+        assert!(!debug.contains("x-api-key"));
+    }
+
+    #[tokio::test]
+    async fn test_near_builder_sends_rpc_api_key_header() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (request_tx, request_rx) = mpsc::channel();
+
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = Vec::new();
+            let mut buffer = [0u8; 1024];
+            loop {
+                let read = stream.read(&mut buffer).unwrap();
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+            }
+            request_tx
+                .send(String::from_utf8(request).unwrap())
+                .unwrap();
+
+            let body = r#"{"jsonrpc":"2.0","id":0,"result":{"ok":true}}"#;
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body,
+            )
+            .unwrap();
+        });
+
+        let secret = "test-provider-secret";
+        let near = crate::Near::custom(format!("http://{address}"), "test")
+            .rpc_api_key(secret)
+            .unwrap()
+            .build();
+        let response: serde_json::Value = near.rpc().call("status", ()).await.unwrap();
+        assert_eq!(response, serde_json::json!({ "ok": true }));
+
+        let request = request_rx.recv().unwrap().to_ascii_lowercase();
+        assert!(request.contains(&format!("x-api-key: {secret}")));
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn test_near_builder_rejects_invalid_rpc_api_keys_without_echoing_them() {
+        for invalid in ["", "secret\nsecond-header: leaked"] {
+            let result = crate::Near::testnet().rpc_api_key(invalid);
+            let error = match result {
+                Ok(_) => panic!("invalid RPC API key was accepted"),
+                Err(error) => error,
+            };
+            if !invalid.is_empty() {
+                assert!(!error.to_string().contains(invalid));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_tx_encodes_legacy_v0_request() {
+        let signed = sample_signed_v0();
+        let (request, response) =
+            capture_send_tx_request(&signed, TxExecutionStatus::Included).await;
+
+        assert_eq!(request["method"], "send_tx");
+        assert_eq!(request["params"]["signed_tx_base64"], signed.to_base64());
+        assert_eq!(request["params"]["wait_until"], "INCLUDED");
+        assert_eq!(response.transaction_hash, signed.get_hash());
+    }
+
+    #[tokio::test]
+    async fn test_send_tx_encodes_versioned_v1_request() {
+        let signed = sample_signed_v1();
+        assert_eq!(signed.to_bytes()[0], 1, "V1 payload must retain its tag");
+
+        let (request, response) = capture_send_tx_request(&signed, TxExecutionStatus::Final).await;
+
+        assert_eq!(request["method"], "send_tx");
+        assert_eq!(request["params"]["signed_tx_base64"], signed.to_base64());
+        assert_eq!(request["params"]["wait_until"], "FINAL");
+        assert_eq!(response.transaction_hash, signed.get_hash());
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -12,7 +12,7 @@ use crate::types::rpc::RawTransactionResponse;
 use crate::types::{
     AccessKeyListView, AccessKeyView, AccountId, AccountView, BlockEffects, BlockReference,
     BlockView, CryptoHash, EpochValidatorInfo, GasKeyNoncesView, GasPrice, MaintenanceWindow,
-    PublicKey, ReceiptToTxResponse, SignedTransactionPayload, StateItem, StatusResponse,
+    PublicKey, ReceiptToTxResponse, SignedTransaction, StateItem, StatusResponse,
     TxExecutionStatus, ViewFunctionResult, ViewStateResult,
 };
 
@@ -793,23 +793,21 @@ impl RpcClient {
 
     /// Send a signed transaction.
     ///
-    /// Accepts both legacy [`SignedTransaction`](crate::SignedTransaction) values
-    /// and versioned [`SignedTransactionV1`](crate::SignedTransactionV1) values.
     #[tracing::instrument(skip(self, signed_tx), fields(
         tx_hash = tracing::field::Empty,
-        sender = %signed_tx.signer_id(),
-        receiver = %signed_tx.receiver_id(),
+        sender = %signed_tx.transaction.signer_id,
+        receiver = %signed_tx.transaction.receiver_id,
         ?wait_until,
     ))]
     pub async fn send_tx(
         &self,
-        signed_tx: &(impl SignedTransactionPayload + ?Sized),
+        signed_tx: &SignedTransaction,
         wait_until: TxExecutionStatus,
     ) -> Result<RawTransactionResponse, RpcError> {
-        let tx_hash = signed_tx.transaction_hash();
+        let tx_hash = signed_tx.get_hash();
         tracing::Span::current().record("tx_hash", tracing::field::display(&tx_hash));
         let params = serde_json::json!({
-            "signed_tx_base64": signed_tx.encoded_base64(),
+            "signed_tx_base64": signed_tx.to_base64(),
             "wait_until": wait_until.as_str(),
         });
         let mut response: RawTransactionResponse = self.call("send_tx", params).await?;
@@ -1044,106 +1042,6 @@ mod tests {
     use reqwest::header::{HeaderMap, HeaderValue};
 
     use super::*;
-    use crate::{
-        Action, NearToken, SecretKey, SignedTransaction, SignedTransactionPayload,
-        SignedTransactionV1, Transaction, TransactionNonce, TransactionNonceMode, TransactionV1,
-    };
-
-    fn spawn_rpc_capture_server() -> (String, std::thread::JoinHandle<serde_json::Value>) {
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let address = listener.local_addr().unwrap();
-
-        let server = std::thread::spawn(move || {
-            let (mut stream, _) = listener.accept().unwrap();
-            let mut request = Vec::new();
-            let mut buffer = [0u8; 4096];
-            let header_end = loop {
-                let read = stream.read(&mut buffer).unwrap();
-                assert!(read > 0, "connection closed before request headers");
-                request.extend_from_slice(&buffer[..read]);
-                if let Some(position) = request.windows(4).position(|window| window == b"\r\n\r\n")
-                {
-                    break position + 4;
-                }
-            };
-
-            let headers = std::str::from_utf8(&request[..header_end]).unwrap();
-            let content_length: usize = headers
-                .lines()
-                .find_map(|line| {
-                    let (name, value) = line.split_once(':')?;
-                    name.eq_ignore_ascii_case("content-length")
-                        .then(|| value.trim().parse().unwrap())
-                })
-                .expect("request must include content-length");
-
-            while request.len() < header_end + content_length {
-                let read = stream.read(&mut buffer).unwrap();
-                assert!(read > 0, "connection closed before request body");
-                request.extend_from_slice(&buffer[..read]);
-            }
-
-            let request_json: serde_json::Value =
-                serde_json::from_slice(&request[header_end..header_end + content_length]).unwrap();
-            let response_body = serde_json::json!({
-                "jsonrpc": "2.0",
-                "id": request_json["id"].clone(),
-                "result": { "final_execution_status": "NONE" },
-            })
-            .to_string();
-            write!(
-                stream,
-                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-                response_body.len(),
-                response_body,
-            )
-            .unwrap();
-
-            request_json
-        });
-
-        (format!("http://{address}"), server)
-    }
-
-    async fn capture_send_tx_request(
-        signed_tx: &(impl SignedTransactionPayload + ?Sized),
-        wait_until: TxExecutionStatus,
-    ) -> (serde_json::Value, RawTransactionResponse) {
-        let (url, server) = spawn_rpc_capture_server();
-        let response = RpcClient::new(url)
-            .send_tx(signed_tx, wait_until)
-            .await
-            .unwrap();
-        (server.join().unwrap(), response)
-    }
-
-    fn sample_signed_v0() -> SignedTransaction {
-        let secret = SecretKey::generate_ed25519();
-        Transaction::new(
-            "alice.testnet".parse().unwrap(),
-            secret.public_key(),
-            7,
-            "bob.testnet".parse().unwrap(),
-            CryptoHash::ZERO,
-            vec![Action::transfer(NearToken::from_near(1))],
-        )
-        .sign(&secret)
-    }
-
-    fn sample_signed_v1() -> SignedTransactionV1 {
-        let secret = SecretKey::generate_ed25519();
-        TransactionV1 {
-            signer_id: "alice.testnet".parse().unwrap(),
-            public_key: secret.public_key(),
-            nonce: TransactionNonce::from_nonce_and_index(11, 2),
-            receiver_id: "bob.testnet".parse().unwrap(),
-            block_hash: CryptoHash::ZERO,
-            actions: vec![Action::transfer(NearToken::from_near(2))],
-            nonce_mode: TransactionNonceMode::Strict,
-        }
-        .sign(&secret)
-    }
-
     // ========================================================================
     // RetryConfig tests
     // ========================================================================
@@ -1287,31 +1185,6 @@ mod tests {
                 assert!(!error.to_string().contains(invalid));
             }
         }
-    }
-
-    #[tokio::test]
-    async fn test_send_tx_encodes_legacy_v0_request() {
-        let signed = sample_signed_v0();
-        let (request, response) =
-            capture_send_tx_request(&signed, TxExecutionStatus::Included).await;
-
-        assert_eq!(request["method"], "send_tx");
-        assert_eq!(request["params"]["signed_tx_base64"], signed.to_base64());
-        assert_eq!(request["params"]["wait_until"], "INCLUDED");
-        assert_eq!(response.transaction_hash, signed.get_hash());
-    }
-
-    #[tokio::test]
-    async fn test_send_tx_encodes_versioned_v1_request() {
-        let signed = sample_signed_v1();
-        assert_eq!(signed.to_bytes()[0], 1, "V1 payload must retain its tag");
-
-        let (request, response) = capture_send_tx_request(&signed, TxExecutionStatus::Final).await;
-
-        assert_eq!(request["method"], "send_tx");
-        assert_eq!(request["params"]["signed_tx_base64"], signed.to_base64());
-        assert_eq!(request["params"]["wait_until"], "FINAL");
-        assert_eq!(response.transaction_hash, signed.get_hash());
     }
 
     // ========================================================================

--- a/crates/near-kit/src/types/action.rs
+++ b/crates/near-kit/src/types/action.rs
@@ -116,6 +116,9 @@ pub const DELEGATE_ACTION_PREFIX: u32 = 1_073_742_190;
 /// `DelegateActionV2`) when serializing for signing.
 pub const DELEGATE_V2_ACTION_PREFIX: u32 = 1_073_742_435;
 
+/// Maximum number of parallel nonces that a gas key may allocate.
+pub const MAX_NONCES_FOR_GAS_KEY: u16 = 1024;
+
 /// Gas key information.
 ///
 /// Gas keys are access keys with a prepaid balance to pay for gas costs.
@@ -147,6 +150,9 @@ pub enum AccessKeyPermission {
 }
 
 impl AccessKeyPermission {
+    /// Maximum number of parallel nonces that a gas key may allocate.
+    pub const MAX_NONCES_FOR_GAS_KEY: u16 = MAX_NONCES_FOR_GAS_KEY;
+
     /// Create a function call permission.
     pub fn function_call(
         receiver_id: AccountId,

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -107,9 +107,8 @@ pub use rpc_extra::{
     StateChangeValueView, StateChangeWithCauseView, ValidatorKickoutReason, ValidatorKickoutView,
 };
 pub use transaction::{
-    Nonce, NonceIndex, NonceMode as TransactionNonceMode, SignedTransaction,
-    SignedTransactionPayload, SignedTransactionV1, Transaction, TransactionNonce, TransactionV1,
-    VersionedTransaction,
+    Nonce, NonceIndex, NonceMode as TransactionNonceMode, SignedTransaction, SignedTransactionV1,
+    Transaction, TransactionNonce, TransactionV1, VersionedTransaction,
 };
 pub use units::{Gas, IntoGas, IntoNearToken, NearToken};
 pub use wait_level::{

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -66,10 +66,10 @@ pub use action::{
     DelegateAction, DelegateActionV2, DeleteAccountAction, DeleteKeyAction, DeployContractAction,
     DeployGlobalContractAction, DeterministicStateInitAction, FunctionCallAction,
     FunctionCallPermission, GasKeyInfo, GlobalContractDeployMode, GlobalContractId,
-    IntoGlobalContractId, NonDelegateAction, PublishMode, SignedDelegateAction, StakeAction,
-    StateInit, StateInitExt, StateInitV1, TransferAction, TransferToGasKeyAction,
-    UseGlobalContractAction, VersionedDelegateActionPayload, VersionedSignedDelegateAction,
-    WithdrawFromGasKeyAction,
+    IntoGlobalContractId, MAX_NONCES_FOR_GAS_KEY, NonDelegateAction, PublishMode,
+    SignedDelegateAction, StakeAction, StateInit, StateInitExt, StateInitV1, TransferAction,
+    TransferToGasKeyAction, UseGlobalContractAction, VersionedDelegateActionPayload,
+    VersionedSignedDelegateAction, WithdrawFromGasKeyAction,
 };
 pub use block_reference::{BlockReference, Finality, SyncCheckpoint, TxExecutionStatus};
 pub use error::{
@@ -93,12 +93,13 @@ pub use rpc::{
     BlockHeaderView, BlockView, ChunkHeaderView, CongestionInfoView, DataReceiptData,
     DataReceiverView, DelegateActionV2View, DelegateActionView, ExecutionMetadata,
     ExecutionOutcome, ExecutionOutcomeWithId, ExecutionStatus, FinalExecutionOutcome,
-    FinalExecutionStatus, GasPrice, GasProfileEntry, GlobalContractIdentifierView,
-    MaintenanceWindow, MerkleDirection, MerklePathItem, NodeVersion, NonceMode,
-    RawTransactionResponse, Receipt, ReceiptContent, ReceiptToTxResponse, STORAGE_AMOUNT_PER_BYTE,
-    SendTxResponse, SlashedValidator, StateChangeKindView, StateItem, StatusResponse, SyncInfo,
-    TransactionNonceView, TransactionView, TrieSplit, ValidatorInfo, ValidatorStakeView,
-    ValidatorStakeViewV1, VersionedDelegateActionPayloadView, ViewFunctionResult, ViewStateResult,
+    FinalExecutionStatus, GasKeyNoncesView, GasPrice, GasProfileEntry,
+    GlobalContractIdentifierView, MaintenanceWindow, MerkleDirection, MerklePathItem, NodeVersion,
+    NonceMode, RawTransactionResponse, Receipt, ReceiptContent, ReceiptToTxResponse,
+    STORAGE_AMOUNT_PER_BYTE, SendTxResponse, SlashedValidator, StateChangeKindView, StateItem,
+    StatusResponse, SyncInfo, TransactionNonceView, TransactionView, TrieSplit, ValidatorInfo,
+    ValidatorStakeView, ValidatorStakeViewV1, VersionedDelegateActionPayloadView,
+    ViewFunctionResult, ViewStateResult,
 };
 pub use rpc_extra::{
     BlockHeaderInnerLiteView, CurrentEpochValidatorInfo, EpochValidatorInfo,
@@ -106,8 +107,9 @@ pub use rpc_extra::{
     StateChangeValueView, StateChangeWithCauseView, ValidatorKickoutReason, ValidatorKickoutView,
 };
 pub use transaction::{
-    Nonce, NonceIndex, NonceMode as TransactionNonceMode, SignedTransaction, SignedTransactionV1,
-    Transaction, TransactionNonce, TransactionV1, VersionedTransaction,
+    Nonce, NonceIndex, NonceMode as TransactionNonceMode, SignedTransaction,
+    SignedTransactionPayload, SignedTransactionV1, Transaction, TransactionNonce, TransactionV1,
+    VersionedTransaction,
 };
 pub use units::{Gas, IntoGas, IntoNearToken, NearToken};
 pub use wait_level::{

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -8,7 +8,7 @@ use serde_with::{base64::Base64, serde_as};
 
 use super::block_reference::TxExecutionStatus;
 use super::error::{ActionError, TxExecutionError};
-use super::{AccountId, CryptoHash, Gas, NearToken, PublicKey, Signature};
+use super::{AccountId, CryptoHash, Gas, NearToken, Nonce, PublicKey, Signature};
 
 // ============================================================================
 // Constants
@@ -210,6 +210,17 @@ pub struct AccessKeyInfoView {
     pub public_key: PublicKey,
     /// Access key details.
     pub access_key: AccessKeyDetails,
+}
+
+/// Parallel nonces assigned to a gas key by `view_gas_key_nonces`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GasKeyNoncesView {
+    /// Nonces indexed in the same order as the gas key's nonce slots.
+    pub nonces: Vec<Nonce>,
+    /// Block height of the query.
+    pub block_height: u64,
+    /// Block hash of the query.
+    pub block_hash: CryptoHash,
 }
 
 // ============================================================================
@@ -1500,6 +1511,23 @@ mod tests {
     }
 
     #[test]
+    fn test_gas_key_nonces_view_deserialization() {
+        let json = serde_json::json!({
+            "nonces": [7, 11, 42],
+            "block_height": 12345,
+            "block_hash": "11111111111111111111111111111111"
+        });
+
+        let view: GasKeyNoncesView = serde_json::from_value(json).unwrap();
+        assert_eq!(view.nonces, vec![7, 11, 42]);
+        assert_eq!(view.block_height, 12345);
+        assert_eq!(
+            view.block_hash,
+            "11111111111111111111111111111111".parse().unwrap()
+        );
+    }
+
+    #[test]
     fn test_view_state_result_deserializes_with_cursor() {
         // `key`/`value`/`last_key` are base64 on the wire.
         let json = serde_json::json!({
@@ -1806,6 +1834,15 @@ mod tests {
         });
         let entry: GasProfileEntry = serde_json::from_value(json).unwrap();
         assert_eq!(entry.gas_used.as_gas(), 999000000);
+    }
+
+    #[test]
+    fn test_max_nonces_for_gas_key() {
+        assert_eq!(crate::MAX_NONCES_FOR_GAS_KEY, 1024);
+        assert_eq!(
+            crate::AccessKeyPermission::MAX_NONCES_FOR_GAS_KEY,
+            crate::MAX_NONCES_FOR_GAS_KEY
+        );
     }
 
     #[test]

--- a/crates/near-kit/src/types/transaction.rs
+++ b/crates/near-kit/src/types/transaction.rs
@@ -121,6 +121,27 @@ pub struct SignedTransaction {
     pub signature: Signature,
 }
 
+/// A signed transaction payload accepted by the transaction submission APIs.
+///
+/// This trait is implemented by both the legacy [`SignedTransaction`] (V0)
+/// and [`SignedTransactionV1`], which can carry either a V0 or V1 transaction.
+/// It allows [`RpcClient::send_tx`](crate::RpcClient::send_tx) and
+/// [`Near::send`](crate::Near::send) to preserve their existing V0 call shape
+/// while also accepting versioned signed transactions.
+pub trait SignedTransactionPayload {
+    /// The transaction hash used to track the submitted transaction.
+    fn transaction_hash(&self) -> CryptoHash;
+
+    /// The account that signed the transaction.
+    fn signer_id(&self) -> &AccountId;
+
+    /// The transaction receiver.
+    fn receiver_id(&self) -> &AccountId;
+
+    /// The borsh-encoded signed transaction as base64 for JSON-RPC submission.
+    fn encoded_base64(&self) -> String;
+}
+
 impl SignedTransaction {
     /// Get the hash of the signed transaction (transaction hash).
     pub fn get_hash(&self) -> CryptoHash {
@@ -176,6 +197,24 @@ impl SignedTransaction {
             crate::error::Error::InvalidTransaction(format!("Invalid base64: {}", e))
         })?;
         Self::from_bytes(&bytes)
+    }
+}
+
+impl SignedTransactionPayload for SignedTransaction {
+    fn transaction_hash(&self) -> CryptoHash {
+        self.get_hash()
+    }
+
+    fn signer_id(&self) -> &AccountId {
+        &self.transaction.signer_id
+    }
+
+    fn receiver_id(&self) -> &AccountId {
+        &self.transaction.receiver_id
+    }
+
+    fn encoded_base64(&self) -> String {
+        self.to_base64()
     }
 }
 
@@ -549,6 +588,24 @@ impl SignedTransactionV1 {
             crate::error::Error::InvalidTransaction(format!("Invalid base64: {}", e))
         })?;
         Self::from_bytes(&bytes)
+    }
+}
+
+impl SignedTransactionPayload for SignedTransactionV1 {
+    fn transaction_hash(&self) -> CryptoHash {
+        self.get_hash()
+    }
+
+    fn signer_id(&self) -> &AccountId {
+        self.transaction.signer_id()
+    }
+
+    fn receiver_id(&self) -> &AccountId {
+        self.transaction.receiver_id()
+    }
+
+    fn encoded_base64(&self) -> String {
+        self.to_base64()
     }
 }
 

--- a/crates/near-kit/src/types/transaction.rs
+++ b/crates/near-kit/src/types/transaction.rs
@@ -121,27 +121,6 @@ pub struct SignedTransaction {
     pub signature: Signature,
 }
 
-/// A signed transaction payload accepted by the transaction submission APIs.
-///
-/// This trait is implemented by both the legacy [`SignedTransaction`] (V0)
-/// and [`SignedTransactionV1`], which can carry either a V0 or V1 transaction.
-/// It allows [`RpcClient::send_tx`](crate::RpcClient::send_tx) and
-/// [`Near::send`](crate::Near::send) to preserve their existing V0 call shape
-/// while also accepting versioned signed transactions.
-pub trait SignedTransactionPayload {
-    /// The transaction hash used to track the submitted transaction.
-    fn transaction_hash(&self) -> CryptoHash;
-
-    /// The account that signed the transaction.
-    fn signer_id(&self) -> &AccountId;
-
-    /// The transaction receiver.
-    fn receiver_id(&self) -> &AccountId;
-
-    /// The borsh-encoded signed transaction as base64 for JSON-RPC submission.
-    fn encoded_base64(&self) -> String;
-}
-
 impl SignedTransaction {
     /// Get the hash of the signed transaction (transaction hash).
     pub fn get_hash(&self) -> CryptoHash {
@@ -197,24 +176,6 @@ impl SignedTransaction {
             crate::error::Error::InvalidTransaction(format!("Invalid base64: {}", e))
         })?;
         Self::from_bytes(&bytes)
-    }
-}
-
-impl SignedTransactionPayload for SignedTransaction {
-    fn transaction_hash(&self) -> CryptoHash {
-        self.get_hash()
-    }
-
-    fn signer_id(&self) -> &AccountId {
-        &self.transaction.signer_id
-    }
-
-    fn receiver_id(&self) -> &AccountId {
-        &self.transaction.receiver_id
-    }
-
-    fn encoded_base64(&self) -> String {
-        self.to_base64()
     }
 }
 
@@ -588,24 +549,6 @@ impl SignedTransactionV1 {
             crate::error::Error::InvalidTransaction(format!("Invalid base64: {}", e))
         })?;
         Self::from_bytes(&bytes)
-    }
-}
-
-impl SignedTransactionPayload for SignedTransactionV1 {
-    fn transaction_hash(&self) -> CryptoHash {
-        self.get_hash()
-    }
-
-    fn signer_id(&self) -> &AccountId {
-        self.transaction.signer_id()
-    }
-
-    fn receiver_id(&self) -> &AccountId {
-        self.transaction.receiver_id()
-    }
-
-    fn encoded_base64(&self) -> String {
-        self.to_base64()
     }
 }
 

--- a/crates/near-kit/tests/integration/gas_key_transaction_integration.rs
+++ b/crates/near-kit/tests/integration/gas_key_transaction_integration.rs
@@ -159,15 +159,22 @@ async fn test_gas_key_signed_transaction() {
         "gas-key transaction must serialize as a tagged V1"
     );
 
-    // Submit through the same ergonomic high-level API used for legacy V0
-    // signed transactions. Near::send dispatches the versioned bytes through
-    // RpcClient::send_tx without dropping the V1 tag.
-    let outcome = root_near
-        .send(&signed)
+    // Submit the tagged V1 payload through the generic RPC escape hatch. The
+    // high-level send API intentionally remains V0-only.
+    let send_params = serde_json::json!({
+        "signed_tx_base64": signed.to_base64(),
+        "wait_until": "FINAL",
+    });
+    let resp: RawTransactionResponse = root_near
+        .rpc()
+        .call("send_tx", send_params)
         .await
         .expect("send gas-key signed transaction");
 
     // The transaction must have actually executed and succeeded.
+    let outcome = resp
+        .outcome
+        .expect("send_tx at wait_until=FINAL must return an execution outcome");
     assert!(
         outcome.is_success(),
         "gas-key transaction did not succeed on-chain: status={:?}, failure={:?}",

--- a/crates/near-kit/tests/integration/gas_key_transaction_integration.rs
+++ b/crates/near-kit/tests/integration/gas_key_transaction_integration.rs
@@ -4,7 +4,7 @@
 //! 1. Create a funded account with an ordinary full-access key.
 //! 2. Add a gas key (`AddKey` with `GasKeyFullAccess`) and fund it
 //!    (`TransferToGasKey`).
-//! 3. Read the gas key's parallel nonce via `EXPERIMENTAL_view_gas_key_nonces`.
+//! 3. Read the gas key's parallel nonce via `view_gas_key_nonces`.
 //! 4. Build a `TransactionV1` whose nonce is a `GasKeyNonce { nonce, nonce_index }`,
 //!    sign it with the gas key, and submit it with `send_tx`.
 //! 5. Assert the transfer landed and the gas key's nonce advanced.
@@ -31,31 +31,17 @@ fn unique_account(prefix: &str) -> AccountId {
         .unwrap()
 }
 
-/// Read a gas key's parallel nonces via `EXPERIMENTAL_view_gas_key_nonces`.
-///
-/// near-kit does not yet have a typed wrapper for this query (it lands with the
-/// RPC track), so the test calls the generic JSON-RPC method directly.
+/// Read a gas key's parallel nonces via the stabilized `query` RPC shape.
 async fn view_gas_key_nonces(
     near: &Near,
     account_id: &AccountId,
     public_key: &PublicKey,
 ) -> Vec<u64> {
-    #[derive(serde::Deserialize)]
-    struct Resp {
-        nonces: Vec<u64>,
-    }
-    let params = serde_json::json!({
-        "request_type": "view_gas_key_nonces",
-        "finality": "final",
-        "account_id": account_id.to_string(),
-        "public_key": public_key.to_string(),
-    });
-    let resp: Resp = near
-        .rpc()
-        .call("query", params)
+    near.rpc()
+        .view_gas_key_nonces(account_id, public_key, BlockReference::final_())
         .await
-        .expect("view_gas_key_nonces query failed");
-    resp.nonces
+        .expect("view_gas_key_nonces query failed")
+        .nonces
 }
 
 #[tokio::test]
@@ -173,23 +159,15 @@ async fn test_gas_key_signed_transaction() {
         "gas-key transaction must serialize as a tagged V1"
     );
 
-    // Submit via the generic send_tx RPC (V1-aware path) and deserialize into
-    // the same typed `RawTransactionResponse` the high-level client uses, so we
-    // assert on the real `FinalExecutionOutcome` rather than poking at raw JSON.
-    let send_params = serde_json::json!({
-        "signed_tx_base64": signed.to_base64(),
-        "wait_until": "FINAL",
-    });
-    let resp: RawTransactionResponse = root_near
-        .rpc()
-        .call("send_tx", send_params)
+    // Submit through the same ergonomic high-level API used for legacy V0
+    // signed transactions. Near::send dispatches the versioned bytes through
+    // RpcClient::send_tx without dropping the V1 tag.
+    let outcome = root_near
+        .send(&signed)
         .await
         .expect("send gas-key signed transaction");
 
     // The transaction must have actually executed and succeeded.
-    let outcome = resp
-        .outcome
-        .expect("send_tx at wait_until=FINAL must return an execution outcome");
     assert!(
         outcome.is_success(),
         "gas-key transaction did not succeed on-chain: status={:?}, failure={:?}",


### PR DESCRIPTION
## Summary

Add the narrow client capabilities required for near-cli-rs to replace the official NEAR protocol/RPC crates with near-kit:

- support configured default RPC headers, including a validated and redacted `x-api-key`
- add typed `view_gas_key_nonces` support and expose the protocol nonce limit
- exercise versioned V1 submission through the existing raw RPC call surface

The existing `RpcClient::send_tx` and `Near::send` APIs remain unchanged. near-cli can use the generic raw RPC surface for V1 while legacy V0 callers keep their current API and wire encoding.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p near-kit --lib` (505 passed)
- `cargo clippy -p near-kit --all-targets --all-features -- -D warnings`
- `cargo test -p near-kit --doc` (129 passed, 27 ignored)
- `cargo test -p near-kit --test integration --features sandbox --no-run`
- `cargo package -p near-kit --allow-dirty --no-verify`
- `cargo package -p near-kit-macros --allow-dirty --no-verify`

The sandbox integration test compiles but was not executed locally because Docker is unavailable.