### PR TITLE
feat!: make transaction wait levels type-only

### DIFF
--- a/crates/near-kit/examples/global_contracts.rs
+++ b/crates/near-kit/examples/global_contracts.rs
@@ -48,7 +48,7 @@ async fn global_contracts_example() -> Result<(), Error> {
     publisher_near
         .publish(wasm_code.clone(), PublishMode::Updatable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await?;
 
     println!("Published guestbook contract (updatable)\n");
@@ -74,7 +74,7 @@ async fn global_contracts_example() -> Result<(), Error> {
     user_near
         .deploy_from(&publisher_account)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await?;
 
     println!("Deployed to {user_account} from publisher\n");
@@ -87,7 +87,7 @@ async fn global_contracts_example() -> Result<(), Error> {
         .gas(Gas::from_tgas(30))
         .deposit(NearToken::ZERO)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await?;
 
     let messages: Vec<serde_json::Value> = root_near
@@ -108,7 +108,7 @@ async fn global_contracts_example() -> Result<(), Error> {
     publisher_near
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await?;
 
     println!("Published same contract (immutable)\n");
@@ -134,7 +134,7 @@ async fn global_contracts_example() -> Result<(), Error> {
     user2_near
         .deploy_from(code_hash)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await?;
 
     println!("Deployed to {user2_account} from code hash");

--- a/crates/near-kit/examples/sequential_sends.rs
+++ b/crates/near-kit/examples/sequential_sends.rs
@@ -91,7 +91,7 @@ async fn sequential_example() -> Result<(), Error> {
                 for tx_idx in 0..txs_per_key {
                     near.transfer(&recipient, NearToken::from_millinear(1))
                         .send()
-                        .wait_until(Included)
+                        .wait_until::<Included>()
                         .await
                         .unwrap();
                     println!("  key[{key_idx}] tx {tx_idx} included");

--- a/crates/near-kit/src/client/mod.rs
+++ b/crates/near-kit/src/client/mod.rs
@@ -25,6 +25,7 @@
 //! - [`AccountQuery`] — Get full account info
 //! - [`AccountExistsQuery`] — Check if account exists
 //! - [`AccessKeysQuery`] — List access keys
+//! - [`TransactionStatusQuery`] — Poll or wait for transaction progress
 //! - [`ViewCall`] — Call view functions on contracts
 //!
 //! # Transaction Builders
@@ -47,14 +48,16 @@ mod keyring_signer;
 
 pub use near::{Near, NearBuilder, SANDBOX_ROOT_ACCOUNT, SANDBOX_ROOT_SECRET_KEY, SandboxNetwork};
 pub use query::{
-    AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, ViewCall, ViewCallBorsh,
+    AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, TransactionStatusQuery,
+    ViewCall, ViewCallBorsh,
 };
 pub use rpc::{RetryConfig, RpcClient};
 #[cfg(feature = "file-signer")]
 pub use signer::FileSigner;
 pub use signer::{EnvSigner, InMemorySigner, RotatingSigner, Signer, SigningKey};
 pub use transaction::{
-    CallBuilder, DelegateOptions, DelegateResult, FunctionCall, TransactionBuilder, TransactionSend,
+    CallBuilder, DelegateOptions, DelegateResult, FunctionCall, SignedTransactionSend,
+    TransactionBuilder, TransactionSend,
 };
 
 #[cfg(feature = "keyring")]

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -11,10 +11,13 @@ use crate::types::{
     PublishMode, SecretKey, StateInit, TryIntoAccountId,
 };
 
-use super::query::{AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, ViewCall};
+use super::query::{
+    AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, TransactionStatusQuery,
+    ViewCall,
+};
 use super::rpc::{MAINNET, RetryConfig, RpcClient, TESTNET};
 use super::signer::{InMemorySigner, Signer};
-use super::transaction::{CallBuilder, TransactionBuilder};
+use super::transaction::{CallBuilder, SignedTransactionSend, TransactionBuilder};
 
 /// Trait for sandbox network configuration.
 ///
@@ -601,7 +604,7 @@ impl Near {
     ///
     /// // Transfer with wait for finality
     /// near.transfer("bob.testnet", NearToken::from_near(1000))
-    ///     .wait_until(Final)
+    ///     .wait_until::<Final>()
     ///     .await?;
     /// # Ok(())
     /// # }
@@ -855,42 +858,26 @@ impl Near {
     ///     .sign()
     ///     .await?;
     ///
-    /// // Send later
-    /// let outcome = near.send(&signed).await?;
+    /// // Send later. The default waits for optimistic execution.
+    /// let outcome: FinalExecutionOutcome = near.send(&signed).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn send(
+    pub fn send<'tx>(
         &self,
-        signed_tx: &crate::types::SignedTransaction,
-    ) -> Result<crate::types::FinalExecutionOutcome, Error> {
-        self.send_with_options(signed_tx, crate::types::ExecutedOptimistic)
-            .await
+        signed_tx: &'tx crate::types::SignedTransaction,
+    ) -> SignedTransactionSend<'tx> {
+        SignedTransactionSend::new(self.rpc.clone(), signed_tx)
     }
 
-    /// Send a pre-signed transaction with a custom wait level.
+    /// Query transaction status and receipt progress.
     ///
-    /// The return type depends on the wait level:
-    /// - Executed levels ([`ExecutedOptimistic`](crate::types::ExecutedOptimistic),
-    ///   [`Executed`](crate::types::Executed), [`Final`](crate::types::Final))
-    ///   → [`FinalExecutionOutcome`](crate::types::FinalExecutionOutcome)
-    /// - Non-executed levels ([`Submitted`](crate::types::Submitted),
-    ///   [`Included`](crate::types::Included), [`IncludedFinal`](crate::types::IncludedFinal))
-    ///   → [`SendTxResponse`](crate::types::SendTxResponse)
-    pub async fn send_with_options<W: crate::types::WaitLevel>(
-        &self,
-        signed_tx: &crate::types::SignedTransaction,
-        _level: W,
-    ) -> Result<W::Response, Error> {
-        let sender_id = &signed_tx.transaction.signer_id;
-        let response = self.rpc.send_tx(signed_tx, W::status()).await?;
-        W::convert(response, sender_id)
-    }
-
-    /// Get transaction status with full receipt details.
-    ///
-    /// Uses `EXPERIMENTAL_tx_status` under the hood. The return type depends
-    /// on the wait level, just like [`send_with_options`](Self::send_with_options):
+    /// Uses `EXPERIMENTAL_tx_status` under the hood and returns an awaitable
+    /// [`TransactionStatusQuery`]. Awaiting it directly uses
+    /// [`Submitted`](crate::types::Submitted), so it returns the node's current
+    /// progress without waiting for a new milestone. Chain
+    /// [`.wait_until::<W>()`](TransactionStatusQuery::wait_until) to wait for a
+    /// specific level.
     ///
     /// - Executed levels ([`ExecutedOptimistic`](crate::types::ExecutedOptimistic),
     ///   [`Executed`](crate::types::Executed), [`Final`](crate::types::Final))
@@ -910,27 +897,27 @@ impl Near {
     /// ```rust,no_run
     /// # use near_kit::*;
     /// # async fn example(near: &Near, tx_hash: CryptoHash) -> Result<(), Error> {
-    /// let outcome = near.tx_status(&tx_hash, "alice.testnet", Final).await?;
+    /// let outcome = near
+    ///     .tx_status(&tx_hash, "alice.testnet")
+    ///     .wait_until::<Final>()
+    ///     .await?;
     /// println!("Gas used: {}", outcome.total_gas_used());
     /// println!("Receipts: {}", outcome.receipts.len());
     ///
-    /// // Poll at an early level for progressive per-receipt status:
-    /// let status = near.tx_status(&tx_hash, "alice.testnet", Included).await?;
+    /// // Poll current progress without blocking:
+    /// let status = near.tx_status(&tx_hash, "alice.testnet").await?;
     /// if let Some(partial) = &status.outcome {
     ///     println!("Receipts so far: {}", partial.receipts_outcome.len());
     /// }
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn tx_status<W: crate::types::WaitLevel>(
+    pub fn tx_status(
         &self,
         tx_hash: &crate::types::CryptoHash,
         sender_id: impl crate::types::TryIntoAccountId,
-        _level: W,
-    ) -> Result<W::Response, Error> {
-        let sender_id = sender_id.try_into_account_id()?;
-        let response = self.rpc.tx_status(tx_hash, &sender_id, W::status()).await?;
-        W::convert(response, &sender_id)
+    ) -> TransactionStatusQuery {
+        TransactionStatusQuery::new(self.rpc.clone(), *tx_hash, sender_id)
     }
 
     // ========================================================================

--- a/crates/near-kit/src/client/query.rs
+++ b/crates/near-kit/src/client/query.rs
@@ -10,7 +10,8 @@ use serde::de::DeserializeOwned;
 
 use crate::error::Error;
 use crate::types::{
-    AccessKeyListView, AccountBalance, AccountId, AccountView, BlockReference, CryptoHash, Finality,
+    AccessKeyListView, AccountBalance, AccountId, AccountView, BlockReference, CryptoHash,
+    Finality, Submitted, TryIntoAccountId, WaitLevel,
 };
 
 use super::rpc::RpcClient;
@@ -296,6 +297,102 @@ impl IntoFuture for AccessKeysQuery {
                 .view_access_key_list(&self.account_id, self.block_ref)
                 .await?;
             Ok(list)
+        })
+    }
+}
+
+// ============================================================================
+// TransactionStatusQuery
+// ============================================================================
+
+/// Awaitable query for transaction execution status.
+///
+/// Awaiting this query directly uses [`Submitted`], which asks the node for its
+/// current progress without waiting for a new execution milestone. Use
+/// [`wait_until`](Self::wait_until) to block until a specific type-safe level.
+/// The selected wait-level type also determines the response type.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use near_kit::*;
+/// # async fn example(
+/// #     near: &Near,
+/// #     tx_hash: &CryptoHash,
+/// #     sender_id: &AccountId,
+/// # ) -> Result<(), Error> {
+/// // The default is a non-blocking progress query.
+/// let progress: SendTxResponse = near.tx_status(tx_hash, sender_id).await?;
+///
+/// // Waiting for execution returns a full execution outcome.
+/// let outcome: FinalExecutionOutcome = near
+///     .tx_status(tx_hash, sender_id)
+///     .wait_until::<Final>()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+///
+/// Wait levels compose naturally in generic helpers because they are selected
+/// entirely in type position:
+///
+/// ```rust,no_run
+/// # use near_kit::*;
+/// async fn status_at<W: WaitLevel>(
+///     near: &Near,
+///     tx_hash: &CryptoHash,
+///     sender_id: &AccountId,
+/// ) -> Result<W::Response, Error> {
+///     near.tx_status(tx_hash, sender_id).wait_until::<W>().await
+/// }
+/// ```
+#[must_use = "transaction status queries do nothing unless awaited"]
+pub struct TransactionStatusQuery<W: WaitLevel = Submitted> {
+    rpc: Arc<RpcClient>,
+    tx_hash: CryptoHash,
+    sender_id: Result<AccountId, Error>,
+    _marker: PhantomData<W>,
+}
+
+impl TransactionStatusQuery {
+    pub(crate) fn new(
+        rpc: Arc<RpcClient>,
+        tx_hash: CryptoHash,
+        sender_id: impl TryIntoAccountId,
+    ) -> Self {
+        Self {
+            rpc,
+            tx_hash,
+            sender_id: sender_id.try_into_account_id().map_err(Error::from),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<W: WaitLevel> TransactionStatusQuery<W> {
+    /// Select the execution wait level and corresponding response type.
+    pub fn wait_until<W2: WaitLevel>(self) -> TransactionStatusQuery<W2> {
+        TransactionStatusQuery {
+            rpc: self.rpc,
+            tx_hash: self.tx_hash,
+            sender_id: self.sender_id,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<W: WaitLevel> IntoFuture for TransactionStatusQuery<W> {
+    type Output = Result<W::Response, Error>;
+    type IntoFuture = crate::platform::BoxFuture<'static, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            let sender_id = self.sender_id?;
+            let response = self
+                .rpc
+                .tx_status(&self.tx_hash, &sender_id, W::STATUS)
+                .await?;
+            W::convert(response, &sender_id)
         })
     }
 }

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -1480,13 +1480,19 @@ impl IntoFuture for CallBuilder {
 /// this builder directly uses [`ExecutedOptimistic`](crate::types::ExecutedOptimistic),
 /// while [`wait_until`](Self::wait_until) selects a different wait level at compile time.
 ///
+/// The builder borrows the signed transaction, so the future produced by
+/// [`IntoFuture`] is tied to the `'tx` lifetime rather than `'static`. To
+/// satisfy a `'static` bound (for example `tokio::spawn`), wrap the send in an
+/// `async move` block that owns the transaction.
+///
 /// # Example
 ///
 /// ```rust,no_run
 /// # use near_kit::*;
 /// # async fn example(near: &Near, signed: &SignedTransaction) -> Result<(), Error> {
-/// // Early wait levels return SendTxResponse. Await `near.send(signed)`
-/// // directly instead to use the ExecutedOptimistic default.
+/// // Early wait levels return SendTxResponse, useful for fire-and-track
+/// // workflows. Awaiting directly without `.wait_until` uses the
+/// // ExecutedOptimistic default and returns FinalExecutionOutcome instead.
 /// let submitted: SendTxResponse = near.send(signed)
 ///     .wait_until::<Included>()
 ///     .await?;

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -30,6 +30,7 @@
 
 use std::fmt;
 use std::future::IntoFuture;
+use std::marker::PhantomData;
 use std::sync::{Arc, OnceLock};
 
 use tracing::Instrument;
@@ -683,10 +684,10 @@ impl TransactionBuilder {
 
     /// Set the execution wait level and prepare to send.
     ///
-    /// This is a shorthand for `.send().wait_until(level)`.
+    /// This is a shorthand for `.send().wait_until::<W>()`.
     /// The return type changes based on the wait level — see [`TransactionSend::wait_until`].
-    pub fn wait_until<W: crate::types::WaitLevel>(self, level: W) -> TransactionSend<W> {
-        self.send().wait_until(level)
+    pub fn wait_until<W: crate::types::WaitLevel>(self) -> TransactionSend<W> {
+        self.send().wait_until::<W>()
     }
 
     /// Override the number of nonce retries for this transaction on `InvalidNonce`
@@ -1034,11 +1035,11 @@ impl TransactionBuilder {
     /// Send the transaction.
     ///
     /// Returns a [`TransactionSend`] that defaults to [`crate::types::ExecutedOptimistic`] wait level.
-    /// Chain `.wait_until(...)` to change the wait level before awaiting.
+    /// Chain `.wait_until::<W>()` to change the wait level before awaiting.
     pub fn send(self) -> TransactionSend {
         TransactionSend {
             builder: self,
-            _marker: std::marker::PhantomData,
+            _marker: PhantomData,
         }
     }
 }
@@ -1419,8 +1420,8 @@ impl CallBuilder {
     }
 
     /// Set the execution wait level.
-    pub fn wait_until<W: WaitLevel>(self, level: W) -> TransactionSend<W> {
-        self.finish().wait_until(level)
+    pub fn wait_until<W: WaitLevel>(self) -> TransactionSend<W> {
+        self.finish().wait_until::<W>()
     }
 
     /// Override the number of nonce retries for this transaction on `InvalidNonce`
@@ -1470,6 +1471,70 @@ impl IntoFuture for CallBuilder {
 }
 
 // ============================================================================
+// SignedTransactionSend
+// ============================================================================
+
+/// Awaitable builder for sending a pre-signed transaction.
+///
+/// The type parameter `W` determines the wait level and response type. Awaiting
+/// this builder directly uses [`ExecutedOptimistic`](crate::types::ExecutedOptimistic),
+/// while [`wait_until`](Self::wait_until) selects a different wait level at compile time.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// # use near_kit::*;
+/// # async fn example(near: &Near, signed: &SignedTransaction) -> Result<(), Error> {
+/// // Early wait levels return SendTxResponse. Await `near.send(signed)`
+/// // directly instead to use the ExecutedOptimistic default.
+/// let submitted: SendTxResponse = near.send(signed)
+///     .wait_until::<Included>()
+///     .await?;
+/// # Ok(())
+/// # }
+/// ```
+#[must_use = "signed transactions are not sent unless awaited"]
+pub struct SignedTransactionSend<'tx, W: WaitLevel = crate::types::ExecutedOptimistic> {
+    rpc: Arc<RpcClient>,
+    signed_tx: &'tx SignedTransaction,
+    _marker: PhantomData<W>,
+}
+
+impl<'tx> SignedTransactionSend<'tx> {
+    pub(crate) fn new(rpc: Arc<RpcClient>, signed_tx: &'tx SignedTransaction) -> Self {
+        Self {
+            rpc,
+            signed_tx,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'tx, W: WaitLevel> SignedTransactionSend<'tx, W> {
+    /// Select the execution wait level and corresponding response type.
+    pub fn wait_until<W2: WaitLevel>(self) -> SignedTransactionSend<'tx, W2> {
+        SignedTransactionSend {
+            rpc: self.rpc,
+            signed_tx: self.signed_tx,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'tx, W: WaitLevel> IntoFuture for SignedTransactionSend<'tx, W> {
+    type Output = Result<W::Response, Error>;
+    type IntoFuture = crate::platform::BoxFuture<'tx, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(async move {
+            let sender_id = &self.signed_tx.transaction.signer_id;
+            let response = self.rpc.send_tx(self.signed_tx, W::STATUS).await?;
+            W::convert(response, sender_id)
+        })
+    }
+}
+
+// ============================================================================
 // TransactionSend
 // ============================================================================
 
@@ -1480,9 +1545,10 @@ impl IntoFuture for CallBuilder {
 ///   [`crate::types::Final`]) → [`FinalExecutionOutcome`]
 /// - Non-executed levels ([`crate::types::Submitted`], [`crate::types::Included`],
 ///   [`crate::types::IncludedFinal`]) → [`crate::types::SendTxResponse`]
+#[must_use = "transactions are not sent unless awaited"]
 pub struct TransactionSend<W: WaitLevel = crate::types::ExecutedOptimistic> {
     builder: TransactionBuilder,
-    _marker: std::marker::PhantomData<W>,
+    _marker: PhantomData<W>,
 }
 
 impl<W: WaitLevel> TransactionSend<W> {
@@ -1496,21 +1562,21 @@ impl<W: WaitLevel> TransactionSend<W> {
     /// // Executed levels return FinalExecutionOutcome
     /// let outcome = near.transfer("bob.testnet", NearToken::from_near(1))
     ///     .send()
-    ///     .wait_until(Final)
+    ///     .wait_until::<Final>()
     ///     .await?;
     ///
     /// // Non-executed levels return SendTxResponse
     /// let response = near.transfer("bob.testnet", NearToken::from_near(1))
     ///     .send()
-    ///     .wait_until(Included)
+    ///     .wait_until::<Included>()
     ///     .await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn wait_until<W2: WaitLevel>(self, _level: W2) -> TransactionSend<W2> {
+    pub fn wait_until<W2: WaitLevel>(self) -> TransactionSend<W2> {
         TransactionSend {
             builder: self.builder,
-            _marker: std::marker::PhantomData,
+            _marker: PhantomData,
         }
     }
 
@@ -1560,7 +1626,7 @@ impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
 
                 // Retry loop for transient InvalidTxErrors (nonce conflicts, expired block hash)
                 let max_nonce_retries = builder.max_nonce_retries;
-                let wait_until = W::status();
+                let wait_until = W::STATUS;
                 let network = builder.rpc.url().to_string();
                 let mut last_error: Option<Error> = None;
                 let mut last_ak_nonce: Option<u64> = None;

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -172,7 +172,7 @@
 //!
 //! // Wait for different execution levels
 //! near.transfer("bob.testnet", NearToken::from_near(1))
-//!     .wait_until(Final)
+//!     .wait_until::<Final>()
 //!     .await?;
 //! # Ok(())
 //! # }
@@ -455,8 +455,8 @@ pub use contract::{Contract, ContractClient};
 pub use client::{
     AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, CallBuilder, DelegateOptions,
     DelegateResult, EnvSigner, FunctionCall, InMemorySigner, Near, NearBuilder, RetryConfig,
-    RotatingSigner, RpcClient, SandboxNetwork, Signer, SigningKey, TransactionBuilder,
-    TransactionSend, ViewCall, ViewCallBorsh,
+    RotatingSigner, RpcClient, SandboxNetwork, SignedTransactionSend, Signer, SigningKey,
+    TransactionBuilder, TransactionSend, TransactionStatusQuery, ViewCall, ViewCallBorsh,
 };
 
 #[cfg(feature = "file-signer")]

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -681,16 +681,15 @@ pub enum FinalExecutionStatus {
 /// # use near_kit::*;
 /// # async fn example(near: &Near) -> Result<(), Error> {
 /// let response = near.transfer("bob.testnet", NearToken::from_near(1))
-///     .wait_until(Included)
+///     .wait_until::<Included>()
 ///     .await?;
 ///
 /// // Later, poll for progress without waiting for finality. At early wait
 /// // levels EXPERIMENTAL_tx_status still returns per-receipt data:
-/// let status = near.tx_status(
-///     &response.transaction_hash,
-///     &response.sender_id,
-///     Included,
-/// ).await?;
+/// let status = near
+///     .tx_status(&response.transaction_hash, &response.sender_id)
+///     .wait_until::<Included>()
+///     .await?;
 /// if let Some(outcome) = &status.outcome {
 ///     for receipt_outcome in &outcome.receipts_outcome {
 ///         // drive a progressive UI from each receipt's status

--- a/crates/near-kit/src/types/wait_level.rs
+++ b/crates/near-kit/src/types/wait_level.rs
@@ -2,7 +2,7 @@
 //!
 //! Instead of using a runtime enum, each wait level is its own type with an
 //! associated `Response` type. This lets the compiler determine the return type
-//! of `send().wait_until(...)` based on which marker you pass in:
+//! of `send().wait_until::<W>()` from the selected type:
 //!
 //! ```rust,no_run
 //! # use near_kit::*;
@@ -12,13 +12,13 @@
 //!
 //! // Executed levels — also returns FinalExecutionOutcome
 //! near.transfer("bob.testnet", NearToken::from_near(1))
-//!     .wait_until(Final)
+//!     .wait_until::<Final>()
 //!     .await?;
 //!
 //! // Non-executed levels — returns SendTxResponse (hash + sender, plus any
 //! // partial outcome the RPC has already produced)
 //! let response = near.transfer("bob.testnet", NearToken::from_near(1))
-//!     .wait_until(Included)
+//!     .wait_until::<Included>()
 //!     .await?;
 //! println!("tx hash: {}", response.transaction_hash);
 //! # Ok(())
@@ -37,18 +37,18 @@ mod sealed {
 
 /// Trait for type-safe transaction wait levels.
 ///
-/// Each wait level is a zero-sized marker type that carries:
+/// Each wait level is a zero-sized marker type that defines:
 /// - The [`TxExecutionStatus`] to send to the RPC
 /// - An associated [`Response`](WaitLevel::Response) type that determines
-///   what `send().wait_until(...)` returns
+///   what `send().wait_until::<W>()` returns
 ///
 /// This trait is sealed and cannot be implemented outside this crate.
 pub trait WaitLevel: sealed::Sealed + Send + Sync + 'static {
     /// The type returned when awaiting a transaction with this wait level.
     type Response: Send + 'static;
 
-    /// The RPC wait_until value.
-    fn status() -> TxExecutionStatus;
+    /// The RPC `wait_until` value.
+    const STATUS: TxExecutionStatus;
 
     /// Convert a raw RPC response into the appropriate return type.
     ///
@@ -96,9 +96,8 @@ pub struct Submitted;
 impl sealed::Sealed for Submitted {}
 impl WaitLevel for Submitted {
     type Response = SendTxResponse;
-    fn status() -> TxExecutionStatus {
-        TxExecutionStatus::None
-    }
+    const STATUS: TxExecutionStatus = TxExecutionStatus::None;
+
     fn convert(
         response: RawTransactionResponse,
         sender_id: &AccountId,
@@ -118,9 +117,8 @@ pub struct Included;
 impl sealed::Sealed for Included {}
 impl WaitLevel for Included {
     type Response = SendTxResponse;
-    fn status() -> TxExecutionStatus {
-        TxExecutionStatus::Included
-    }
+    const STATUS: TxExecutionStatus = TxExecutionStatus::Included;
+
     fn convert(
         response: RawTransactionResponse,
         sender_id: &AccountId,
@@ -140,9 +138,8 @@ pub struct IncludedFinal;
 impl sealed::Sealed for IncludedFinal {}
 impl WaitLevel for IncludedFinal {
     type Response = SendTxResponse;
-    fn status() -> TxExecutionStatus {
-        TxExecutionStatus::IncludedFinal
-    }
+    const STATUS: TxExecutionStatus = TxExecutionStatus::IncludedFinal;
+
     fn convert(
         response: RawTransactionResponse,
         sender_id: &AccountId,
@@ -187,9 +184,8 @@ pub struct ExecutedOptimistic;
 impl sealed::Sealed for ExecutedOptimistic {}
 impl WaitLevel for ExecutedOptimistic {
     type Response = FinalExecutionOutcome;
-    fn status() -> TxExecutionStatus {
-        TxExecutionStatus::ExecutedOptimistic
-    }
+    const STATUS: TxExecutionStatus = TxExecutionStatus::ExecutedOptimistic;
+
     fn convert(
         response: RawTransactionResponse,
         _sender_id: &AccountId,
@@ -207,9 +203,8 @@ pub struct Executed;
 impl sealed::Sealed for Executed {}
 impl WaitLevel for Executed {
     type Response = FinalExecutionOutcome;
-    fn status() -> TxExecutionStatus {
-        TxExecutionStatus::Executed
-    }
+    const STATUS: TxExecutionStatus = TxExecutionStatus::Executed;
+
     fn convert(
         response: RawTransactionResponse,
         _sender_id: &AccountId,
@@ -227,9 +222,8 @@ pub struct Final;
 impl sealed::Sealed for Final {}
 impl WaitLevel for Final {
     type Response = FinalExecutionOutcome;
-    fn status() -> TxExecutionStatus {
-        TxExecutionStatus::Final
-    }
+    const STATUS: TxExecutionStatus = TxExecutionStatus::Final;
+
     fn convert(
         response: RawTransactionResponse,
         _sender_id: &AccountId,

--- a/crates/near-kit/tests/integration/basic_integration.rs
+++ b/crates/near-kit/tests/integration/basic_integration.rs
@@ -142,7 +142,7 @@ async fn test_create_and_query_account() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(new_account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/debug_rpc_responses.rs
+++ b/crates/near-kit/tests/integration/debug_rpc_responses.rs
@@ -160,7 +160,7 @@ async fn debug_transaction_receipts() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -232,7 +232,11 @@ async fn debug_transaction_receipts() {
 
     // Now get full receipt details via EXPERIMENTAL_tx_status
     let tx_hash = outcome.transaction_hash();
-    let full_outcome = near.tx_status(tx_hash, &root_account, Final).await.unwrap();
+    let full_outcome: FinalExecutionOutcome = near
+        .tx_status(tx_hash, &root_account)
+        .wait_until::<Final>()
+        .await
+        .unwrap();
 
     println!("\n========================================");
     println!("FULL RECEIPTS (via EXPERIMENTAL_tx_status)");
@@ -326,7 +330,7 @@ async fn debug_access_key_details() {
             Some(NearToken::from_near(1)), // allowance
         )
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -448,7 +452,7 @@ async fn test_error_invalid_method() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/delegate_action_integration.rs
+++ b/crates/near-kit/tests/integration/delegate_action_integration.rs
@@ -47,7 +47,7 @@ async fn test_delegate_action_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -61,7 +61,7 @@ async fn test_delegate_action_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(relayer_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -75,7 +75,7 @@ async fn test_delegate_action_transfer() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(recipient_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -124,7 +124,7 @@ async fn test_delegate_action_transfer() {
         .transaction(signed_delegate.sender_id())
         .signed_delegate_action(signed_delegate)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -163,7 +163,7 @@ async fn test_delegate_action_function_call() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -177,7 +177,7 @@ async fn test_delegate_action_function_call() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(relayer_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -196,7 +196,7 @@ async fn test_delegate_action_function_call() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -230,7 +230,7 @@ async fn test_delegate_action_function_call() {
         .transaction(signed_delegate.sender_id())
         .signed_delegate_action(signed_delegate)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -254,7 +254,7 @@ async fn test_delegate_action_multiple_actions() {
         .transfer(NearToken::from_near(20))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -268,7 +268,7 @@ async fn test_delegate_action_multiple_actions() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(relayer_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -307,7 +307,7 @@ async fn test_delegate_action_multiple_actions() {
         .transaction(signed_delegate.sender_id())
         .signed_delegate_action(signed_delegate)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -340,7 +340,7 @@ async fn test_delegate_action_roundtrip_encoding() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -354,7 +354,7 @@ async fn test_delegate_action_roundtrip_encoding() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(recipient_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -410,7 +410,7 @@ async fn test_delegate_action_validation_errors() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/delegate_v2_integration.rs
+++ b/crates/near-kit/tests/integration/delegate_v2_integration.rs
@@ -43,7 +43,7 @@ async fn test_delegate_v2_relay() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("create sender");
 
@@ -55,7 +55,7 @@ async fn test_delegate_v2_relay() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(relayer_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("create relayer");
 
@@ -67,7 +67,7 @@ async fn test_delegate_v2_relay() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(recipient_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("create recipient");
 

--- a/crates/near-kit/tests/integration/error_consolidation_integration.rs
+++ b/crates/near-kit/tests/integration/error_consolidation_integration.rs
@@ -40,7 +40,7 @@ async fn test_successful_transfer_returns_ok() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Successful transaction should return Ok");
 
@@ -66,7 +66,7 @@ async fn test_action_error_returns_ok_with_failure_outcome() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -79,7 +79,7 @@ async fn test_action_error_returns_ok_with_failure_outcome() {
         .transaction(&account_id)
         .delete_key(fake_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -112,7 +112,7 @@ async fn test_function_call_error_returns_ok_with_failure_outcome() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -151,7 +151,7 @@ async fn test_wrong_signer_key_returns_access_key_not_found() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/error_handling_integration.rs
+++ b/crates/near-kit/tests/integration/error_handling_integration.rs
@@ -147,7 +147,7 @@ async fn test_error_view_on_newly_created_account() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -181,7 +181,7 @@ async fn test_error_view_nonexistent_method() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -229,7 +229,7 @@ async fn test_error_view_with_invalid_args() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -262,7 +262,7 @@ async fn test_error_transfer_to_nonexistent_implicit_account() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -298,7 +298,7 @@ async fn test_error_insufficient_balance_transfer() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -315,7 +315,7 @@ async fn test_error_insufficient_balance_transfer() {
         .transfer(NearToken::from_millinear(100))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -343,7 +343,7 @@ async fn test_error_create_account_that_already_exists() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -359,7 +359,7 @@ async fn test_error_create_account_that_already_exists() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(new_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -384,7 +384,7 @@ async fn test_error_delete_nonexistent_key() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -397,7 +397,7 @@ async fn test_error_delete_nonexistent_key() {
         .transaction(&account_id)
         .delete_key(fake_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -432,7 +432,7 @@ async fn test_error_function_call_panic() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -472,7 +472,7 @@ async fn test_error_function_call_insufficient_gas() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/exec_metadata_integration.rs
+++ b/crates/near-kit/tests/integration/exec_metadata_integration.rs
@@ -6,7 +6,7 @@
 //! `#[serde(flatten)] Option<FinalExecutionOutcome>` silently becomes `None`
 //! when any nested field fails to parse, surfacing as "no execution outcome".
 //! This test confirms a real 2.13 outcome round-trips through the typed
-//! `.send().wait_until(Final)` path and exposes the V4 `contracts` field.
+//! `.send().wait_until::<Final>()` path and exposes the V4 `contracts` field.
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -38,7 +38,7 @@ async fn test_v4_execution_metadata_parses_through_send() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("create_account outcome must deserialize (incl. V4 metadata)");
 

--- a/crates/near-kit/tests/integration/gas_key_transaction_integration.rs
+++ b/crates/near-kit/tests/integration/gas_key_transaction_integration.rs
@@ -63,7 +63,7 @@ async fn test_gas_key_signed_transaction() {
         .transfer(NearToken::from_near(20))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("create owner account");
 
@@ -96,7 +96,7 @@ async fn test_gas_key_signed_transaction() {
             NearToken::from_near(5),
         ))
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("add + fund gas key");
 
@@ -130,7 +130,7 @@ async fn test_gas_key_signed_transaction() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(recipient_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("create recipient");
 

--- a/crates/near-kit/tests/integration/global_contracts_integration.rs
+++ b/crates/near-kit/tests/integration/global_contracts_integration.rs
@@ -44,7 +44,7 @@ async fn create_funded_account(
         .transfer(funding)
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -73,7 +73,7 @@ async fn test_near_publish_shorthand_updatable() {
     let outcome = publisher_near
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -94,7 +94,7 @@ async fn test_near_publish_shorthand_immutable() {
     let outcome = publisher_near
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -116,7 +116,7 @@ async fn test_near_deploy_from_shorthand_publisher() {
     publisher_near
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -127,7 +127,7 @@ async fn test_near_deploy_from_shorthand_publisher() {
     user_near
         .deploy_from(publisher_id.clone())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -155,7 +155,7 @@ async fn test_near_deploy_from_shorthand_hash() {
     publisher_near
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -166,7 +166,7 @@ async fn test_near_deploy_from_shorthand_hash() {
     user_near
         .deploy_from(code_hash)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -194,7 +194,7 @@ async fn test_publish_deploy_from_call_end_to_end() {
     publisher_near
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -205,7 +205,7 @@ async fn test_publish_deploy_from_call_end_to_end() {
     user_near
         .deploy_from(publisher_id.as_str())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -217,7 +217,7 @@ async fn test_publish_deploy_from_call_end_to_end() {
         .gas(Gas::from_tgas(30))
         .deposit(NearToken::ZERO)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -248,7 +248,7 @@ async fn test_publish_contract_by_account() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -275,7 +275,7 @@ async fn test_publish_contract_by_hash() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -302,7 +302,7 @@ async fn test_deploy_from_publisher() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -315,7 +315,7 @@ async fn test_deploy_from_publisher() {
         .transaction(&user_id)
         .deploy_from(publisher_id.clone())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -356,7 +356,7 @@ async fn test_deploy_from_hash() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -369,7 +369,7 @@ async fn test_deploy_from_hash() {
         .transaction(&user_id)
         .deploy_from(code_hash)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -407,7 +407,7 @@ async fn test_state_init_by_hash() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Immutable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -419,7 +419,7 @@ async fn test_state_init_by_hash() {
     let outcome = publisher_near
         .state_init(si, NearToken::from_near(5))
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -446,7 +446,7 @@ async fn test_state_init_by_publisher() {
         .transaction(&publisher_id)
         .publish(wasm_code, PublishMode::Updatable)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -459,7 +459,7 @@ async fn test_state_init_by_publisher() {
     let outcome = publisher_near
         .state_init(si, NearToken::from_near(5))
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -491,7 +491,7 @@ async fn test_action_create_account() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(child_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -515,7 +515,7 @@ async fn test_action_transfer() {
         .transaction(&receiver_id)
         .transfer(NearToken::from_near(3))
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -540,7 +540,7 @@ async fn test_action_deploy_contract() {
         .transaction(&contract_id)
         .deploy(wasm_code)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -565,7 +565,7 @@ async fn test_action_function_call() {
         .transaction(&contract_id)
         .deploy(wasm_code)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -577,7 +577,7 @@ async fn test_action_function_call() {
         .gas(Gas::from_tgas(30))
         .deposit(NearToken::ZERO)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 }
@@ -597,7 +597,7 @@ async fn test_action_add_full_access_key() {
         .transaction(&account_id)
         .add_full_access_key(new_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -627,7 +627,7 @@ async fn test_action_add_function_call_key() {
             Some(NearToken::from_near(1)),
         )
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -652,7 +652,7 @@ async fn test_action_delete_key() {
         .transaction(&account_id)
         .add_full_access_key(second_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -665,7 +665,7 @@ async fn test_action_delete_key() {
         .transaction(&account_id)
         .delete_key(second_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -693,7 +693,7 @@ async fn test_action_delete_account() {
         .transfer(NearToken::from_near(2))
         .add_full_access_key(to_delete_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -707,7 +707,7 @@ async fn test_action_delete_account() {
         .transaction(&to_delete_id)
         .delete_account(&beneficiary_id)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -741,7 +741,7 @@ async fn test_action_stake() {
         .transaction(&staker_id)
         .stake(stake_amount, staker_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -775,7 +775,7 @@ async fn test_multiple_actions() {
         .add_full_access_key(child_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -806,7 +806,7 @@ async fn test_multiple_function_calls() {
         .transaction(&contract_id)
         .deploy(wasm_code)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -820,7 +820,7 @@ async fn test_multiple_function_calls() {
         .args(serde_json::json!({ "text": "Second message" }))
         .gas(Gas::from_tgas(15))
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/ml_dsa_integration.rs
+++ b/crates/near-kit/tests/integration/ml_dsa_integration.rs
@@ -99,7 +99,7 @@ async fn test_ml_dsa65_signed_transfer_accepted_on_chain() {
         .transfer(NearToken::from_near(20))
         .add_full_access_key(public_key.clone())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await;
     if let Err(e) = &create
         && looks_like_ml_dsa_unsupported(e)
@@ -137,7 +137,7 @@ async fn test_ml_dsa65_signed_transfer_accepted_on_chain() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(recipient_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -150,7 +150,7 @@ async fn test_ml_dsa65_signed_transfer_accepted_on_chain() {
         .transaction(&recipient)
         .transfer(NearToken::from_near(5))
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("ML-DSA-65-signed transfer must be accepted on-chain");
 

--- a/crates/near-kit/tests/integration/offline_signing_integration.rs
+++ b/crates/near-kit/tests/integration/offline_signing_integration.rs
@@ -38,7 +38,7 @@ async fn test_sign_offline_transfer() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -55,7 +55,7 @@ async fn test_sign_offline_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -128,7 +128,7 @@ async fn test_sign_offline_function_call() {
         .add_full_access_key(contract_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -164,8 +164,9 @@ async fn test_sign_offline_function_call() {
         .unwrap();
 
     // Send and wait for finalization so the view call sees the state change
-    let _outcome = contract_near
-        .send_with_options(&signed, Final)
+    let _outcome: FinalExecutionOutcome = contract_near
+        .send(&signed)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -199,7 +200,7 @@ async fn test_signed_transaction_roundtrip_bytes() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -216,7 +217,7 @@ async fn test_signed_transaction_roundtrip_bytes() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -269,7 +270,7 @@ async fn test_signed_transaction_roundtrip_base64() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -286,7 +287,7 @@ async fn test_signed_transaction_roundtrip_base64() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -331,7 +332,7 @@ async fn test_offline_sign_and_transport_simulation() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -349,7 +350,7 @@ async fn test_offline_sign_and_transport_simulation() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/rpc_types_integration.rs
+++ b/crates/near-kit/tests/integration/rpc_types_integration.rs
@@ -265,7 +265,7 @@ async fn test_final_execution_outcome_full_fields() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -337,7 +337,7 @@ async fn test_execution_metadata_and_gas_profile() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -385,14 +385,18 @@ async fn test_tx_status_with_receipts() {
         .transfer(NearToken::from_near(2))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
     let tx_hash = outcome.transaction_hash();
 
     // Now get the full transaction status with receipts
-    let status_outcome = near.tx_status(tx_hash, &root_account, Final).await.unwrap();
+    let status_outcome: FinalExecutionOutcome = near
+        .tx_status(tx_hash, &root_account)
+        .wait_until::<Final>()
+        .await
+        .unwrap();
 
     // Same FinalExecutionOutcome type as send() returns, with receipts populated
     assert!(status_outcome.is_success(), "Transaction should succeed");
@@ -455,17 +459,28 @@ async fn test_tx_status_early_wait_level_surfaces_receipts() {
         .transfer(NearToken::from_near(2))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
     let tx_hash = outcome.transaction_hash();
 
+    // A bare status query defaults to Submitted: it returns the node's current
+    // progress immediately instead of waiting for a later milestone.
+    let current: SendTxResponse = near.tx_status(tx_hash, &root_account).await.unwrap();
+    assert_eq!(&current.transaction_hash, tx_hash);
+    assert_eq!(&current.sender_id, &root_account);
+    assert!(
+        current.outcome.is_some(),
+        "default tx_status should surface the settled transaction's progress"
+    );
+
     // Poll at an early wait level (Included). Previously this dropped the
     // outcome and returned only hash + sender; now it carries the partial
     // outcome so the receipts are reachable.
     let response: SendTxResponse = near
-        .tx_status(tx_hash, &root_account, Included)
+        .tx_status(tx_hash, &root_account)
+        .wait_until::<Included>()
         .await
         .unwrap();
 
@@ -535,7 +550,7 @@ async fn test_action_view_variants() {
         .transfer(NearToken::from_near(3))
         .add_full_access_key(account1_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/sandbox_integration.rs
+++ b/crates/near-kit/tests/integration/sandbox_integration.rs
@@ -40,7 +40,7 @@ async fn test_sandbox_balance() {
         .transfer(NearToken::from_near(1000))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -66,7 +66,7 @@ async fn test_sandbox_transfer() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -85,7 +85,7 @@ async fn test_sandbox_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -118,7 +118,7 @@ async fn test_sandbox_multiple_transfers() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -139,7 +139,7 @@ async fn test_sandbox_multiple_transfers() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(receiver1_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -150,7 +150,7 @@ async fn test_sandbox_multiple_transfers() {
         .transfer(NearToken::from_near(3))
         .add_full_access_key(receiver2_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -180,7 +180,7 @@ async fn test_sandbox_simple_transfer() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -197,7 +197,7 @@ async fn test_sandbox_simple_transfer() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -206,7 +206,7 @@ async fn test_sandbox_simple_transfer() {
     // Now do a simple transfer using the convenience method
     sender_near
         .transfer(&receiver_id, NearToken::from_near(2))
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -235,7 +235,7 @@ async fn test_sandbox_create_account_outcome() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -253,7 +253,7 @@ async fn test_sandbox_create_account_outcome() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(contract_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -276,7 +276,7 @@ async fn test_sandbox_delete_account() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(parent_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -293,7 +293,7 @@ async fn test_sandbox_delete_account() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(temp_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -309,7 +309,7 @@ async fn test_sandbox_delete_account() {
         .transaction(&temp_id)
         .delete_account(&parent_id)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -332,7 +332,7 @@ async fn test_sandbox_add_and_delete_key() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -347,7 +347,7 @@ async fn test_sandbox_add_and_delete_key() {
         .transaction(&account_id)
         .add_full_access_key(second_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -360,7 +360,7 @@ async fn test_sandbox_add_and_delete_key() {
         .transaction(&account_id)
         .delete_key(second_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -384,7 +384,7 @@ async fn test_sandbox_multiple_actions_in_one_transaction() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(parent_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -405,7 +405,7 @@ async fn test_sandbox_multiple_actions_in_one_transaction() {
         .transfer(NearToken::from_near(20))
         .add_full_access_key(alice_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -416,7 +416,7 @@ async fn test_sandbox_multiple_actions_in_one_transaction() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(bob_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -452,7 +452,7 @@ async fn test_sandbox_set_balance() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -492,7 +492,7 @@ async fn test_sandbox_set_balance_preserves_other_fields() {
         .add_full_access_key(account_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -547,7 +547,7 @@ async fn test_sandbox_set_balance_for_staking() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(validator_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -571,7 +571,7 @@ async fn test_sandbox_set_balance_for_staking() {
         .transaction(&validator_id)
         .stake(stake_amount, validator_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -598,7 +598,7 @@ async fn test_sandbox_patch_debug() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -637,7 +637,7 @@ async fn test_sandbox_patch_debug() {
 }
 
 // =============================================================================
-// sign_message and send_with_options tests
+// sign_message and pre-signed transaction tests
 // =============================================================================
 
 #[tokio::test]
@@ -655,7 +655,7 @@ async fn test_sign_message_nep413() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -706,7 +706,7 @@ async fn test_sign_message_without_signer_fails() {
 }
 
 #[tokio::test]
-async fn test_send_with_options_final() {
+async fn test_signed_send_wait_until_final() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
 
@@ -720,7 +720,7 @@ async fn test_send_with_options_final() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -737,7 +737,7 @@ async fn test_send_with_options_final() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -750,8 +750,12 @@ async fn test_send_with_options_final() {
 
     println!("Signed transaction hash: {}", signed.get_hash());
 
-    // Send with Final wait option
-    let outcome = sender_near.send_with_options(&signed, Final).await.unwrap();
+    // Select Final in type position; the response type follows the wait level.
+    let outcome: FinalExecutionOutcome = sender_near
+        .send(&signed)
+        .wait_until::<Final>()
+        .await
+        .unwrap();
 
     println!("Transaction succeeded: {:?}", outcome.transaction_hash());
 
@@ -762,7 +766,7 @@ async fn test_send_with_options_final() {
 }
 
 #[tokio::test]
-async fn test_send_with_options_included_returns_send_tx_response() {
+async fn test_signed_send_wait_until_included_returns_send_tx_response() {
     let sandbox = SandboxConfig::shared().await;
     let root_near = sandbox.client();
 
@@ -776,7 +780,7 @@ async fn test_send_with_options_included_returns_send_tx_response() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -793,7 +797,7 @@ async fn test_send_with_options_included_returns_send_tx_response() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -804,8 +808,9 @@ async fn test_send_with_options_included_returns_send_tx_response() {
         .await
         .unwrap();
 
-    let response = sender_near
-        .send_with_options(&signed, Included)
+    let response: SendTxResponse = sender_near
+        .send(&signed)
+        .wait_until::<Included>()
         .await
         .unwrap();
 
@@ -829,7 +834,7 @@ async fn test_wait_until_included_on_builder() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -846,14 +851,14 @@ async fn test_wait_until_included_on_builder() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
     // Use Included directly on the builder — this was the original bug path
     let response: SendTxResponse = sender_near
         .transfer(&receiver_id, NearToken::from_near(1))
-        .wait_until(Included)
+        .wait_until::<Included>()
         .await
         .unwrap();
 
@@ -876,7 +881,7 @@ async fn test_send_pre_signed_transaction() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(sender_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -893,7 +898,7 @@ async fn test_send_pre_signed_transaction() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
+++ b/crates/near-kit/tests/integration/signer_edge_cases_integration.rs
@@ -38,7 +38,7 @@ async fn test_in_memory_signer_from_secret_key() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -53,7 +53,7 @@ async fn test_in_memory_signer_from_secret_key() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -78,7 +78,7 @@ async fn test_in_memory_signer_from_seed_phrase() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -121,7 +121,7 @@ async fn test_rotating_signer_uses_multiple_keys() {
         .add_full_access_key(key2.public_key())
         .add_full_access_key(key3.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -138,7 +138,7 @@ async fn test_rotating_signer_uses_multiple_keys() {
             .transfer(NearToken::from_near(1))
             .add_full_access_key(SecretKey::generate_ed25519().public_key())
             .send()
-            .wait_until(Final)
+            .wait_until::<Final>()
             .await
             .unwrap();
     }
@@ -165,7 +165,7 @@ async fn test_rotating_signer_with_single_key() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -181,7 +181,7 @@ async fn test_rotating_signer_with_single_key() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -230,7 +230,7 @@ async fn test_sign_with_override() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(key1.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -240,7 +240,7 @@ async fn test_sign_with_override() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(key2.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -258,7 +258,7 @@ async fn test_sign_with_override() {
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .sign_with(signer2)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -287,7 +287,7 @@ async fn test_wrong_key_for_account() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(correct_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -303,7 +303,7 @@ async fn test_wrong_key_for_account() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await;
 
     assert!(result.is_err(), "Should fail with wrong key");
@@ -335,7 +335,7 @@ async fn test_deleted_key_fails() {
         .add_full_access_key(key1.public_key())
         .add_full_access_key(key2.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -349,7 +349,7 @@ async fn test_deleted_key_fails() {
 
     near2
         .delete_key(key1.public_key())
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -361,7 +361,7 @@ async fn test_deleted_key_fails() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await;
 
     assert!(result.is_err(), "Should fail with deleted key");
@@ -383,7 +383,7 @@ async fn test_signing_with_ed25519_key() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(ed_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -398,7 +398,7 @@ async fn test_signing_with_ed25519_key() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/stabilized_rpc_integration.rs
+++ b/crates/near-kit/tests/integration/stabilized_rpc_integration.rs
@@ -52,7 +52,7 @@ async fn test_block_effects_returns_changes_for_block() {
         .transfer(NearToken::from_near(3))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("create_account must execute");
 

--- a/crates/near-kit/tests/integration/token_error_integration.rs
+++ b/crates/near-kit/tests/integration/token_error_integration.rs
@@ -37,7 +37,7 @@ async fn test_ft_metadata_on_non_contract_account() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -88,7 +88,7 @@ async fn test_ft_balance_of_on_non_contract() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -117,7 +117,7 @@ async fn test_ft_transfer_without_signer() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -178,7 +178,7 @@ async fn test_ft_on_wrong_contract_type() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -217,7 +217,7 @@ async fn test_nft_metadata_on_non_contract() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -241,7 +241,7 @@ async fn test_nft_token_on_non_contract() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -285,7 +285,7 @@ async fn test_nft_on_wrong_contract_type() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/token_integration.rs
+++ b/crates/near-kit/tests/integration/token_integration.rs
@@ -40,7 +40,7 @@ async fn deploy_ft_contract(
         .add_full_access_key(ft_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await?;
 
     // Initialize the FT contract
@@ -80,7 +80,7 @@ async fn test_ft_metadata() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -114,7 +114,7 @@ async fn test_ft_balance_of() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -156,7 +156,7 @@ async fn test_ft_total_supply() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -186,7 +186,7 @@ async fn test_ft_transfer() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -203,7 +203,7 @@ async fn test_ft_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -216,7 +216,7 @@ async fn test_ft_transfer() {
     // First, register receiver for storage
     let bounds = ft.storage_balance_bounds().await.unwrap();
     ft.storage_deposit(&receiver_id, bounds.min)
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -235,7 +235,7 @@ async fn test_ft_transfer() {
     let transfer_amount = 100_000_000_000_000_000_000_u128; // 100 tokens (18 decimals)
 
     ft.transfer_with_memo(&receiver_id, transfer_amount, "Test transfer")
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -273,7 +273,7 @@ async fn test_ft_storage_deposit() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -291,7 +291,7 @@ async fn test_ft_storage_deposit() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(user_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -306,7 +306,7 @@ async fn test_ft_storage_deposit() {
     // Register user
     let bounds = ft.storage_balance_bounds().await.unwrap();
     ft.storage_deposit(&user_id, bounds.min)
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -340,7 +340,7 @@ async fn deploy_nft_contract(
         .add_full_access_key(nft_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await?;
 
     // Initialize the NFT contract
@@ -405,7 +405,7 @@ async fn test_nft_metadata() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -438,7 +438,7 @@ async fn test_nft_token_query() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -485,7 +485,7 @@ async fn test_nft_tokens_for_owner() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -545,7 +545,7 @@ async fn test_nft_transfer() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -563,7 +563,7 @@ async fn test_nft_transfer() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(receiver_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -584,7 +584,7 @@ async fn test_nft_transfer() {
     let nft_with_signer = owner_near.nft(&nft_id).unwrap();
     nft_with_signer
         .transfer_with_memo(&receiver_id, "transfer-test", "Gift for you!")
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -610,7 +610,7 @@ async fn test_nft_total_supply() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -658,7 +658,7 @@ async fn test_nft_supply_for_owner() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner1_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -676,7 +676,7 @@ async fn test_nft_supply_for_owner() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(owner2_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -742,7 +742,7 @@ async fn test_ft_amount_arithmetic_from_real_balances() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -785,7 +785,7 @@ async fn test_ft_metadata_caching() {
         .transfer(NearToken::from_near(100))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/tracing_integration.rs
+++ b/crates/near-kit/tests/integration/tracing_integration.rs
@@ -192,7 +192,7 @@ async fn test_send_transaction_span_hierarchy() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(account_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -314,7 +314,7 @@ async fn test_function_call_span_fields() {
                 .expect("fungible_token.wasm not found"),
         )
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -337,7 +337,7 @@ async fn test_function_call_span_fields() {
             }
         }))
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -394,7 +394,7 @@ async fn test_ft_balance_of_span_hierarchy() {
         .transfer(NearToken::from_near(50))
         .add_full_access_key(owner_key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -409,7 +409,7 @@ async fn test_ft_balance_of_span_hierarchy() {
         .add_full_access_key(ft_key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -429,7 +429,7 @@ async fn test_ft_balance_of_span_hierarchy() {
             }
         }))
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/transaction_failure_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_failure_integration.rs
@@ -37,7 +37,7 @@ async fn test_deploy_invalid_wasm() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -67,7 +67,7 @@ async fn test_deploy_empty_wasm() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -124,7 +124,7 @@ async fn test_add_duplicate_key() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -157,7 +157,7 @@ async fn test_delete_last_full_access_key() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -192,7 +192,7 @@ async fn test_create_subaccount_of_nonexistent_parent() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -218,7 +218,7 @@ async fn test_create_account_without_initial_balance() {
         .add_full_access_key(key.public_key())
         // No .transfer() call
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await;
 
     // Note: Creating an account without balance may succeed
@@ -242,7 +242,7 @@ async fn test_create_account_with_insufficient_balance() {
         .transfer(NearToken::from_yoctonear(1)) // Way too small
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await;
 
     // This may fail due to insufficient balance for storage
@@ -266,7 +266,7 @@ async fn test_transaction_with_failing_action_in_middle() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -283,7 +283,7 @@ async fn test_transaction_with_failing_action_in_middle() {
         .transaction(&account_id)
         .delete_key(fake_key.public_key()) // This key doesn't exist
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -310,7 +310,7 @@ async fn test_delete_nonexistent_account() {
         .transaction(&nonexistent)
         .delete_account(SANDBOX_ROOT_ACCOUNT)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -337,7 +337,7 @@ async fn test_delete_account_to_nonexistent_beneficiary() {
         .transfer(NearToken::from_near(5))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -351,7 +351,7 @@ async fn test_delete_account_to_nonexistent_beneficiary() {
         .transaction(&account_id)
         .delete_account(&nonexistent_beneficiary)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await;
 
     // This should fail because the beneficiary doesn't exist
@@ -375,7 +375,7 @@ async fn test_stake_with_insufficient_balance() {
         .transfer(NearToken::from_near(1)) // Small balance
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -387,7 +387,7 @@ async fn test_stake_with_insufficient_balance() {
         .transaction(&account_id)
         .stake(NearToken::from_near(1000), key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Action errors should return Ok(outcome)");
 
@@ -418,7 +418,7 @@ async fn test_transfer_zero_amount() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -435,7 +435,7 @@ async fn test_transfer_zero_amount() {
         .transfer(NearToken::from_near(1))
         .add_full_access_key(SecretKey::generate_ed25519().public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -461,7 +461,7 @@ async fn test_transfer_max_amount() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/transaction_outcome_integration.rs
+++ b/crates/near-kit/tests/integration/transaction_outcome_integration.rs
@@ -35,7 +35,7 @@ async fn test_failed_transaction_preserves_receipts() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("setup: deploy should succeed")
         .result()

--- a/crates/near-kit/tests/integration/typed_contract_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_error_integration.rs
@@ -96,7 +96,7 @@ async fn test_typed_contract_view_on_account_without_contract() {
         .transfer(NearToken::from_near(10))
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -133,7 +133,7 @@ async fn test_typed_contract_call_without_signer() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -173,7 +173,7 @@ async fn test_typed_contract_view_on_wrong_contract_type() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -211,7 +211,7 @@ async fn test_typed_contract_call_with_insufficient_gas() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -255,7 +255,7 @@ async fn test_typed_contract_view_returns_wrong_type() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -301,7 +301,7 @@ async fn test_typed_contract_query_at_invalid_block() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 
@@ -342,7 +342,7 @@ async fn test_typed_contract_view_methods_still_work_without_signer() {
         .add_full_access_key(key.public_key())
         .deploy(wasm)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/typed_contract_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_integration.rs
@@ -76,7 +76,7 @@ async fn deploy_guestbook(near: &Near, contract_account: &str) -> Result<(), nea
         .add_full_access_key(new_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await?;
 
     Ok(())
@@ -138,7 +138,7 @@ async fn test_typed_contract_call_methods() {
         .add_message(AddMessageArgs {
             text: "Hello from typed contract!".to_string(),
         })
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Failed to add message");
 
@@ -184,7 +184,7 @@ async fn test_typed_contract_multiple_messages() {
             .add_message(AddMessageArgs {
                 text: text.to_string(),
             })
-            .wait_until(Final)
+            .wait_until::<Final>()
             .await
             .expect("Failed to add message");
     }
@@ -231,7 +231,7 @@ async fn test_typed_contract_with_custom_gas() {
             text: "Message with custom gas".to_string(),
         })
         .gas("50 Tgas")
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Failed to add message with custom gas");
 
@@ -265,7 +265,7 @@ async fn test_typed_contract_block_reference() {
         .add_message(AddMessageArgs {
             text: "Test message".to_string(),
         })
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Failed to add message");
 
@@ -301,7 +301,7 @@ async fn test_typed_contract_payable_method() {
         .add_message(AddMessageArgs {
             text: "Regular message".to_string(),
         })
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Failed to add regular message");
 
@@ -311,7 +311,7 @@ async fn test_typed_contract_payable_method() {
             text: "Premium message".to_string(),
         })
         .deposit("1 NEAR")
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Failed to add premium message");
 
@@ -375,7 +375,7 @@ async fn test_typed_contract_no_args_view() {
         .add_message(AddMessageArgs {
             text: "Test message".to_string(),
         })
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("Failed to add message");
 

--- a/crates/near-kit/tests/integration/typed_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_error_integration.rs
@@ -32,7 +32,7 @@ async fn funded_account(
         .transfer(balance)
         .add_full_access_key(key.public_key())
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .unwrap();
 

--- a/crates/near-kit/tests/integration/view_state_integration.rs
+++ b/crates/near-kit/tests/integration/view_state_integration.rs
@@ -32,7 +32,7 @@ async fn deploy_guestbook(near: &Near, contract_account: &str) {
         .add_full_access_key(new_key.public_key())
         .deploy(wasm_code)
         .send()
-        .wait_until(Final)
+        .wait_until::<Final>()
         .await
         .expect("deploy guestbook");
 }
@@ -52,7 +52,7 @@ async fn test_view_state_pagination_reads_all_entries() {
             .call("add_message")
             .args(serde_json::json!({ "text": format!("message number {i}") }))
             .send()
-            .wait_until(Final)
+            .wait_until::<Final>()
             .await
             .expect("add_message");
     }

--- a/crates/near-kit/tests/wait_level_api.rs
+++ b/crates/near-kit/tests/wait_level_api.rs
@@ -1,0 +1,110 @@
+//! Compile-time examples for the type-only transaction wait-level API.
+
+use near_kit::*;
+
+#[test]
+fn transaction_builders_select_wait_levels_in_type_position() {
+    let near = Near::testnet().build();
+
+    let default: TransactionSend<ExecutedOptimistic> =
+        near.transfer("bob.testnet", NearToken::from_near(1)).send();
+    let _included: TransactionSend<Included> = default.wait_until::<Included>();
+
+    let _final_send: TransactionSend<Final> = near
+        .transfer("bob.testnet", NearToken::from_near(1))
+        .wait_until::<Final>();
+}
+
+#[test]
+fn wait_level_types_map_to_rpc_statuses() {
+    assert_eq!(Submitted::STATUS, TxExecutionStatus::None);
+    assert_eq!(Included::STATUS, TxExecutionStatus::Included);
+    assert_eq!(IncludedFinal::STATUS, TxExecutionStatus::IncludedFinal);
+    assert_eq!(
+        ExecutedOptimistic::STATUS,
+        TxExecutionStatus::ExecutedOptimistic,
+    );
+    assert_eq!(Executed::STATUS, TxExecutionStatus::Executed);
+    assert_eq!(Final::STATUS, TxExecutionStatus::Final);
+}
+
+#[tokio::test]
+async fn status_query_reports_invalid_sender_when_awaited() {
+    let near = Near::testnet().build();
+    let error = near
+        .tx_status(&CryptoHash::ZERO, "not a valid account ID")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, Error::ParseAccountId(_)));
+}
+
+// These helpers are intentionally compile-only. Their signatures document and
+// verify the response type selected by each default and generic wait level.
+
+#[allow(dead_code)]
+async fn send_transaction_at<W: WaitLevel>(
+    transaction: TransactionBuilder,
+) -> Result<W::Response, Error> {
+    transaction.wait_until::<W>().await
+}
+
+#[allow(dead_code)]
+async fn send_call_at<W: WaitLevel>(call: CallBuilder) -> Result<W::Response, Error> {
+    call.wait_until::<W>().await
+}
+
+#[allow(dead_code)]
+async fn included_transaction_returns_progress(
+    transaction: TransactionBuilder,
+) -> Result<SendTxResponse, Error> {
+    transaction.wait_until::<Included>().await
+}
+
+#[allow(dead_code)]
+async fn final_transaction_returns_execution_outcome(
+    transaction: TransactionBuilder,
+) -> Result<FinalExecutionOutcome, Error> {
+    transaction.wait_until::<Final>().await
+}
+
+#[allow(dead_code)]
+async fn default_transaction_send_returns_execution_outcome(
+    transaction: TransactionBuilder,
+) -> Result<FinalExecutionOutcome, Error> {
+    transaction.await
+}
+
+#[allow(dead_code)]
+async fn send_signed_at<W: WaitLevel>(
+    near: &Near,
+    signed_tx: &SignedTransaction,
+) -> Result<W::Response, Error> {
+    near.send(signed_tx).wait_until::<W>().await
+}
+
+#[allow(dead_code)]
+async fn query_status_at<W: WaitLevel>(
+    near: &Near,
+    tx_hash: &CryptoHash,
+    sender_id: &AccountId,
+) -> Result<W::Response, Error> {
+    near.tx_status(tx_hash, sender_id).wait_until::<W>().await
+}
+
+#[allow(dead_code)]
+async fn default_signed_send_returns_execution_outcome(
+    near: &Near,
+    signed_tx: &SignedTransaction,
+) -> Result<FinalExecutionOutcome, Error> {
+    near.send(signed_tx).await
+}
+
+#[allow(dead_code)]
+async fn default_status_query_returns_current_progress(
+    near: &Near,
+    tx_hash: &CryptoHash,
+    sender_id: &AccountId,
+) -> Result<SendTxResponse, Error> {
+    near.tx_status(tx_hash, sender_id).await
+}


### PR DESCRIPTION
## Summary

This makes transaction wait levels type-only and gives built transactions, pre-signed transactions, and transaction-status queries one consistent fluent API.

Before, wait levels were passed as zero-sized positional values:

```rust
transaction.wait_until(Final).await?;
near.send_with_options(&signed_tx, Included).await?;
near.tx_status(&tx_hash, sender_id, Final).await?;
```

Now they are selected explicitly in type position:

```rust
transaction.wait_until::<Final>().await?;

near.send(&signed_tx)
    .wait_until::<Included>()
    .await?;

near.tx_status(&tx_hash, sender_id)
    .wait_until::<Final>()
    .await?;
```

The wait-level type still determines both the RPC `wait_until` value and the concrete Rust response type. Wire behavior and response conversion are unchanged.

## Why the old API looked like that

The positional value was intentional, even though the implementation named it `_level` and never read it.

Different wait levels return different static types:

- `Submitted`, `Included`, and `IncludedFinal` return `SendTxResponse`.
- `ExecutedOptimistic`, `Executed`, and `Final` return `FinalExecutionOutcome`.

A runtime enum cannot change an async function's concrete return type. The original typestate design therefore used zero-sized marker structs implementing `WaitLevel`. Passing `Final` let Rust infer `W = Final`; the implementation then selected `W::Response`, called the RPC status associated with `W`, and converted the raw response through `W`.

That is type-safe, but the public signature communicates the wrong model: a positional `Final` looks like runtime data even though it only exists to drive type inference. It is also awkward for generic wrappers, which must accept and forward a value that carries no information.

This change makes the API match the implementation: a wait level is a compile-time response contract.

## Design

All high-level transaction operations now use `.wait_until::<W>()`:

- `TransactionBuilder` and `CallBuilder` return the existing `TransactionSend<W>`.
- `Near::send` returns `SignedTransactionSend<'tx, W>` and replaces `send_with_options`.
- `Near::tx_status` returns `TransactionStatusQuery<W>`.

`WaitLevel::status()` is now the associated constant `WaitLevel::STATUS`, making the type-only mapping explicit. The builders store only `PhantomData<W>`; there is no runtime wait-level state.

This also makes generic composition straightforward:

```rust
async fn status_at<W: WaitLevel>(
    near: &Near,
    tx_hash: &CryptoHash,
    sender_id: &AccountId,
) -> Result<W::Response, Error> {
    near
        .tx_status(tx_hash, sender_id)
        .wait_until::<W>()
        .await
}
```

The low-level `RpcClient::send_tx` and `RpcClient::tx_status` methods are unchanged. They continue to accept runtime `TxExecutionStatus` values for callers that genuinely choose a wait level at runtime.

## Defaults and response types

The defaults are operation-specific:

- Built and pre-signed sends default to `ExecutedOptimistic`, preserving the existing direct-`.await` behavior and `FinalExecutionOutcome` response.
- A bare `tx_status(...).await` defaults to `Submitted`, making it a non-blocking query for the node's current progress and returning `SendTxResponse`.

| Wait-level type | RPC status | Response type |
| --- | --- | --- |
| `Submitted` | `NONE` | `SendTxResponse` |
| `Included` | `INCLUDED` | `SendTxResponse` |
| `IncludedFinal` | `INCLUDED_FINAL` | `SendTxResponse` |
| `ExecutedOptimistic` | `EXECUTED_OPTIMISTIC` | `FinalExecutionOutcome` |
| `Executed` | `EXECUTED` | `FinalExecutionOutcome` |
| `Final` | `FINAL` | `FinalExecutionOutcome` |

Early `tx_status` queries continue to preserve any partial receipt outcome already returned by `EXPERIMENTAL_tx_status`; the selected level controls how long the node waits, not whether already-available progress is discarded.

Both new builders are `#[must_use]`, so forgetting to await a send or status query still produces a compiler warning.

## Breaking migration

| Before | After |
| --- | --- |
| `.wait_until(Final)` | `.wait_until::<Final>()` |
| `.send().wait_until(Included)` | `.send().wait_until::<Included>()` |
| `near.send_with_options(&signed, Final).await` | `near.send(&signed).wait_until::<Final>().await` |
| `near.tx_status(&hash, sender, Final).await` | `near.tx_status(&hash, sender).wait_until::<Final>().await` |
| `near.tx_status(&hash, sender, Submitted).await` | `near.tx_status(&hash, sender).await` |
| `W::status()` | `W::STATUS` |

Ordinary `near.send(&signed).await` remains unchanged at the call site.

`Near::send` and `Near::tx_status` now return public types implementing `IntoFuture` rather than anonymous futures from `async fn`. Direct `.await` syntax is unchanged. Code passing these expressions directly to an API bounded on `Future` may need `.into_future()` or an `async move` wrapper.

## Examples and tests

This PR adds focused compile-time API coverage for:

- default and custom `TransactionSend<W>` typing;
- all six `WaitLevel::STATUS` mappings;
- generic `W::Response` composition across transaction, call, signed-send, and status-query paths;
- the `ExecutedOptimistic` default for sends;
- the `Submitted` default for status queries;
- deferred account-ID errors from `TransactionStatusQuery`.

Existing integration tests and public examples are migrated to the new syntax. The sandbox coverage also exercises:

- `Final` and early signed-transaction sends;
- full and partial `tx_status` responses;
- the new bare `tx_status` progress-query default;
- transaction, contract-call, token, delegate, gas-key, ML-DSA, tracing, and typed-contract paths.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo check --workspace --all-targets`
- `cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js`

GitHub's sandbox-backed `Test` job passes, including the live `tx_status` progress-query coverage.
