### PR TITLE
feat: derive ML-DSA-65 keys from BIP-39 seed phrases

### DIFF
--- a/crates/near-kit/src/types/hd.rs
+++ b/crates/near-kit/src/types/hd.rs
@@ -1,10 +1,16 @@
-//! SLIP-10 Ed25519 hierarchical deterministic key derivation.
+//! SLIP-10 hardened hierarchical deterministic key derivation.
 //!
 //! Implements the Ed25519 branch of SLIP-0010
-//! (<https://github.com/satoshilabs/slips/blob/master/slip-0010.md>).
+//! (<https://github.com/satoshilabs/slips/blob/master/slip-0010.md>) and the
+//! ML-DSA-65 branch of the analogous post-quantum construction from
+//! satoshilabs/slips#1968 (adopted by near/devex#58). Both branches share the
+//! identical SLIP-10 machinery — the same hardened-only child step over
+//! HMAC-SHA512 — and differ *only* in the master HMAC salt: `"ed25519 seed"`
+//! for Ed25519, `"ML-DSA-65 seed"` for ML-DSA-65. As a result the two keys
+//! derived from the same BIP-39 seed are unrelated.
 //!
-//! Ed25519 SLIP-10 only supports hardened derivation — non-hardened
-//! components are rejected by [`parse_hd_path`].
+//! Only hardened derivation is supported — non-hardened components are rejected
+//! by [`parse_hd_path`].
 
 use hmac::{Hmac, KeyInit, Mac};
 use sha2::Sha512;
@@ -13,6 +19,12 @@ type HmacSha512 = Hmac<Sha512>;
 
 /// BIP-32 hardened derivation offset (2^31).
 const HARDENED: u32 = 0x8000_0000;
+
+/// Master HMAC salt for the Ed25519 SLIP-0010 branch.
+const ED25519_SEED_SALT: &[u8] = b"ed25519 seed";
+
+/// Master HMAC salt for the ML-DSA-65 branch (satoshilabs/slips#1968).
+const ML_DSA65_SEED_SALT: &[u8] = b"ML-DSA-65 seed";
 
 /// Error parsing a BIP-32 path string for Ed25519 SLIP-10 derivation.
 #[derive(Debug, PartialEq, Eq)]
@@ -82,21 +94,24 @@ pub(crate) fn parse_hd_path(path: &str) -> Result<Vec<u32>, HdPathError> {
         .collect()
 }
 
-/// Derive a 32-byte Ed25519 secret scalar from `seed` along `path` using
-/// SLIP-10 for the Ed25519 curve.
+/// Derive the full 64-byte SLIP-10 node `I = I_L || I_R` (the secret scalar
+/// followed by the chain code) from `seed` along `path`, using `salt` as the
+/// master HMAC key.
 ///
-/// `path` must be a slice of already-hardened indexes (each with the high
-/// bit set). Use [`parse_hd_path`] to produce one from a string.
-pub(crate) fn derive_ed25519_slip10(seed: &[u8], path: &[u32]) -> [u8; 32] {
-    // Master: I = HMAC-SHA512(key="ed25519 seed", data=seed)
-    let mut mac = HmacSha512::new_from_slice(b"ed25519 seed").expect("HMAC accepts any key length");
+/// This is the shared engine behind [`derive_ed25519_slip10`] and
+/// [`derive_ml_dsa65_slip10`]; the two branches differ only in `salt`. `path`
+/// must be a slice of already-hardened indexes (each with the high bit set).
+/// Use [`parse_hd_path`] to produce one from a string.
+fn derive_slip10_node(salt: &[u8], seed: &[u8], path: &[u32]) -> [u8; 64] {
+    // Master: I = HMAC-SHA512(key=salt, data=seed)
+    let mut mac = HmacSha512::new_from_slice(salt).expect("HMAC accepts any key length");
     mac.update(seed);
     let mut i = mac.finalize().into_bytes();
 
     for &index in path {
         debug_assert!(
             index & HARDENED != 0,
-            "ed25519 SLIP-10 requires hardened indexes; got {index:#x}"
+            "SLIP-10 requires hardened indexes; got {index:#x}"
         );
         // Hardened child: Data = 0x00 || I_L(parent) || ser32(index)
         let (il, ir) = i.split_at(32);
@@ -111,8 +126,33 @@ pub(crate) fn derive_ed25519_slip10(seed: &[u8], path: &[u32]) -> [u8; 32] {
         i = mac.finalize().into_bytes();
     }
 
+    let mut node = [0u8; 64];
+    node.copy_from_slice(&i);
+    node
+}
+
+/// Derive a 32-byte Ed25519 secret scalar from `seed` along `path` using
+/// SLIP-10 for the Ed25519 curve (master salt `"ed25519 seed"`).
+///
+/// `path` must be a slice of already-hardened indexes (each with the high
+/// bit set). Use [`parse_hd_path`] to produce one from a string.
+pub(crate) fn derive_ed25519_slip10(seed: &[u8], path: &[u32]) -> [u8; 32] {
+    let node = derive_slip10_node(ED25519_SEED_SALT, seed, path);
     let mut key = [0u8; 32];
-    key.copy_from_slice(&i[..32]);
+    key.copy_from_slice(&node[..32]);
+    key
+}
+
+/// Derive a 32-byte ML-DSA-65 node secret (the FIPS-204 seed ξ) from `seed`
+/// along `path` using the SLIP-10 construction from satoshilabs/slips#1968
+/// (master salt `"ML-DSA-65 seed"`). Feed the result to ML-DSA-65 KeyGen.
+///
+/// `path` must be a slice of already-hardened indexes (each with the high
+/// bit set). Use [`parse_hd_path`] to produce one from a string.
+pub(crate) fn derive_ml_dsa65_slip10(seed: &[u8], path: &[u32]) -> [u8; 32] {
+    let node = derive_slip10_node(ML_DSA65_SEED_SALT, seed, path);
+    let mut key = [0u8; 32];
+    key.copy_from_slice(&node[..32]);
     key
 }
 
@@ -207,6 +247,121 @@ mod tests {
                 &parse_hd_path("m/0'/2147483647'/1'/2147483646'/2'").unwrap()
             )),
             "551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d"
+        );
+    }
+
+    // ------------------------------------------------------------------------
+    // ML-DSA-65 test vectors (satoshilabs/slips#1968, adopted by near/devex#58)
+    //
+    // Same SLIP-10 machinery as the ed25519 vectors above, but with the master
+    // salt "ML-DSA-65 seed"; the 32-byte node secret I_L is the FIPS-204 seed ξ
+    // fed to ML-DSA-65 KeyGen. Each row is [path, chain_code, sha256(pubkey)].
+    // We assert the chain code verbatim and the SHA-256 of the 1952-byte
+    // ML-DSA-65 public key derived from I_L (the raw keys are too large to
+    // inline). These are the verbatim slips#1968 vectors, which are themselves
+    // validated against the NIST ACVP ML-DSA-keyGen-FIPS204 KATs.
+    // ------------------------------------------------------------------------
+
+    fn assert_ml_dsa65_vectors(seed_hex: &str, rows: &[(&str, &str, &str)]) {
+        use sha2::{Digest, Sha256};
+
+        let seed = unhex(seed_hex);
+        for (path, chain_code, pk_sha256) in rows {
+            let node = derive_slip10_node(ML_DSA65_SEED_SALT, &seed, &parse_hd_path(path).unwrap());
+            assert_eq!(
+                hex::encode(&node[32..]),
+                *chain_code,
+                "chain code for {path}"
+            );
+
+            // Derive the ML-DSA-65 public key from I_L via the real key path.
+            let il: [u8; 32] = node[..32].try_into().unwrap();
+            let public = crate::types::key::SecretKey::ml_dsa65_from_seed(il).public_key();
+            let raw = public.as_ml_dsa65_bytes().expect("full ML-DSA-65 key");
+            assert_eq!(
+                hex::encode(Sha256::digest(raw.as_slice())),
+                *pk_sha256,
+                "pubkey digest for {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn slip1968_vec1_ml_dsa65() {
+        assert_ml_dsa65_vectors(
+            "000102030405060708090a0b0c0d0e0f",
+            &[
+                (
+                    "m",
+                    "7e74b6275f92cc4fb2cbdac0c63cb5e7ac2bce1ded2b7dbc7bf2232f772578d5",
+                    "f41b8366cd9b720dbab9dfcefde673e4c19798192d7543f30f277e57e77ba457",
+                ),
+                (
+                    "m/0'",
+                    "d8b27c87ec212d6501629199262a9d0d66ec26deab313c26a474bc4ddd5dce7c",
+                    "1d9d7fce0a1560acef9b117f3e3022cb0bdd46f30a3134db33165baf66b53e7e",
+                ),
+                (
+                    "m/0'/1'",
+                    "60219beef857bd0bc7870424c4f60464decb097a18ae37b035df22ebaa7515b9",
+                    "0fdc416cbe544a493b59ae8112a907d5acf09ed4583eb8e12d6c769bcf394943",
+                ),
+                (
+                    "m/0'/1'/2'",
+                    "dc7b0e1379b3f1acd02d1e25f13d8bb16830ca68c73b00d900b9030a41d6a658",
+                    "6db4146987c59099709622700d66bcb07b8d49e1007ea6570e15fc3f6dac1c53",
+                ),
+                (
+                    "m/0'/1'/2'/2'",
+                    "565cb34027c3b54773f7f48e329bc86db7ffc6f618b112af6d59a3f82501e17a",
+                    "d487dcf16e74ddd731fafe780d0e5e8b8d338d4f7a3b7e209f8b4c519419764d",
+                ),
+                (
+                    "m/0'/1'/2'/2'/1000000000'",
+                    "dc65d6cf4fa993c2f04fae2b41d70d8c5ba4c9d2042ea5720bf42a2315a6b7db",
+                    "9591ff122a7eff9cd64100f2123e678db9c257815ec5570b0b6acd8847e62f24",
+                ),
+            ],
+        );
+    }
+
+    #[test]
+    fn slip1968_vec2_ml_dsa65() {
+        assert_ml_dsa65_vectors(
+            "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a2\
+             9f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542",
+            &[
+                (
+                    "m",
+                    "0e696f43f0e71c1c9febf61f43f10903385b78cee5871915472027b25ba755cc",
+                    "36233a01384e7081becf4da903d10fe7d357da9061cbed1983819fe0a0ced509",
+                ),
+                (
+                    "m/0'",
+                    "d977be3c8525364e155764ef76b985126d8f6be41b55e6e50a9915ae29f27a56",
+                    "577dc77b0987d6cc587a88605590b183f3a7580577dab08cac1ede0a9636b882",
+                ),
+                (
+                    "m/0'/2147483647'",
+                    "45406bac7fc36390d89ac938bff6ca1ebf9fc6da2057d1580b26a8f2e25a0d2f",
+                    "a0155112060496906db18bd46cdd7e18dd35e6e14621083300a0027fd6a421a2",
+                ),
+                (
+                    "m/0'/2147483647'/1'",
+                    "10ffddec3c4acf719afe528b1ced03e0f7d8555999c11b69376bd5ff4e04dbea",
+                    "41357d47d1269fe94f9fc66396d7dc768e5bcaae700a0b877471a06ef2e12d27",
+                ),
+                (
+                    "m/0'/2147483647'/1'/2147483646'",
+                    "3580d842e9d8d6a072b77d95e08b0a87648edfaec9bc25cee6c9127d1aa4a679",
+                    "e947963f404e03be513bdccf23c5a3cb9bd4455f306276fcd9acd4b0d3e16e75",
+                ),
+                (
+                    "m/0'/2147483647'/1'/2147483646'/2'",
+                    "55a202d3f7803dd79e31c454e65eb7da49dee824b467bfed5204df980e71571d",
+                    "4b6c9f1dd1a811fe704c1355e32c43b63007317868ed6c3fce385f11c1b5da39",
+                ),
+            ],
         );
     }
 

--- a/crates/near-kit/src/types/hd.rs
+++ b/crates/near-kit/src/types/hd.rs
@@ -26,7 +26,7 @@ const ED25519_SEED_SALT: &[u8] = b"ed25519 seed";
 /// Master HMAC salt for the ML-DSA-65 branch (satoshilabs/slips#1968).
 const ML_DSA65_SEED_SALT: &[u8] = b"ML-DSA-65 seed";
 
-/// Error parsing a BIP-32 path string for Ed25519 SLIP-10 derivation.
+/// Error parsing a BIP-32 path string for SLIP-10 derivation.
 #[derive(Debug, PartialEq, Eq)]
 pub(crate) enum HdPathError {
     /// A path segment was empty (e.g. `"m//0'"` or a trailing `/`).
@@ -35,7 +35,8 @@ pub(crate) enum HdPathError {
     InvalidIndex(String),
     /// The raw index was ≥ 2^31 (the hardened bit position).
     IndexOutOfRange(String),
-    /// Ed25519 SLIP-10 requires every component to be hardened (`'` or `H` suffix).
+    /// SLIP-10 (both the Ed25519 and ML-DSA-65 branches) requires every
+    /// component to be hardened (`'` or `H` suffix).
     NotHardened(String),
 }
 
@@ -46,7 +47,7 @@ impl std::fmt::Display for HdPathError {
             Self::InvalidIndex(s) => write!(f, "invalid path index {s:?}"),
             Self::IndexOutOfRange(s) => write!(f, "path index out of range {s:?}"),
             Self::NotHardened(s) => {
-                write!(f, "ed25519 requires hardened derivation, got {s:?}")
+                write!(f, "SLIP-10 requires hardened derivation, got {s:?}")
             }
         }
     }

--- a/crates/near-kit/src/types/key.rs
+++ b/crates/near-kit/src/types/key.rs
@@ -13,7 +13,7 @@ use rand::rngs::OsRng;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use sha2::Digest;
 
-use super::hd::{derive_ed25519_slip10, parse_hd_path};
+use super::hd::{derive_ed25519_slip10, derive_ml_dsa65_slip10, parse_hd_path};
 use crate::error::{ParseKeyError, SignerError};
 
 /// ML-DSA-65 public key length in bytes (FIPS 204).
@@ -761,28 +761,105 @@ impl SecretKey {
         hd_path: impl AsRef<str>,
         passphrase: Option<&str>,
     ) -> Result<Self, SignerError> {
-        // Normalize and parse mnemonic
-        let normalized = phrase
-            .as_ref()
-            .trim()
-            .to_lowercase()
-            .split_whitespace()
-            .collect::<Vec<_>>()
-            .join(" ");
-
-        let mnemonic: Mnemonic = normalized
-            .parse()
-            .map_err(|_| SignerError::InvalidSeedPhrase)?;
-
-        // Convert mnemonic to seed (64 bytes)
-        let seed = mnemonic.to_seed(passphrase.unwrap_or(""));
-
-        // Parse HD path and derive via SLIP-10 (Ed25519)
+        let seed = mnemonic_to_seed(phrase, passphrase)?;
         let path = parse_hd_path(hd_path.as_ref())
             .map_err(|e| SignerError::KeyDerivationFailed(format!("Invalid HD path: {e}")))?;
         let derived = derive_ed25519_slip10(&seed, &path);
 
         Ok(Self::ed25519_from_bytes(derived))
+    }
+
+    /// Derive an ML-DSA-65 secret key from a BIP-39 seed phrase.
+    ///
+    /// Uses the post-quantum SLIP-10 construction from satoshilabs/slips#1968
+    /// with the default NEAR HD path (`m/44'/397'/0'`): the 32-byte node secret
+    /// is the FIPS-204 seed ξ fed to ML-DSA-65 KeyGen.
+    ///
+    /// The master HMAC salt differs from the Ed25519 branch (`"ML-DSA-65 seed"`
+    /// vs `"ed25519 seed"`), so the ML-DSA-65 key derived from a phrase is
+    /// **unrelated** to the Ed25519 key derived from the same phrase.
+    ///
+    /// # Arguments
+    ///
+    /// * `phrase` - BIP-39 mnemonic phrase (12, 15, 18, 21, or 24 words)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use near_kit::SecretKey;
+    ///
+    /// let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    /// let secret_key = SecretKey::ml_dsa65_from_seed_phrase(phrase).unwrap();
+    /// assert!(secret_key.to_string().starts_with("ml-dsa-65:"));
+    /// ```
+    pub fn ml_dsa65_from_seed_phrase(phrase: impl AsRef<str>) -> Result<Self, SignerError> {
+        Self::ml_dsa65_from_seed_phrase_with_path(phrase, DEFAULT_HD_PATH)
+    }
+
+    /// Derive an ML-DSA-65 secret key from a BIP-39 seed phrase with a custom
+    /// HD path.
+    ///
+    /// Uses the satoshilabs/slips#1968 SLIP-10 construction. Only hardened
+    /// derivation paths are supported (all path components must use `'`).
+    ///
+    /// # Arguments
+    ///
+    /// * `phrase` - BIP-39 mnemonic phrase (12, 15, 18, 21, or 24 words)
+    /// * `hd_path` - BIP-32 derivation path (e.g., `"m/44'/397'/0'"`)
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use near_kit::SecretKey;
+    ///
+    /// let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    /// let secret_key = SecretKey::ml_dsa65_from_seed_phrase_with_path(phrase, "m/44'/397'/1'").unwrap();
+    /// ```
+    pub fn ml_dsa65_from_seed_phrase_with_path(
+        phrase: impl AsRef<str>,
+        hd_path: impl AsRef<str>,
+    ) -> Result<Self, SignerError> {
+        Self::ml_dsa65_from_seed_phrase_with_path_and_passphrase(phrase, hd_path, None)
+    }
+
+    /// Derive an ML-DSA-65 secret key from a BIP-39 seed phrase with a
+    /// passphrase.
+    ///
+    /// The passphrase provides additional entropy for seed generation (BIP-39
+    /// feature). An empty passphrase is equivalent to no passphrase. Derivation
+    /// otherwise follows satoshilabs/slips#1968 — see
+    /// [`SecretKey::ml_dsa65_from_seed_phrase`] for the salt caveat.
+    ///
+    /// # Arguments
+    ///
+    /// * `phrase` - BIP-39 mnemonic phrase
+    /// * `hd_path` - BIP-32 derivation path
+    /// * `passphrase` - Optional passphrase for additional entropy
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use near_kit::SecretKey;
+    ///
+    /// let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    /// let secret_key = SecretKey::ml_dsa65_from_seed_phrase_with_path_and_passphrase(
+    ///     phrase,
+    ///     "m/44'/397'/0'",
+    ///     Some("my-passphrase"),
+    /// )
+    /// .unwrap();
+    /// ```
+    pub fn ml_dsa65_from_seed_phrase_with_path_and_passphrase(
+        phrase: impl AsRef<str>,
+        hd_path: impl AsRef<str>,
+        passphrase: Option<&str>,
+    ) -> Result<Self, SignerError> {
+        let seed = mnemonic_to_seed(phrase, passphrase)?;
+        let path = parse_hd_path(hd_path.as_ref())
+            .map_err(|e| SignerError::KeyDerivationFailed(format!("Invalid HD path: {e}")))?;
+        let derived = derive_ml_dsa65_slip10(&seed, &path);
+
+        Ok(Self::ml_dsa65_from_seed(derived))
     }
 
     /// Generate a new random seed phrase and derive the corresponding secret key.
@@ -1160,6 +1237,32 @@ impl BorshDeserialize for Signature {
 // Seed Phrase Generation
 // ============================================================================
 
+/// Normalize a BIP-39 mnemonic and derive its 64-byte seed, applying an
+/// optional passphrase.
+///
+/// Shared by the Ed25519 and ML-DSA-65 seed-phrase constructors: the mnemonic
+/// is trimmed, lowercased, and whitespace-collapsed before parsing, then run
+/// through BIP-39's PBKDF2 seed derivation. The two key branches differ only
+/// downstream, in the SLIP-10 master salt.
+fn mnemonic_to_seed(
+    phrase: impl AsRef<str>,
+    passphrase: Option<&str>,
+) -> Result<[u8; 64], SignerError> {
+    let normalized = phrase
+        .as_ref()
+        .trim()
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    let mnemonic: Mnemonic = normalized
+        .parse()
+        .map_err(|_| SignerError::InvalidSeedPhrase)?;
+
+    Ok(mnemonic.to_seed(passphrase.unwrap_or("")))
+}
+
 /// Generate a random BIP-39 seed phrase.
 ///
 /// # Arguments
@@ -1340,6 +1443,27 @@ impl KeyPair {
     /// ```
     pub fn from_seed_phrase(phrase: impl AsRef<str>) -> Result<Self, SignerError> {
         let secret_key = SecretKey::from_seed_phrase(phrase)?;
+        Ok(Self::from_secret_key(secret_key))
+    }
+
+    /// Create an ML-DSA-65 key pair from a seed phrase using the default NEAR
+    /// HD path.
+    ///
+    /// Derives the post-quantum key via satoshilabs/slips#1968; see
+    /// [`SecretKey::ml_dsa65_from_seed_phrase`] for details (including why it is
+    /// unrelated to the Ed25519 key from the same phrase).
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use near_kit::KeyPair;
+    ///
+    /// let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    /// let keypair = KeyPair::ml_dsa65_from_seed_phrase(phrase).unwrap();
+    /// assert!(keypair.public_key.to_string().starts_with("ml-dsa-65:"));
+    /// ```
+    pub fn ml_dsa65_from_seed_phrase(phrase: impl AsRef<str>) -> Result<Self, SignerError> {
+        let secret_key = SecretKey::ml_dsa65_from_seed_phrase(phrase)?;
         Ok(Self::from_secret_key(secret_key))
     }
 
@@ -2108,5 +2232,96 @@ mod tests {
 
         let short_handle = format!("ml-dsa-65-hash:{}", bs58::encode([0u8; 16]).into_string());
         assert!(short_handle.parse::<PublicKey>().is_err());
+    }
+
+    // ========================================================================
+    // ML-DSA-65 Seed Phrase Tests
+    // ========================================================================
+
+    #[test]
+    fn test_ml_dsa65_from_seed_phrase_cross_sdk_vector() {
+        // Cross-SDK regression: the ML-DSA-65 key derived from this phrase at
+        // the default NEAR path must match the value locked in by the
+        // TypeScript SDK (r-near/near-kit#224). This proves both SDKs derive
+        // byte-identically. ML-DSA-65 secret keys serialize as their 32-byte
+        // FIPS-204 seed under the `ml-dsa-65:` prefix.
+        let secret = SecretKey::ml_dsa65_from_seed_phrase(TEST_PHRASE).unwrap();
+        assert_eq!(secret.key_type(), KeyType::MlDsa65);
+        assert_eq!(
+            secret.to_string(),
+            "ml-dsa-65:7t9yn5gKtyA9EwqwGCHe6WeDdDhDQkRDVhASM7ZvRoum"
+        );
+    }
+
+    #[test]
+    fn test_ml_dsa65_from_seed_phrase_deterministic() {
+        let key1 = SecretKey::ml_dsa65_from_seed_phrase(TEST_PHRASE).unwrap();
+        let key2 = SecretKey::ml_dsa65_from_seed_phrase(TEST_PHRASE).unwrap();
+        assert_eq!(key1.as_bytes(), key2.as_bytes());
+        assert_eq!(key1.public_key(), key2.public_key());
+    }
+
+    #[test]
+    fn test_ml_dsa65_from_seed_phrase_different_paths() {
+        let key1 =
+            SecretKey::ml_dsa65_from_seed_phrase_with_path(TEST_PHRASE, "m/44'/397'/0'").unwrap();
+        let key2 =
+            SecretKey::ml_dsa65_from_seed_phrase_with_path(TEST_PHRASE, "m/44'/397'/1'").unwrap();
+        assert_ne!(key1.public_key(), key2.public_key());
+    }
+
+    #[test]
+    fn test_ml_dsa65_from_seed_phrase_with_passphrase() {
+        let no_pass = SecretKey::ml_dsa65_from_seed_phrase_with_path_and_passphrase(
+            TEST_PHRASE,
+            DEFAULT_HD_PATH,
+            None,
+        )
+        .unwrap();
+        let with_pass = SecretKey::ml_dsa65_from_seed_phrase_with_path_and_passphrase(
+            TEST_PHRASE,
+            DEFAULT_HD_PATH,
+            Some("my-password"),
+        )
+        .unwrap();
+        assert_ne!(no_pass.public_key(), with_pass.public_key());
+    }
+
+    #[test]
+    fn test_ml_dsa65_seed_phrase_differs_from_ed25519() {
+        // The ML-DSA-65 and Ed25519 branches share the SLIP-10 machinery but
+        // use different master salts, so the same phrase yields unrelated keys.
+        let ml = SecretKey::ml_dsa65_from_seed_phrase(TEST_PHRASE).unwrap();
+        let ed = SecretKey::from_seed_phrase(TEST_PHRASE).unwrap();
+        assert_eq!(ml.key_type(), KeyType::MlDsa65);
+        assert_eq!(ed.key_type(), KeyType::Ed25519);
+        // The 32-byte node secrets (both keys' `as_bytes`) must not collide.
+        assert_ne!(ml.as_bytes(), ed.as_bytes());
+    }
+
+    #[test]
+    fn test_ml_dsa65_from_seed_phrase_invalid() {
+        let result = SecretKey::ml_dsa65_from_seed_phrase("invalid words that are not a mnemonic");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_ml_dsa65_seed_phrase_key_can_sign() {
+        let secret = SecretKey::ml_dsa65_from_seed_phrase(TEST_PHRASE).unwrap();
+        let public = secret.public_key();
+        let message = b"post-quantum seed phrase";
+        assert!(secret.sign(message).verify(message, &public));
+    }
+
+    #[test]
+    fn test_ml_dsa65_keypair_from_seed_phrase() {
+        let keypair = KeyPair::ml_dsa65_from_seed_phrase(TEST_PHRASE).unwrap();
+        assert_eq!(keypair.public_key.key_type(), KeyType::MlDsa65);
+        assert_eq!(
+            keypair.secret_key.to_string(),
+            "ml-dsa-65:7t9yn5gKtyA9EwqwGCHe6WeDdDhDQkRDVhASM7ZvRoum"
+        );
+        // The bundled public key matches re-deriving it from the secret.
+        assert_eq!(keypair.public_key, keypair.secret_key.public_key());
     }
 }


### PR DESCRIPTION
## Summary

- Adds ML-DSA-65 seed-phrase key derivation, adopting the post-quantum SLIP-10 construction from satoshilabs/slips#1968 (same construction as QIP-0002 / the Lattice HD Wallets paper) and implementing near/devex#58.
- Reuses the existing SLIP-10 hardened machinery; the ML-DSA-65 branch differs only in the master HMAC salt (`"ML-DSA-65 seed"` vs `"ed25519 seed"`), so the 32-byte node secret `I_L` is the FIPS-204 seed ξ fed to ML-DSA-65 KeyGen. The ML-DSA-65 key from a phrase is therefore unrelated to the Ed25519 key from the same phrase.
- Matches the TypeScript implementation in r-near/near-kit#224, including a shared cross-SDK regression vector that locks both SDKs to the same derived key.

## API added

- `SecretKey::ml_dsa65_from_seed_phrase`
- `SecretKey::ml_dsa65_from_seed_phrase_with_path`
- `SecretKey::ml_dsa65_from_seed_phrase_with_path_and_passphrase`
- `KeyPair::ml_dsa65_from_seed_phrase`

Internally, `hd.rs` factors the SLIP-10 engine into a salt-parametrized helper with `derive_ed25519_slip10` / `derive_ml_dsa65_slip10` wrappers (ed25519 call sites and vector tests unchanged).

## Tests

- Inline slips#1968 ML-DSA-65 vectors (both seed vectors, all chains): assert the chain code verbatim and the SHA-256 of the derived 1952-byte public key. Digests are used because raw keys are 1952 bytes; the vectors are validated against slips#1968 / the NIST ACVP ML-DSA-keyGen-FIPS204 KATs.
- Cross-SDK regression: `ml_dsa65_from_seed_phrase(TEST_PHRASE)` at the default path yields `ml-dsa-65:7t9yn5gKtyA9EwqwGCHe6WeDdDhDQkRDVhASM7ZvRoum` (the value TS #224 locks in).
- Determinism, path sensitivity, passphrase sensitivity, difference from the ed25519 key, and invalid-mnemonic rejection.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features` and the no-default-features + sandbox variant
- [x] `cargo test -p near-kit` (lib + doctests)