### PR TITLE
feat: put tracing behind a feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           cache-on-failure: "true"
       - run: cargo fmt --all -- --check
       - run: cargo clippy --workspace --all-targets --all-features
+      # Covers the tracing-off no-op facade (and sandbox without tracing)
+      - run: cargo clippy -p near-kit --all-targets --no-default-features --features sandbox
 
   test:
     name: Test

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Available known tokens: `tokens::USDC`, `tokens::USDT`, `tokens::W_NEAR`
 |---------|-------------|
 | `sandbox` | Local testing with [near-sandbox](https://crates.io/crates/near-sandbox) |
 | `keyring` | System keyring integration for desktop apps |
+| `tracing` | [`tracing`](https://crates.io/crates/tracing) spans and events for RPC calls and transactions (on by default; drop it with `default-features = false`) |
 | `interactive-clap` | Enables `interactive-clap` derives on re-exported `NearToken` and `Gas` for CLI tools |
 
 ### A note on `near-token` / `near-gas`

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -54,8 +54,8 @@ keyring = { workspace = true, optional = true }
 # Error handling
 thiserror.workspace = true
 
-# Logging
-tracing.workspace = true
+# Logging (optional; gated by `tracing` — see src/trace.rs for the no-op fallback)
+tracing = { workspace = true, optional = true }
 
 # Proc macros for typed contracts
 near-kit-macros.workspace = true
@@ -82,10 +82,13 @@ getrandom = { version = "0.2", default-features = false }
 getrandom_v04 = { package = "getrandom", version = "0.4", default-features = false }
 
 [features]
-default = ["keyring", "file-signer"]
+default = ["keyring", "file-signer", "tracing"]
 sandbox = ["dep:testcontainers", "dep:libc", "tokio/rt"]
 keyring = ["dep:keyring"]
 file-signer = ["dep:dirs"]
+# Emit `tracing` spans and events for RPC calls, transactions, and token
+# operations. Disable (via `default-features = false`) to drop the dependency.
+tracing = ["dep:tracing"]
 # JS-host entropy backend for `wasm32-unknown-unknown`. Enables `getrandom`'s
 # `js` feature (used transitively by `rand`/`ed25519-dalek`/`k256`) and
 # `getrandom` 0.4's `wasm_js` feature (used transitively by
@@ -100,6 +103,9 @@ interactive-clap = ["near-token/interactive-clap", "near-gas/interactive-clap"]
 [dev-dependencies]
 tokio-test.workspace = true
 tempfile.workspace = true
+# The tracing integration tests need the real `tracing` crate regardless of
+# how the optional main dependency is configured.
+tracing.workspace = true
 tracing-subscriber.workspace = true
 
 # All targets except JS-host wasm: full tokio runtime for tests and doctests

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -7,6 +7,7 @@ use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use crate::error::RpcError;
+use crate::trace;
 use crate::types::rpc::RawTransactionResponse;
 use crate::types::{
     AccessKeyListView, AccessKeyView, AccountId, AccountView, BlockEffects, BlockReference,
@@ -173,7 +174,7 @@ impl RpcClient {
     }
 
     /// Make a raw RPC call with retries.
-    #[tracing::instrument(skip(self, params), fields(rpc.method = method, rpc.url = %sanitize_url(&self.url)))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, params), fields(rpc.method = method, rpc.url = %sanitize_url(&self.url))))]
     pub async fn call<P: Serialize, R: DeserializeOwned>(
         &self,
         method: &str,
@@ -198,7 +199,7 @@ impl RpcClient {
                         self.retry_config.initial_delay_ms * 2u64.pow(attempt),
                         self.retry_config.max_delay_ms,
                     );
-                    tracing::warn!(
+                    trace::warn!(
                         attempt = attempt + 1,
                         max_attempts = total_attempts,
                         delay_ms = delay,
@@ -209,7 +210,7 @@ impl RpcClient {
                     continue;
                 }
                 Err(e) => {
-                    tracing::error!(error = %e, "RPC request failed");
+                    trace::error!(error = %e, "RPC request failed");
                     return Err(e);
                 }
             }
@@ -223,6 +224,9 @@ impl RpcClient {
         &self,
         request: &JsonRpcRequest<'_, impl Serialize>,
     ) -> Result<R, RpcError> {
+        // Gated on the feature (not routed through `crate::trace`) because the
+        // no-op macros would leave `json` unused.
+        #[cfg(feature = "tracing")]
         if tracing::enabled!(tracing::Level::TRACE)
             && let Ok(json) = serde_json::to_string(request)
         {
@@ -240,7 +244,7 @@ impl RpcClient {
         let status = response.status();
         let body = response.text().await?;
 
-        tracing::trace!(payload = %body, "RPC response");
+        trace::trace!(payload = %body, "RPC response");
 
         if !status.is_success() {
             // nearcore returns non-2xx (e.g. 422 UNKNOWN_BLOCK, 408 TIMEOUT_ERROR) with
@@ -513,7 +517,7 @@ impl RpcClient {
     // ========================================================================
 
     /// View account information.
-    #[tracing::instrument(skip(self, block), fields(%account_id))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, block), fields(%account_id)))]
     pub async fn view_account(
         &self,
         account_id: &AccountId,
@@ -527,7 +531,7 @@ impl RpcClient {
     }
 
     /// View access key information.
-    #[tracing::instrument(skip(self, block), fields(%account_id, %public_key))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, block), fields(%account_id, %public_key)))]
     pub async fn view_access_key(
         &self,
         account_id: &AccountId,
@@ -554,7 +558,7 @@ impl RpcClient {
     }
 
     /// View all access keys for an account.
-    #[tracing::instrument(skip(self, block), fields(%account_id))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, block), fields(%account_id)))]
     pub async fn view_access_key_list(
         &self,
         account_id: &AccountId,
@@ -571,7 +575,7 @@ impl RpcClient {
     ///
     /// This uses the stabilized `query` RPC shape with
     /// `request_type: "view_gas_key_nonces"`.
-    #[tracing::instrument(skip(self, block), fields(%account_id, %public_key))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, block), fields(%account_id, %public_key)))]
     pub async fn view_gas_key_nonces(
         &self,
         account_id: &AccountId,
@@ -588,7 +592,7 @@ impl RpcClient {
     }
 
     /// Call a view function on a contract.
-    #[tracing::instrument(skip(self, args, block), fields(contract_id = %account_id, method = method_name))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, args, block), fields(contract_id = %account_id, method = method_name)))]
     pub async fn view_function(
         &self,
         account_id: &AccountId,
@@ -630,7 +634,7 @@ impl RpcClient {
     /// View the WASM code deployed on an account.
     ///
     /// Uses the stabilized `query` RPC shape with `request_type: "view_code"`.
-    #[tracing::instrument(skip(self, block), fields(%account_id))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, block), fields(%account_id)))]
     pub async fn view_code(
         &self,
         account_id: &AccountId,
@@ -649,7 +653,7 @@ impl RpcClient {
     /// Picks the request type from the identifier kind:
     /// `view_global_contract_code` for code-hash identifiers,
     /// `view_global_contract_code_by_account_id` for publisher accounts.
-    #[tracing::instrument(skip(self, block), fields(?id))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, block), fields(?id)))]
     pub async fn view_global_contract_code(
         &self,
         id: &GlobalContractId,
@@ -692,7 +696,7 @@ impl RpcClient {
     ///
     /// Prefer [`RpcClient::view_state_all`] to collect every entry without
     /// managing the cursor yourself.
-    #[tracing::instrument(skip(self, prefix, after_key, block), fields(%account_id))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, prefix, after_key, block), fields(%account_id)))]
     pub async fn view_state(
         &self,
         account_id: &AccountId,
@@ -731,7 +735,7 @@ impl RpcClient {
     ///
     /// All pages are read against the same `block` so the result is a
     /// consistent snapshot.
-    #[tracing::instrument(skip(self, prefix, block), fields(%account_id))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, prefix, block), fields(%account_id)))]
     pub async fn view_state_all(
         &self,
         account_id: &AccountId,
@@ -776,7 +780,7 @@ impl RpcClient {
     }
 
     /// Get block information.
-    #[tracing::instrument(skip(self, block))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, block)))]
     pub async fn block(&self, block: BlockReference) -> Result<BlockView, RpcError> {
         let params = block.to_rpc_params();
         self.call("block", params).await
@@ -786,7 +790,7 @@ impl RpcClient {
     ///
     /// Uses the stabilized `block_effects` method (protocol 2.13), the new name
     /// for `EXPERIMENTAL_changes_in_block`.
-    #[tracing::instrument(skip(self, block))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, block)))]
     pub async fn block_effects(&self, block: BlockReference) -> Result<BlockEffects, RpcError> {
         let params = block.to_rpc_params();
         self.call("block_effects", params).await
@@ -797,7 +801,7 @@ impl RpcClient {
     /// Uses the stabilized `genesis_config` method (protocol 2.13), the new name
     /// for `EXPERIMENTAL_genesis_config`. The genesis config is a large,
     /// network-specific document, so it is returned as untyped JSON.
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     pub async fn genesis_config(&self) -> Result<serde_json::Value, RpcError> {
         // Send an empty params array (not `null`) — this is what the other
         // no-arg methods here use, and some JSON-RPC servers require `params` to
@@ -810,7 +814,7 @@ impl RpcClient {
     /// Each window is a half-open block-height range during which the validator
     /// has no block/chunk production duties. Uses the stabilized
     /// `maintenance_windows` method (protocol 2.13).
-    #[tracing::instrument(skip(self), fields(%account_id))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), fields(%account_id)))]
     pub async fn maintenance_windows(
         &self,
         account_id: &AccountId,
@@ -820,13 +824,13 @@ impl RpcClient {
     }
 
     /// Get node status.
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     pub async fn status(&self) -> Result<StatusResponse, RpcError> {
         self.call("status", serde_json::json!([])).await
     }
 
     /// Get current gas price.
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     pub async fn gas_price(&self, block_hash: Option<&CryptoHash>) -> Result<GasPrice, RpcError> {
         let params = match block_hash {
             Some(hash) => serde_json::json!([hash.to_string()]),
@@ -840,7 +844,7 @@ impl RpcClient {
     /// Pass `None` for the latest epoch, or a block height/hash to query a
     /// specific epoch. Finality and sync-checkpoint variants are treated as
     /// latest (the `validators` RPC accepts only `block_id` or `null`).
-    #[tracing::instrument(skip(self))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self)))]
     pub async fn validators(
         &self,
         block: Option<BlockReference>,
@@ -851,19 +855,19 @@ impl RpcClient {
 
     /// Send a signed transaction.
     ///
-    #[tracing::instrument(skip(self, signed_tx), fields(
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self, signed_tx), fields(
         tx_hash = tracing::field::Empty,
         sender = %signed_tx.transaction.signer_id,
         receiver = %signed_tx.transaction.receiver_id,
         ?wait_until,
-    ))]
+    )))]
     pub async fn send_tx(
         &self,
         signed_tx: &SignedTransaction,
         wait_until: TxExecutionStatus,
     ) -> Result<RawTransactionResponse, RpcError> {
         let tx_hash = signed_tx.get_hash();
-        tracing::Span::current().record("tx_hash", tracing::field::display(&tx_hash));
+        trace::Span::current().record("tx_hash", trace::field::display(&tx_hash));
         let params = serde_json::json!({
             "signed_tx_base64": signed_tx.to_base64(),
             "wait_until": wait_until.as_str(),
@@ -878,7 +882,7 @@ impl RpcClient {
     /// Uses `EXPERIMENTAL_tx_status` which returns complete receipt information.
     /// When the transaction has been executed, the outcome's `receipts` field
     /// will be populated (unlike `send_tx` which leaves it empty).
-    #[tracing::instrument(skip(self), fields(%tx_hash, sender = %sender_id, ?wait_until))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), fields(%tx_hash, sender = %sender_id, ?wait_until)))]
     pub async fn tx_status(
         &self,
         tx_hash: &CryptoHash,
@@ -905,7 +909,7 @@ impl RpcClient {
     /// Uses `EXPERIMENTAL_receipt_to_tx`, available on nodes running
     /// nearcore 2.12 or later. Returns [`RpcError::UnknownReceipt`] if the
     /// node does not know the receipt.
-    #[tracing::instrument(skip(self), fields(%receipt_id))]
+    #[cfg_attr(feature = "tracing", tracing::instrument(skip(self), fields(%receipt_id)))]
     pub async fn receipt_to_tx(
         &self,
         receipt_id: &CryptoHash,
@@ -1048,6 +1052,8 @@ fn block_id_or_null(block: Option<&BlockReference>) -> serde_json::Value {
 ///
 /// RPC provider URLs may carry API keys as query parameters or path tokens.
 /// This returns `scheme://host/path` so credentials don't leak into tracing spans.
+// Without `tracing`, only the unit tests reference this.
+#[cfg_attr(not(feature = "tracing"), allow(dead_code))]
 fn sanitize_url(url: &str) -> &str {
     // Strip query and fragment
     let end = url.find('?').or_else(|| url.find('#')).unwrap_or(url.len());

--- a/crates/near-kit/src/client/transaction.rs
+++ b/crates/near-kit/src/client/transaction.rs
@@ -33,7 +33,7 @@ use std::future::IntoFuture;
 use std::marker::PhantomData;
 use std::sync::{Arc, OnceLock};
 
-use tracing::Instrument;
+use crate::trace::{self, Instrument};
 
 use crate::error::{Error, RpcError};
 use crate::types::{
@@ -57,6 +57,7 @@ fn nonce_manager() -> &'static NonceManager {
 /// Produce a comma-separated summary of action types for tracing spans.
 ///
 /// Function calls include the method name, e.g. `"create_account,transfer,function_call(init)"`.
+#[cfg(feature = "tracing")]
 fn actions_summary(actions: &[Action]) -> String {
     use std::fmt::Write;
     let mut out = String::new();
@@ -90,6 +91,7 @@ fn actions_summary(actions: &[Action]) -> String {
 /// When the actions contain exactly one function call, records `method`, `gas`,
 /// and `deposit` on the current span. Multiple function calls emit a debug event
 /// per call instead, since span fields can't repeat.
+#[cfg(feature = "tracing")]
 fn record_function_call_fields(actions: &[Action]) {
     let function_calls: Vec<_> = actions
         .iter()
@@ -101,14 +103,14 @@ fn record_function_call_fields(actions: &[Action]) {
 
     match function_calls.as_slice() {
         [fc] => {
-            let span = tracing::Span::current();
+            let span = trace::Span::current();
             span.record("method", fc.method_name.as_str());
-            span.record("gas", tracing::field::display(&fc.gas));
-            span.record("deposit", tracing::field::display(&fc.deposit));
+            span.record("gas", trace::field::display(&fc.gas));
+            span.record("deposit", trace::field::display(&fc.deposit));
         }
         multiple if !multiple.is_empty() => {
             for fc in multiple {
-                tracing::debug!(
+                trace::debug!(
                     method = %fc.method_name,
                     gas = %fc.gas,
                     deposit = %fc.deposit,
@@ -748,21 +750,21 @@ impl TransactionBuilder {
             .ok_or(Error::NoSigner)?;
 
         let signer_id = signer.account_id().clone();
-        let action_count = self.actions.len();
 
-        let span = tracing::info_span!(
+        let span = trace::info_span!(
             "build_transaction",
             sender = %signer_id,
             receiver = %self.receiver_id,
-            action_count,
+            action_count = self.actions.len(),
             actions = %actions_summary(&self.actions),
-            method = tracing::field::Empty,
-            gas = tracing::field::Empty,
-            deposit = tracing::field::Empty,
+            method = trace::field::Empty,
+            gas = trace::field::Empty,
+            deposit = trace::field::Empty,
         );
 
         let actions = self.actions;
         async move {
+            #[cfg(feature = "tracing")]
             record_function_call_fields(&actions);
 
             // Use public_key() directly to avoid side effects from key() —
@@ -796,7 +798,7 @@ impl TransactionBuilder {
                 actions,
             );
 
-            tracing::debug!(tx_hash = %tx.get_hash(), nonce, "Transaction built (unsigned)");
+            trace::debug!(tx_hash = %tx.get_hash(), nonce, "Transaction built (unsigned)");
 
             Ok(tx)
         }
@@ -894,21 +896,21 @@ impl TransactionBuilder {
             .ok_or(Error::NoSigner)?;
 
         let signer_id = signer.account_id().clone();
-        let action_count = self.actions.len();
 
-        let span = tracing::info_span!(
+        let span = trace::info_span!(
             "sign_transaction",
             sender = %signer_id,
             receiver = %self.receiver_id,
-            action_count,
+            action_count = self.actions.len(),
             actions = %actions_summary(&self.actions),
-            method = tracing::field::Empty,
-            gas = tracing::field::Empty,
-            deposit = tracing::field::Empty,
+            method = trace::field::Empty,
+            gas = trace::field::Empty,
+            deposit = trace::field::Empty,
         );
 
         let actions = self.actions;
         async move {
+            #[cfg(feature = "tracing")]
             record_function_call_fields(&actions);
 
             // Get a signing key atomically. For RotatingSigner, this claims the next
@@ -950,7 +952,7 @@ impl TransactionBuilder {
             let tx_hash = tx.get_hash();
             let signature = key.sign(tx_hash.as_bytes()).await?;
 
-            tracing::debug!(tx_hash = %tx_hash, nonce, "Transaction signed");
+            trace::debug!(tx_hash = %tx_hash, nonce, "Transaction signed");
 
             Ok(SignedTransaction {
                 transaction: tx,
@@ -1616,18 +1618,19 @@ impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
 
             let signer_id = signer.account_id().clone();
 
-            let span = tracing::info_span!(
+            let span = trace::info_span!(
                 "send_transaction",
                 sender = %signer_id,
                 receiver = %builder.receiver_id,
                 action_count = builder.actions.len(),
                 actions = %actions_summary(&builder.actions),
-                method = tracing::field::Empty,
-                gas = tracing::field::Empty,
-                deposit = tracing::field::Empty,
+                method = trace::field::Empty,
+                gas = trace::field::Empty,
+                deposit = trace::field::Empty,
             );
 
             async move {
+                #[cfg(feature = "tracing")]
                 record_function_call_fields(&builder.actions);
 
                 // Retry loop for transient InvalidTxErrors (nonce conflicts, expired block hash)
@@ -1699,7 +1702,7 @@ impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
                         Err(RpcError::InvalidTx(
                             crate::types::InvalidTxError::InvalidNonce { tx_nonce, ak_nonce },
                         )) if attempt < max_nonce_retries => {
-                            tracing::warn!(
+                            trace::warn!(
                                 tx_nonce = tx_nonce,
                                 ak_nonce = ak_nonce,
                                 attempt = attempt + 1,
@@ -1715,7 +1718,7 @@ impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
                         Err(RpcError::InvalidTx(crate::types::InvalidTxError::Expired))
                             if attempt + 1 < max_nonce_retries =>
                         {
-                            tracing::warn!(
+                            trace::warn!(
                                 attempt = attempt + 1,
                                 "Transaction expired (stale block hash), retrying with fresh block hash"
                             );
@@ -1729,7 +1732,7 @@ impl<W: WaitLevel> IntoFuture for TransactionSend<W> {
                             continue;
                         }
                         Err(e) => {
-                            tracing::error!(error = %e, "Transaction send failed");
+                            trace::error!(error = %e, "Transaction send failed");
                             return Err(e.into());
                         }
                     }

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -370,6 +370,8 @@
 //! `near-kit` compiles for `wasm32-unknown-unknown` (Dioxus, Leptos, Yew, etc.) with
 //! `default-features = false`. This disables `keyring` and `file-signer` (both use OS
 //! APIs unavailable in the browser); use [`InMemorySigner`] or [`EnvSigner`] instead.
+//! It also disables `tracing`; add `features = ["tracing"]` back if you want spans
+//! (the `tracing` crate itself is wasm-compatible).
 //!
 //! `near-kit` relies on `getrandom` (via `rand`, `ed25519-dalek`, `k256`, and `ml-dsa`)
 //! for key generation and nonce randomness. On `wasm32-unknown-unknown`, `getrandom`
@@ -415,6 +417,7 @@
 //! |---------|---------|-------------|
 //! | `keyring` | Yes | System keyring signer (macOS Keychain, Windows Credential Manager, etc.) |
 //! | `file-signer` | Yes | [`FileSigner`] for loading keys from `~/.near-credentials` |
+//! | `tracing` | Yes | [`tracing`](https://docs.rs/tracing) spans and events for RPC calls and transactions |
 //! | `sandbox` | No | Integration with `near-sandbox` for local testing |
 //! | `js` | No | JS-host entropy backend (`getrandom`'s `js`/`wasm_js`) for `wasm32-unknown-unknown` |
 //!
@@ -445,6 +448,7 @@ pub mod contract;
 pub mod error;
 mod platform;
 pub mod tokens;
+mod trace;
 pub mod types;
 
 // Sandbox module - only available with "sandbox" feature

--- a/crates/near-kit/src/sandbox.rs
+++ b/crates/near-kit/src/sandbox.rs
@@ -72,13 +72,13 @@
 use std::borrow::Cow;
 use std::sync::Arc;
 
+use crate::trace::info;
 use testcontainers::{
     ContainerAsync, CopyToContainer, Image,
     core::{ContainerPort, WaitFor},
     runners::AsyncRunner,
 };
 use tokio::sync::OnceCell;
-use tracing::info;
 
 use crate::client::Near;
 

--- a/crates/near-kit/src/tokens/ft.rs
+++ b/crates/near-kit/src/tokens/ft.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
+use crate::trace::{self, Instrument};
 use serde::Serialize;
 use tokio::sync::OnceCell;
-use tracing::Instrument;
 
 use crate::client::{CallBuilder, RpcClient, Signer, TransactionBuilder};
 use crate::error::Error;
@@ -162,7 +162,7 @@ impl FungibleToken {
     /// ```
     pub async fn balance_of(&self, account_id: impl TryIntoAccountId) -> Result<FtAmount, Error> {
         let account_id: AccountId = account_id.try_into_account_id()?;
-        let span = tracing::debug_span!("ft_balance_of", contract = %self.contract_id, %account_id);
+        let span = trace::debug_span!("ft_balance_of", contract = %self.contract_id, %account_id);
 
         async {
             let metadata = self.metadata().await?;
@@ -380,7 +380,7 @@ impl FungibleToken {
         let receiver_id: AccountId = receiver_id
             .try_into_account_id()
             .expect("invalid account ID");
-        tracing::debug!(contract = %self.contract_id, receiver = %receiver_id, "ft_transfer");
+        trace::debug!(contract = %self.contract_id, receiver = %receiver_id, "ft_transfer");
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -460,7 +460,7 @@ impl FungibleToken {
         let receiver_id: AccountId = receiver_id
             .try_into_account_id()
             .expect("invalid account ID");
-        tracing::debug!(contract = %self.contract_id, receiver = %receiver_id, "ft_transfer_call");
+        trace::debug!(contract = %self.contract_id, receiver = %receiver_id, "ft_transfer_call");
 
         #[derive(Serialize)]
         struct TransferCallArgs {

--- a/crates/near-kit/src/tokens/nft.rs
+++ b/crates/near-kit/src/tokens/nft.rs
@@ -2,9 +2,9 @@
 
 use std::sync::Arc;
 
+use crate::trace::{self, Instrument};
 use serde::Serialize;
 use tokio::sync::OnceCell;
-use tracing::Instrument;
 
 use crate::client::{CallBuilder, RpcClient, Signer, TransactionBuilder};
 use crate::error::Error;
@@ -148,7 +148,7 @@ impl NonFungibleToken {
     /// ```
     pub async fn token(&self, token_id: impl AsRef<str>) -> Result<Option<NftToken>, Error> {
         let token_id = token_id.as_ref();
-        let span = tracing::debug_span!("nft_token", contract = %self.contract_id, token_id);
+        let span = trace::debug_span!("nft_token", contract = %self.contract_id, token_id);
 
         async {
             #[derive(Serialize)]
@@ -205,7 +205,7 @@ impl NonFungibleToken {
     ) -> Result<Vec<NftToken>, Error> {
         let account_id: AccountId = account_id.try_into_account_id()?;
         let span =
-            tracing::debug_span!("nft_tokens_for_owner", contract = %self.contract_id, %account_id);
+            trace::debug_span!("nft_tokens_for_owner", contract = %self.contract_id, %account_id);
 
         async {
             #[derive(Serialize)]
@@ -327,7 +327,7 @@ impl NonFungibleToken {
         let receiver_id: AccountId = receiver_id
             .try_into_account_id()
             .expect("invalid account ID");
-        tracing::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), receiver = %receiver_id, "nft_transfer");
+        trace::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), receiver = %receiver_id, "nft_transfer");
         #[derive(Serialize)]
         struct TransferArgs {
             receiver_id: String,
@@ -430,7 +430,7 @@ impl NonFungibleToken {
         let receiver_id: AccountId = receiver_id
             .try_into_account_id()
             .expect("invalid account ID");
-        tracing::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), receiver = %receiver_id, "nft_transfer_call");
+        trace::debug!(contract = %self.contract_id, token_id = token_id.as_ref(), receiver = %receiver_id, "nft_transfer_call");
         #[derive(Serialize)]
         struct TransferCallArgs {
             receiver_id: String,

--- a/crates/near-kit/src/trace.rs
+++ b/crates/near-kit/src/trace.rs
@@ -30,7 +30,7 @@ mod noop {
             Span
         }
 
-        pub(crate) fn record<V>(&self, _field: &str, _value: V) -> &Self {
+        pub(crate) fn record<Q: ?Sized, V>(&self, _field: &Q, _value: V) -> &Self {
             self
         }
     }

--- a/crates/near-kit/src/trace.rs
+++ b/crates/near-kit/src/trace.rs
@@ -1,0 +1,74 @@
+//! Internal facade over the `tracing` crate.
+//!
+//! With the `tracing` feature enabled (the default) this re-exports the real
+//! macros and types. Without it, everything compiles down to no-ops so call
+//! sites don't need `cfg` guards. The one thing this can't cover is the
+//! `#[tracing::instrument]` attribute macro — those sites use
+//! `#[cfg_attr(feature = "tracing", tracing::instrument(...))]` instead.
+//!
+//! Note the no-op event/span macros discard their arguments without
+//! evaluating them, so values that are only used inside a tracing call must
+//! themselves be gated on the feature (or they trigger unused warnings).
+
+// Which re-exports are referenced depends on other features (e.g. `info` is
+// only used under `sandbox`), and rustc's unused-import tracking is unreliable
+// across macro re-export chains — so allow unused here.
+#[cfg(feature = "tracing")]
+#[allow(unused_imports)]
+pub(crate) use tracing::{
+    Instrument, Span, debug, debug_span, error, field, info, info_span, trace, warn,
+};
+
+#[cfg(not(feature = "tracing"))]
+mod noop {
+    /// No-op stand-in for `tracing::Span`.
+    #[derive(Clone, Debug)]
+    pub(crate) struct Span;
+
+    impl Span {
+        pub(crate) fn current() -> Self {
+            Span
+        }
+
+        pub(crate) fn record<V>(&self, _field: &str, _value: V) -> &Self {
+            self
+        }
+    }
+
+    /// No-op stand-in for `tracing::Instrument`: `.instrument(span)` returns
+    /// the future unchanged.
+    pub(crate) trait Instrument: Sized {
+        fn instrument(self, _span: Span) -> Self {
+            self
+        }
+    }
+
+    impl<T> Instrument for T {}
+
+    /// No-op stand-ins for the `tracing::field` helpers used in plain code
+    /// (the ones inside span/event macros are discarded with the macro args).
+    pub(crate) mod field {
+        pub(crate) fn display<T>(value: T) -> T {
+            value
+        }
+    }
+
+    macro_rules! noop_event {
+        ($($args:tt)*) => {{}};
+    }
+
+    macro_rules! noop_span {
+        ($($args:tt)*) => {
+            $crate::trace::Span
+        };
+    }
+
+    pub(crate) use {noop_event, noop_span};
+}
+
+#[cfg(not(feature = "tracing"))]
+#[allow(unused_imports)]
+pub(crate) use noop::{
+    Instrument, Span, field, noop_event as debug, noop_event as error, noop_event as info,
+    noop_event as trace, noop_event as warn, noop_span as debug_span, noop_span as info_span,
+};

--- a/crates/near-kit/src/types/error.rs
+++ b/crates/near-kit/src/types/error.rs
@@ -15,15 +15,15 @@ use super::{AccountId, CryptoHash, Gas, NearToken, PublicKey};
 /// Raw JSON payload of an error this version of near-kit could not parse
 /// into a typed variant.
 ///
-/// Emits a `tracing::warn!` when constructed during deserialization so
-/// fallback misclassification is observable.
+/// Emits a `tracing::warn!` when constructed during deserialization (with the
+/// `tracing` feature enabled) so fallback misclassification is observable.
 #[derive(Debug, Clone)]
 pub struct UnknownError(pub serde_json::Value);
 
 impl<'de> serde::Deserialize<'de> for UnknownError {
     fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
         let value = serde_json::Value::deserialize(deserializer)?;
-        tracing::warn!(raw = %value, "unrecognized error variant from RPC, falling back to Unknown");
+        crate::trace::warn!(raw = %value, "unrecognized error variant from RPC, falling back to Unknown");
         Ok(Self(value))
     }
 }

--- a/crates/near-kit/tests/integration/main.rs
+++ b/crates/near-kit/tests/integration/main.rs
@@ -23,6 +23,7 @@ mod signer_edge_cases_integration;
 mod stabilized_rpc_integration;
 mod token_error_integration;
 mod token_integration;
+#[cfg(feature = "tracing")]
 mod tracing_integration;
 mod transaction_failure_integration;
 mod transaction_outcome_integration;


### PR DESCRIPTION
Closes #253

Makes the `tracing` dependency optional behind a new **default-on** `tracing` feature. Default builds are unchanged; users who don't need it (e.g. wasm embedders already building with `default-features = false`) drop the dependency entirely.

## How

- **`src/trace.rs` facade**: internally, all call sites go through `crate::trace`, which re-exports the real tracing macros/types when the feature is on and compiles to no-ops (empty event macros, unit `Span`, identity `Instrument`) when it's off — so call sites stay free of `cfg` noise.
- `#[tracing::instrument]` attribute macros can't be shimmed by the facade, so those become `#[cfg_attr(feature = "tracing", tracing::instrument(...))]`.
- The no-op macros discard their arguments unevaluated, so values used *only* in tracing calls would trigger unused warnings with the feature off. Span-only helpers (`actions_summary`, `record_function_call_fields`), the TRACE-level payload block in `try_call`, and `sanitize_url`'s dead-code state are gated/annotated accordingly; the `action_count` locals are inlined into the span macros.
- Tracing integration tests are gated on the feature, with `tracing` added as a dev-dependency so they always see the real crate.
- CI: new clippy line for `--no-default-features --features sandbox`, covering the no-op facade and the sandbox-without-tracing combination (the existing wasm job already builds with `--no-default-features`).

## Impact on dependency trees

- Native: `tracing` remains transitively via reqwest's hyper/h2 stack, so this mainly drops near-kit's own spans/events codegen.
- `wasm32-unknown-unknown` (`--no-default-features --features js`): `tracing` is **fully gone** from the tree.

## Testing

- `cargo clippy --workspace --all-targets --all-features` ✓ (RUSTFLAGS=-Dwarnings)
- `cargo clippy -p near-kit --all-targets --no-default-features` (± `sandbox`, ± `tracing`) ✓
- `cargo check --target wasm32-unknown-unknown --no-default-features --features js` ✓
- Unit tests: 503 passed (default), 498 passed (`--no-default-features`; the 5 delta is keyring/file-signer-gated) ✓
- Live sandbox: all 4 `tracing_integration` tests pass — span hierarchy and enriched fields unchanged with the feature on ✓