### PR TITLE
feat: make the RPC client optional via a default-on `rpc` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features
       # Covers the tracing-off no-op facade (and sandbox without tracing)
       - run: cargo clippy -p near-kit --all-targets --no-default-features --features sandbox
+      # Covers the offline (no `rpc`) configuration
+      - run: cargo check -p near-kit --no-default-features
 
   test:
     name: Test
@@ -73,10 +75,13 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown,wasm32-wasip2
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: wasm
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: "true"
       - run: cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js
+      # WASI: the offline core (types, signing, tx building) — no HTTP transport
+      # builds for this target yet, so `rpc` stays off
+      - run: cargo check --target wasm32-wasip2 -p near-kit --no-default-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       - run: cargo clippy --workspace --all-targets --all-features
       # Covers the tracing-off no-op facade (and sandbox without tracing)
       - run: cargo clippy -p near-kit --all-targets --no-default-features --features sandbox
-      # Covers the offline (no `rpc`) configuration
-      - run: cargo check -p near-kit --no-default-features
+      # Covers the offline (no `rpc`) configuration, including tests/examples gating
+      - run: cargo check -p near-kit --all-targets --no-default-features
 
   test:
     name: Test
@@ -51,6 +51,10 @@ jobs:
         run: cargo llvm-cov --workspace --features sandbox --lcov --output-path lcov.info
       - name: Run doctests
         run: cargo test --workspace --doc
+      # The offline (no `rpc`) configuration keeps its own doctests compiling;
+      # examples that need the RPC layer are cfg_attr'd to `ignore` without it
+      - name: Run offline doctests
+        run: cargo test -p near-kit --no-default-features --doc
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -81,7 +85,8 @@ jobs:
           shared-key: wasm
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: "true"
-      - run: cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js
+      # Browser: the full client over reqwest's JS `fetch` backend
+      - run: cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js,rpc
       # WASI: the offline core (types, signing, tx building) — no HTTP transport
       # builds for this target yet, so `rpc` stays off
       - run: cargo check --target wasm32-wasip2 -p near-kit --no-default-features

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Available known tokens: `tokens::USDC`, `tokens::USDT`, `tokens::W_NEAR`
 
 ### Offline / no-network usage
 
-With `default-features = false` the RPC layer drops out and near-kit becomes a pure offline toolkit: all the types, the signers, transaction building and signing, and NEP-413 `verify_signature`. This is what you want on targets without an HTTP stack — the motivating example is `wasm32-wasip2`, where you can sign transactions and messages inside a component and hand them off for submission elsewhere.
+With `default-features = false` the RPC layer drops out and near-kit becomes a pure offline toolkit: all the types, the signers, transaction construction and signing via `Transaction` (`new` → `sign` → `to_bytes`), and NEP-413 `verify_signature`. This is what you want on targets without an HTTP stack — the motivating example is `wasm32-wasip2`, where you can sign transactions and messages inside a component and hand them off for submission elsewhere. Note the fluent `TransactionBuilder` belongs to the RPC layer (it is created from a `Near` client), so it requires the `rpc` feature.
 
 ### A note on `near-token` / `near-gas`
 

--- a/README.md
+++ b/README.md
@@ -198,10 +198,15 @@ Available known tokens: `tokens::USDC`, `tokens::USDT`, `tokens::W_NEAR`
 
 | Feature | Description |
 |---------|-------------|
+| `rpc` | The RPC layer: the `Near` client, queries, transactions, token helpers, and the HTTP client (on by default) |
 | `sandbox` | Local testing with [near-sandbox](https://crates.io/crates/near-sandbox) |
 | `keyring` | System keyring integration for desktop apps |
 | `tracing` | [`tracing`](https://crates.io/crates/tracing) spans and events for RPC calls and transactions (on by default; drop it with `default-features = false`) |
 | `interactive-clap` | Enables `interactive-clap` derives on re-exported `NearToken` and `Gas` for CLI tools |
+
+### Offline / no-network usage
+
+With `default-features = false` the RPC layer drops out and near-kit becomes a pure offline toolkit: all the types, the signers, transaction building and signing, and NEP-413 `verify_signature`. This is what you want on targets without an HTTP stack — the motivating example is `wasm32-wasip2`, where you can sign transactions and messages inside a component and hand them off for submission elsewhere.
 
 ### A note on `near-token` / `near-gas`
 

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -22,8 +22,8 @@ near-global-contracts.workspace = true
 tokio = { version = "1", features = ["sync"] }
 futures.workspace = true
 
-# HTTP client
-reqwest.workspace = true
+# HTTP client (optional; gated by `rpc` — the offline build has no transport)
+reqwest = { workspace = true, optional = true }
 
 # Serialization
 serde.workspace = true
@@ -82,8 +82,14 @@ getrandom = { version = "0.2", default-features = false }
 getrandom_v04 = { package = "getrandom", version = "0.4", default-features = false }
 
 [features]
-default = ["keyring", "file-signer", "tracing"]
-sandbox = ["dep:testcontainers", "dep:libc", "tokio/rt"]
+default = ["rpc", "keyring", "file-signer", "tracing"]
+# The JSON-RPC layer: the `Near` client, query/transaction builders, contract
+# and token helpers, and the HTTP transport underneath them. Disable (via
+# `default-features = false`) for offline use — types, signing, and transaction
+# building without a network stack (e.g. on wasm32-wasip2, where reqwest
+# doesn't build).
+rpc = ["dep:reqwest"]
+sandbox = ["rpc", "dep:testcontainers", "dep:libc", "tokio/rt"]
 keyring = ["dep:keyring"]
 file-signer = ["dep:dirs"]
 # Emit `tracing` spans and events for RPC calls, transactions, and token

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -106,6 +106,17 @@ js = ["getrandom/js", "getrandom_v04/wasm_js"]
 # Useful for CLI tools using `interactive-clap` for argument parsing.
 interactive-clap = ["near-token/interactive-clap", "near-gas/interactive-clap"]
 
+# These two examples drive a live `Near` client end to end, so they only build
+# with the RPC layer. The remaining examples compile without `rpc`: their
+# client usage sits behind `#[cfg(feature = "sandbox")]` with stub fallbacks.
+[[example]]
+name = "quickstart"
+required-features = ["rpc"]
+
+[[example]]
+name = "meta_transactions"
+required-features = ["rpc"]
+
 [dev-dependencies]
 tokio-test.workspace = true
 tempfile.workspace = true

--- a/crates/near-kit/src/client/mod.rs
+++ b/crates/near-kit/src/client/mod.rs
@@ -36,25 +36,36 @@
 //! - [`CallBuilder`] — Function call builder (part of transactions)
 //! - [`FunctionCall`] — Standalone function call for composable transactions
 
+// Everything that talks to the network lives behind the `rpc` feature; the
+// signers stay available in offline builds (they only do local cryptography).
+#[cfg(feature = "rpc")]
 mod near;
+#[cfg(feature = "rpc")]
 mod nonce_manager;
+#[cfg(feature = "rpc")]
 mod query;
+#[cfg(feature = "rpc")]
 mod rpc;
 mod signer;
+#[cfg(feature = "rpc")]
 mod transaction;
 
 #[cfg(feature = "keyring")]
 mod keyring_signer;
 
+#[cfg(feature = "rpc")]
 pub use near::{Near, NearBuilder, SANDBOX_ROOT_ACCOUNT, SANDBOX_ROOT_SECRET_KEY, SandboxNetwork};
+#[cfg(feature = "rpc")]
 pub use query::{
     AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, ContractCodeQuery,
     GlobalContractQuery, TransactionStatusQuery, ViewCall, ViewCallBorsh,
 };
+#[cfg(feature = "rpc")]
 pub use rpc::{RetryConfig, RpcClient};
 #[cfg(feature = "file-signer")]
 pub use signer::FileSigner;
 pub use signer::{EnvSigner, InMemorySigner, RotatingSigner, Signer, SigningKey};
+#[cfg(feature = "rpc")]
 pub use transaction::{
     CallBuilder, DelegateOptions, DelegateResult, FunctionCall, SignedTransactionSend,
     TransactionBuilder, TransactionSend,

--- a/crates/near-kit/src/client/signer.rs
+++ b/crates/near-kit/src/client/signer.rs
@@ -13,7 +13,8 @@
 //!
 //! # Example
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::{Near, InMemorySigner};
 //!
 //! # async fn example() -> Result<(), near_kit::Error> {
@@ -684,7 +685,8 @@ impl Signer for EnvSigner {
 /// Keys can be loaded from any storage backend (file, keyring, env) via
 /// [`from_signers()`](Self::from_signers):
 ///
-/// ```rust,no_run
+#[cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#[cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 /// # use near_kit::*;
 /// let rotating = RotatingSigner::from_signers(vec![
 ///     FileSigner::from_file("keys/bot-key-0.json", "bot.testnet")?.into_inner(),
@@ -764,7 +766,8 @@ impl RotatingSigner {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
+    #[cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+    #[cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
     /// use near_kit::{RotatingSigner, FileSigner};
     ///
     /// // Load keys from separate credential files for the same account

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -169,6 +169,9 @@ pub enum KeyStoreError {
 #[derive(Debug, Error)]
 pub enum RpcError {
     // ─── Network/Transport ───
+    // reqwest only compiles with the `rpc` feature, so this variant (and its
+    // `is_retryable` arm below) exists only there.
+    #[cfg(feature = "rpc")]
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
 
@@ -299,6 +302,7 @@ impl RpcError {
     /// Check if this error is retryable.
     pub fn is_retryable(&self) -> bool {
         match self {
+            #[cfg(feature = "rpc")]
             RpcError::Http(e) => {
                 // `is_connect()` doesn't exist on reqwest's JS fetch backend
                 // (`wasm32-unknown-unknown` — no hyper connector); `is_request()`

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -17,7 +17,8 @@
 //!
 //! ## Handling Transaction Errors
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::*;
 //!
 //! # async fn example() -> Result<(), Error> {
@@ -166,7 +167,12 @@ pub enum KeyStoreError {
 // ============================================================================
 
 /// RPC-specific errors.
+// `non_exhaustive` keeps the `rpc` feature additive: the `Http` variant below
+// only exists with the feature on, so an exhaustive downstream match written
+// against the offline build would otherwise break when feature unification
+// turns `rpc` on.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum RpcError {
     // ─── Network/Transport ───
     // reqwest only compiles with the `rpc` feature, so this variant (and its

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -18,7 +18,8 @@
 //!
 //! No credentials needed for querying blockchain state:
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::*;
 //!
 //! #[tokio::main]
@@ -41,7 +42,8 @@
 //!
 //! For state-changing operations, configure a signer:
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::*;
 //!
 //! #[tokio::main]
@@ -118,7 +120,8 @@
 //!
 //! Many builder methods also accept strings directly:
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! # use near_kit::*;
 //! # async fn example(near: &Near) -> Result<(), Error> {
 //! near.call("contract.testnet", "method")
@@ -133,7 +136,8 @@
 //!
 //! Read operations return query builders that can be customized before awaiting:
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::*;
 //!
 //! # async fn example() -> Result<(), Error> {
@@ -167,7 +171,8 @@
 //!
 //! Write operations return transaction builders for customization:
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::*;
 //!
 //! # async fn example(near: &Near) -> Result<(), Error> {
@@ -190,7 +195,8 @@
 //!
 //! Chain multiple actions into a single atomic transaction:
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::*;
 //!
 //! # async fn example(near: &Near) -> Result<(), Box<dyn std::error::Error>> {
@@ -219,7 +225,8 @@
 //! to avoid copy-pasting addresses. They automatically resolve to the correct address
 //! based on the network:
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::*;
 //!
 //! # async fn example() -> Result<(), Error> {
@@ -295,7 +302,8 @@
 //! | [`RotatingSigner`] | High-throughput with multiple keys (avoids nonce collisions) |
 //! | [`KeyringSigner`] | System keyring (macOS Keychain, etc.) — requires `keyring` feature |
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::*;
 //!
 //! # fn example() -> Result<(), Error> {
@@ -320,7 +328,8 @@
 //! For production apps that manage multiple accounts, use [`Near::with_signer`] to
 //! derive clients that share the same RPC connection but sign as different accounts:
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::*;
 //!
 //! # fn example() -> Result<(), Error> {
@@ -371,7 +380,9 @@
 //! `default-features = false`. This disables `keyring` and `file-signer` (both use OS
 //! APIs unavailable in the browser); use [`InMemorySigner`] or [`EnvSigner`] instead.
 //! It also disables `tracing`; add `features = ["tracing"]` back if you want spans
-//! (the `tracing` crate itself is wasm-compatible).
+//! (the `tracing` crate itself is wasm-compatible). And it disables `rpc` — add it
+//! back to keep the [`Near`] client, which speaks HTTP through the browser's `fetch`
+//! on this target.
 //!
 //! `near-kit` relies on `getrandom` (via `rand`, `ed25519-dalek`, `k256`, and `ml-dsa`)
 //! for key generation and nonce randomness. On `wasm32-unknown-unknown`, `getrandom`
@@ -381,13 +392,15 @@
 //!
 //! ```toml
 //! [dependencies]
-//! near-kit = { version = "0.12", default-features = false, features = ["js"] }
+//! near-kit = { version = "0.13", default-features = false, features = ["js", "rpc"] }
 //! ```
 //!
 //! If you're running `wasm32-unknown-unknown` outside a JS host, leave `js` off and
 //! register your own `getrandom` backend instead (see below) — forcing the browser
-//! backend would break your runtime. (WASI targets like `wasm32-wasip1` don't need any
-//! of this: `getrandom` supports them natively, so leave `js` off there too.)
+//! backend would break your runtime. Leave `rpc` off there too: the HTTP client is
+//! `fetch`-backed on this target, so without a JS host only the offline core (see
+//! below) works. (WASI targets like `wasm32-wasip1` don't need any of this:
+//! `getrandom` supports them natively, so leave `js` off there too.)
 //!
 //! ### Custom entropy backends
 //!
@@ -397,7 +410,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! near-kit = { version = "0.12", default-features = false }
+//! near-kit = { version = "0.13", default-features = false }
 //! getrandom = { version = "0.2", features = ["custom"] }
 //! ```
 //!
@@ -442,7 +455,8 @@
 //! All operations return `Result<T, near_kit::Error>`. The [`Error`] type provides
 //! detailed information about failures:
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::*;
 //!
 //! # async fn example() -> Result<(), Error> {

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -392,7 +392,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! near-kit = { version = "0.13", default-features = false, features = ["js", "rpc"] }
+//! near-kit = { version = "0.14", default-features = false, features = ["js", "rpc"] }
 //! ```
 //!
 //! If you're running `wasm32-unknown-unknown` outside a JS host, leave `js` off and
@@ -410,7 +410,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! near-kit = { version = "0.13", default-features = false }
+//! near-kit = { version = "0.14", default-features = false }
 //! getrandom = { version = "0.2", features = ["custom"] }
 //! ```
 //!
@@ -430,13 +430,16 @@
 //! token helpers, and the HTTP client underneath — is gated behind the default-on
 //! `rpc` feature. With `default-features = false` you keep the offline core:
 //! all the types, the signers ([`InMemorySigner`], [`EnvSigner`], ...),
-//! transaction building and signing, and NEP-413 [`nep413::verify_signature`].
+//! transaction construction and signing via [`Transaction`](types::Transaction)
+//! (`new` → `sign` → `to_bytes`), and NEP-413 [`nep413::verify_signature`].
+//! The fluent [`TransactionBuilder`] is part of the RPC layer — it is created
+//! from a [`Near`] client — so it requires `rpc`.
 //! The motivating target is `wasm32-wasip2`, where the HTTP client doesn't
 //! build — sign transactions and messages in the component, send them elsewhere:
 //!
 //! ```toml
 //! [dependencies]
-//! near-kit = { version = "0.13", default-features = false }
+//! near-kit = { version = "0.14", default-features = false }
 //! ```
 //!
 //! ## Feature Flags

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -411,14 +411,30 @@
 //! also works for 0.4: it compiles everywhere and errors at runtime if entropy is ever
 //! requested.
 //!
+//! ## Offline / no-network usage
+//!
+//! The entire RPC layer — [`Near`], the query/transaction builders, contract and
+//! token helpers, and the HTTP client underneath — is gated behind the default-on
+//! `rpc` feature. With `default-features = false` you keep the offline core:
+//! all the types, the signers ([`InMemorySigner`], [`EnvSigner`], ...),
+//! transaction building and signing, and NEP-413 [`nep413::verify_signature`].
+//! The motivating target is `wasm32-wasip2`, where the HTTP client doesn't
+//! build — sign transactions and messages in the component, send them elsewhere:
+//!
+//! ```toml
+//! [dependencies]
+//! near-kit = { version = "0.13", default-features = false }
+//! ```
+//!
 //! ## Feature Flags
 //!
 //! | Feature | Default | Description |
 //! |---------|---------|-------------|
+//! | `rpc` | Yes | The RPC layer: [`Near`], queries, transactions, tokens, and the HTTP client. Disable for offline signing/verification (e.g. on `wasm32-wasip2`) |
 //! | `keyring` | Yes | System keyring signer (macOS Keychain, Windows Credential Manager, etc.) |
 //! | `file-signer` | Yes | [`FileSigner`] for loading keys from `~/.near-credentials` |
 //! | `tracing` | Yes | [`tracing`](https://docs.rs/tracing) spans and events for RPC calls and transactions |
-//! | `sandbox` | No | Integration with `near-sandbox` for local testing |
+//! | `sandbox` | No | Integration with `near-sandbox` for local testing (implies `rpc`) |
 //! | `js` | No | JS-host entropy backend (`getrandom`'s `js`/`wasm_js`) for `wasm32-unknown-unknown` |
 //!
 //! ## Error Handling
@@ -444,9 +460,11 @@
 //! ```
 
 pub mod client;
+#[cfg(feature = "rpc")]
 pub mod contract;
 pub mod error;
 mod platform;
+#[cfg(feature = "rpc")]
 pub mod tokens;
 mod trace;
 pub mod types;
@@ -461,16 +479,19 @@ pub use types::nep413;
 pub use types::*;
 
 // Re-export contract types
+#[cfg(feature = "rpc")]
 pub use contract::{Contract, ContractClient};
 
 // Re-export client types
+#[cfg(feature = "rpc")]
 pub use client::{
     AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, CallBuilder,
-    ContractCodeQuery, DelegateOptions, DelegateResult, EnvSigner, FunctionCall,
-    GlobalContractQuery, InMemorySigner, Near, NearBuilder, RetryConfig, RotatingSigner, RpcClient,
-    SandboxNetwork, SignedTransactionSend, Signer, SigningKey, TransactionBuilder, TransactionSend,
-    TransactionStatusQuery, ViewCall, ViewCallBorsh,
+    ContractCodeQuery, DelegateOptions, DelegateResult, FunctionCall, GlobalContractQuery, Near,
+    NearBuilder, RetryConfig, RpcClient, SandboxNetwork, SignedTransactionSend, TransactionBuilder,
+    TransactionSend, TransactionStatusQuery, ViewCall, ViewCallBorsh,
 };
+// The signers do local cryptography only — they stay available offline.
+pub use client::{EnvSigner, InMemorySigner, RotatingSigner, Signer, SigningKey};
 
 #[cfg(feature = "file-signer")]
 pub use client::FileSigner;
@@ -479,13 +500,18 @@ pub use client::FileSigner;
 pub use client::KeyringSigner;
 
 // Re-export token types
+#[cfg(feature = "rpc")]
 pub use tokens::{
     FtAmount, FtMetadata, FungibleToken, IntoContractId, KnownToken, NftContractMetadata, NftToken,
     NftTokenMetadata, NonFungibleToken, StorageBalance, StorageBalanceBounds, USDC, USDT, W_NEAR,
 };
 
-// Re-export proc macros
+// Re-export proc macros. `#[contract]` expands to code that uses `Near`,
+// `ContractClient`, and the query/call builders, so it needs `rpc`; the other
+// three are inert markers (`call`) or serialization-format overrides
+// (`borsh`/`json`) whose expansions reference nothing network-bound.
 pub use near_kit_macros::borsh;
 pub use near_kit_macros::call;
+#[cfg(feature = "rpc")]
 pub use near_kit_macros::contract;
 pub use near_kit_macros::json;

--- a/crates/near-kit/src/trace.rs
+++ b/crates/near-kit/src/trace.rs
@@ -19,7 +19,11 @@ pub(crate) use tracing::{
     Instrument, Span, debug, debug_span, error, field, info, info_span, trace, warn,
 };
 
+// Only the event-macro stand-ins have users in every feature combination
+// (e.g. `types/error.rs`); the span/instrument/field stand-ins are used
+// exclusively from `rpc`-gated code, so without `rpc` they are dead code.
 #[cfg(not(feature = "tracing"))]
+#[cfg_attr(not(feature = "rpc"), allow(dead_code, unused_macros))]
 mod noop {
     /// No-op stand-in for `tracing::Span`.
     #[derive(Clone, Debug)]

--- a/crates/near-kit/src/types/nep413.rs
+++ b/crates/near-kit/src/types/nep413.rs
@@ -57,9 +57,15 @@ use borsh::BorshSerialize;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::{hex::Hex, serde_as};
 
+// These three are only used by the RPC-backed `verify()`; the offline
+// `verify_signature()` path doesn't need them.
+#[cfg(feature = "rpc")]
 use crate::Near;
+#[cfg(feature = "rpc")]
 use crate::error::Error;
-use crate::types::{AccountId, BlockReference, CryptoHash, PublicKey, Signature};
+#[cfg(feature = "rpc")]
+use crate::types::BlockReference;
+use crate::types::{AccountId, CryptoHash, PublicKey, Signature};
 
 /// NEP-413 tag prefix: 2^31 + 413 = 2147484061
 ///
@@ -513,6 +519,7 @@ pub fn verify_signature(
 /// # Ok(())
 /// # }
 /// ```
+#[cfg(feature = "rpc")]
 pub async fn verify(
     signed: &SignedMessage,
     params: &SignMessageParams,

--- a/crates/near-kit/src/types/nep413.rs
+++ b/crates/near-kit/src/types/nep413.rs
@@ -5,7 +5,8 @@
 //!
 //! # Example
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! use near_kit::{Near, InMemorySigner, nep413};
 //!
 //! # async fn example() -> Result<(), near_kit::Error> {
@@ -162,7 +163,8 @@ impl AuthPayload {
     ///
     /// # Example
     ///
-    /// ```rust,no_run
+    #[cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+    #[cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
     /// use near_kit::{Near, nep413};
     ///
     /// # async fn example() -> Result<(), near_kit::Error> {

--- a/crates/near-kit/src/types/rpc.rs
+++ b/crates/near-kit/src/types/rpc.rs
@@ -697,7 +697,8 @@ pub enum FinalExecutionStatus {
 ///
 /// # Example
 ///
-/// ```rust,no_run
+#[cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#[cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 /// # use near_kit::*;
 /// # async fn example(near: &Near) -> Result<(), Error> {
 /// let response = near.transfer("bob.testnet", NearToken::from_near(1))

--- a/crates/near-kit/src/types/wait_level.rs
+++ b/crates/near-kit/src/types/wait_level.rs
@@ -4,7 +4,8 @@
 //! associated `Response` type. This lets the compiler determine the return type
 //! of `send().wait_until::<W>()` from the selected type:
 //!
-//! ```rust,no_run
+#![cfg_attr(feature = "rpc", doc = "```rust,no_run")]
+#![cfg_attr(not(feature = "rpc"), doc = "```rust,ignore")]
 //! # use near_kit::*;
 //! # async fn example(near: &Near) -> Result<(), Error> {
 //! // Default — returns FinalExecutionOutcome

--- a/crates/near-kit/tests/macro_derives.rs
+++ b/crates/near-kit/tests/macro_derives.rs
@@ -1,4 +1,5 @@
 //! The `#[near_kit::contract]` macro must derive `Debug` + `Clone` on the generated marker and client types.
+#![cfg(feature = "rpc")]
 use near_kit::*;
 
 #[contract]

--- a/crates/near-kit/tests/wait_level_api.rs
+++ b/crates/near-kit/tests/wait_level_api.rs
@@ -1,4 +1,5 @@
 //! Compile-time examples for the type-only transaction wait-level API.
+#![cfg(feature = "rpc")]
 
 use near_kit::*;
 


### PR DESCRIPTION
## Summary

Puts the JSON-RPC layer — `Near`, the query/transaction builders, contract and token helpers, and the reqwest HTTP transport under them — behind a new default-on `rpc` feature. With `default-features = false`, near-kit becomes a pure offline toolkit: all the types, the signers, transaction building and signing, and NEP-413 `verify_signature`.

The motivation is `wasm32-wasip2`: near/intents' defuse-wallet-sdk wants near-kit inside a WASI component, and reqwest has no WASI backend (seanmonstar/reqwest#2979, seanmonstar/reqwest#2453) — on `target_os = "wasi"` it resolves to its native stack, which fails on the aws-lc-sys C cross-compile and on hyper forcing tokio's `net` feature (a hard `compile_error!` on wasm). Gating the transport lets the offline core compile there today. Default-feature users are unaffected.

## Design notes

- `rpc = ["dep:reqwest"]`, on by default; `sandbox` implies `rpc`. The gate covers `client/{near,query,rpc,transaction,nonce_manager}`, the `contract` and `tokens` modules, and the `#[contract]` macro re-export (its expansion references `Near` and the builders). Signers stay available offline — they're local cryptography only.
- `RpcError`'s `Http(reqwest::Error)` variant only exists with `rpc`, so the enum is now `#[non_exhaustive]`: without that, enabling the feature would add a variant and break downstream exhaustive matches via feature unification (features must be additive). This is a one-time breaking change for anyone matching `RpcError` exhaustively today, in the same release as the gating itself.
- Feature-gated cargo targets follow the existing `sandbox` conventions: `#![cfg(feature = "rpc")]` in tests/wait_level_api.rs and tests/macro_derives.rs, `required-features = ["rpc"]` on the quickstart and meta_transactions examples.
- Doctests attached to offline items (signer/error/nep413/wait_level module docs, the crate docs) demonstrate `Near`-driven usage, which is the right example content for the default reader. Their fences are `cfg_attr`'d: `rust,no_run` with `rpc` on, `rust,ignore` without — so they stay compile-checked in the default doctest run and `cargo test -p near-kit --no-default-features --doc` also passes.
- CI: the offline check runs with `--all-targets`, a new lane runs the offline doctests, and the wasm32-unknown-unknown check builds `--features js,rpc` — the full client on reqwest's `fetch` backend. That coverage existed implicitly while reqwest was non-optional and would otherwise have been lost (e.g. the wasm-specific `is_request()` arm in `RpcError::is_retryable` compiles in no other configuration). The wasip2 check stays `rpc`-off since no transport builds there yet.
- Docs: the WebAssembly section now tells browser users to use `features = ["js", "rpc"]`, and a new "Offline / no-network usage" section (lib.rs + README) covers the `default-features = false` story.

## Test plan

All run locally with `RUSTFLAGS=-Dwarnings`:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-targets --all-features` — clean
- `cargo clippy -p near-kit --all-targets --no-default-features --features sandbox` — clean
- `cargo check -p near-kit --all-targets --no-default-features` — clean (was 31 errors across tests/examples before the gating fixes)
- `cargo check -p near-kit --no-default-features --features rpc` — clean
- `cargo check -p near-kit` (default features) — clean
- `cargo test -p near-kit --lib` — 506 passed
- `cargo test --workspace --doc` — 136 passed, 0 failed
- `cargo test -p near-kit --no-default-features --doc` — 36 passed, 0 failed, 28 ignored (was 18 failures)
- `cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js,rpc` — clean
- `cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js` — clean
- `cargo check --target wasm32-wasip2 -p near-kit --no-default-features` — clean
- `cargo +1.88 check --workspace --all-targets` (MSRV) — clean

Note: part 1 of 2 — a follow-up PR (feat/rpc-transport-wasip2, stacked on this branch) adds a pluggable RpcTransport with a wasi:http implementation so the RPC client itself works on wasm32-wasip2.
