### PR TITLE
refactor: inject custom HTTP clients

### DIFF
--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use reqwest::header::{HeaderMap, HeaderValue};
 use serde::de::DeserializeOwned;
 
 use crate::contract::ContractClient;
@@ -1148,7 +1147,7 @@ impl std::fmt::Debug for Near {
 /// ```
 pub struct NearBuilder {
     rpc_url: String,
-    rpc_headers: HeaderMap,
+    http_client: reqwest::Client,
     signer: Option<Arc<dyn Signer>>,
     retry_config: RetryConfig,
     chain_id: ChainId,
@@ -1160,7 +1159,7 @@ impl NearBuilder {
     fn new(rpc_url: impl Into<String>, chain_id: ChainId) -> Self {
         Self {
             rpc_url: rpc_url.into(),
-            rpc_headers: HeaderMap::new(),
+            http_client: reqwest::Client::new(),
             signer: None,
             retry_config: RetryConfig::default(),
             chain_id,
@@ -1214,32 +1213,14 @@ impl NearBuilder {
         self
     }
 
-    /// Add default HTTP headers to every RPC request.
+    /// Use a preconfigured HTTP client for RPC requests.
     ///
-    /// Existing headers with the same name are replaced. Credential-bearing
-    /// values should be marked sensitive before being passed here so their
-    /// `Debug` representation is redacted.
-    pub fn rpc_headers(mut self, headers: HeaderMap) -> Self {
-        self.rpc_headers.extend(headers);
+    /// This allows callers to configure transport concerns such as default
+    /// headers, proxies, TLS, and timeouts without expanding near-kit's API for
+    /// each individual HTTP setting.
+    pub fn http_client(mut self, client: reqwest::Client) -> Self {
+        self.http_client = client;
         self
-    }
-
-    /// Authenticate RPC requests with an `x-api-key` header.
-    ///
-    /// The key is validated as an HTTP header value and marked sensitive so it
-    /// cannot be exposed through header `Debug` output.
-    pub fn rpc_api_key(mut self, api_key: impl AsRef<str>) -> Result<Self, Error> {
-        let api_key = api_key.as_ref();
-        if api_key.is_empty() {
-            return Err(Error::Config("RPC API key cannot be empty".to_string()));
-        }
-
-        let mut value = HeaderValue::from_bytes(api_key.as_bytes()).map_err(|_| {
-            Error::Config("RPC API key is not a valid HTTP header value".to_string())
-        })?;
-        value.set_sensitive(true);
-        self.rpc_headers.insert("x-api-key", value);
-        Ok(self)
     }
 
     /// Set the maximum number of transaction send attempts on `InvalidNonce` errors.
@@ -1258,10 +1239,11 @@ impl NearBuilder {
     /// Build the client.
     pub fn build(self) -> Near {
         Near {
-            rpc: Arc::new(
-                RpcClient::with_retry_config(self.rpc_url, self.retry_config)
-                    .with_default_headers(self.rpc_headers),
-            ),
+            rpc: Arc::new(RpcClient::with_http_client_and_retry_config(
+                self.rpc_url,
+                self.http_client,
+                self.retry_config,
+            )),
             signer: self.signer,
             chain_id: self.chain_id,
             max_nonce_retries: self.max_nonce_retries,

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -4,7 +4,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
-use reqwest::header::HeaderMap;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::error::RpcError;
@@ -139,7 +138,6 @@ struct CallFunctionResponse {
 pub struct RpcClient {
     url: String,
     client: reqwest::Client,
-    default_headers: HeaderMap,
     retry_config: RetryConfig,
     request_id: AtomicU64,
 }
@@ -147,35 +145,25 @@ pub struct RpcClient {
 impl RpcClient {
     /// Create a new RPC client with the given URL.
     pub fn new(url: impl Into<String>) -> Self {
-        Self {
-            url: url.into(),
-            client: reqwest::Client::new(),
-            default_headers: HeaderMap::new(),
-            retry_config: RetryConfig::default(),
-            request_id: AtomicU64::new(0),
-        }
+        Self::with_http_client_and_retry_config(url, reqwest::Client::new(), RetryConfig::default())
     }
 
     /// Create a new RPC client with custom retry configuration.
     pub fn with_retry_config(url: impl Into<String>, retry_config: RetryConfig) -> Self {
+        Self::with_http_client_and_retry_config(url, reqwest::Client::new(), retry_config)
+    }
+
+    pub(crate) fn with_http_client_and_retry_config(
+        url: impl Into<String>,
+        client: reqwest::Client,
+        retry_config: RetryConfig,
+    ) -> Self {
         Self {
             url: url.into(),
-            client: reqwest::Client::new(),
-            default_headers: HeaderMap::new(),
+            client,
             retry_config,
             request_id: AtomicU64::new(0),
         }
-    }
-
-    /// Add default HTTP headers to every RPC request.
-    ///
-    /// This is useful for authenticated RPC providers. Header values that contain
-    /// credentials should be marked sensitive with
-    /// [`HeaderValue::set_sensitive`](reqwest::header::HeaderValue::set_sensitive)
-    /// before being passed here so their `Debug` representation is redacted.
-    pub fn with_default_headers(mut self, headers: HeaderMap) -> Self {
-        self.default_headers = headers;
-        self
     }
 
     /// Get the RPC URL.
@@ -243,7 +231,6 @@ impl RpcClient {
         let response = self
             .client
             .post(&self.url)
-            .headers(self.default_headers.clone())
             .header("Content-Type", "application/json")
             .json(request)
             .send()
@@ -953,7 +940,6 @@ impl Clone for RpcClient {
         Self {
             url: self.url.clone(),
             client: self.client.clone(),
-            default_headers: self.default_headers.clone(),
             retry_config: self.retry_config.clone(),
             request_id: AtomicU64::new(0),
         }
@@ -1111,23 +1097,8 @@ mod tests {
         assert!(debug.contains("rpc.testnet.near.org"));
     }
 
-    #[test]
-    fn test_rpc_client_debug_redacts_default_headers() {
-        let secret = "super-secret-rpc-api-key";
-        let mut value = HeaderValue::from_static(secret);
-        value.set_sensitive(true);
-        let mut headers = HeaderMap::new();
-        headers.insert("x-api-key", value);
-
-        let client = RpcClient::new("https://rpc.testnet.near.org").with_default_headers(headers);
-        let debug = format!("{client:?}");
-
-        assert!(!debug.contains(secret));
-        assert!(!debug.contains("x-api-key"));
-    }
-
     #[tokio::test]
-    async fn test_near_builder_sends_rpc_api_key_header() {
+    async fn test_near_builder_uses_custom_http_client() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let address = listener.local_addr().unwrap();
         let (request_tx, request_rx) = mpsc::channel();
@@ -1161,30 +1132,26 @@ mod tests {
         });
 
         let secret = "test-provider-secret";
+        let mut headers = HeaderMap::new();
+        let mut api_key = HeaderValue::from_static(secret);
+        api_key.set_sensitive(true);
+        headers.insert("x-api-key", api_key);
+        let http_client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .unwrap();
         let near = crate::Near::custom(format!("http://{address}"), "test")
-            .rpc_api_key(secret)
-            .unwrap()
+            .http_client(http_client)
             .build();
+        let debug = format!("{:?}", near.rpc());
+        assert!(!debug.contains(secret));
+        assert!(!debug.contains("x-api-key"));
         let response: serde_json::Value = near.rpc().call("status", ()).await.unwrap();
         assert_eq!(response, serde_json::json!({ "ok": true }));
 
         let request = request_rx.recv().unwrap().to_ascii_lowercase();
         assert!(request.contains(&format!("x-api-key: {secret}")));
         server.join().unwrap();
-    }
-
-    #[test]
-    fn test_near_builder_rejects_invalid_rpc_api_keys_without_echoing_them() {
-        for invalid in ["", "secret\nsecond-header: leaked"] {
-            let result = crate::Near::testnet().rpc_api_key(invalid);
-            let error = match result {
-                Ok(_) => panic!("invalid RPC API key was accepted"),
-                Err(error) => error,
-            };
-            if !invalid.is_empty() {
-                assert!(!error.to_string().contains(invalid));
-            }
-        }
     }
 
     // ========================================================================


### PR DESCRIPTION
## Summary

Refine the transport prerequisite from #247 before publishing 0.12.1:

- remove the header-specific `NearBuilder::rpc_headers` API
- remove the API-key-specific `NearBuilder::rpc_api_key` API
- accept a preconfigured `reqwest::Client` through a fluent `NearBuilder::http_client` method
- keep HTTP configuration outside near-kit while preserving authenticated-RPC support for consumers such as near-cli

The existing `Near::custom` and `NearBuilder::build` signatures remain unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p near-kit --lib` (503 passed)
- `cargo clippy -p near-kit --all-targets --all-features -- -D warnings`
- `git diff --check`