### PR TITLE
feat: pluggable RPC transport with wasm32-wasip2 (wasi:http) support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
           cache-on-failure: "true"
       # Browser: the full client over reqwest's JS `fetch` backend
       - run: cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js,rpc
-      # WASI: the offline core (types, signing, tx building) — no HTTP transport
-      # builds for this target yet, so `rpc` stays off
+      # WASI: the offline core (types, signing, tx building) without a transport
       - run: cargo check --target wasm32-wasip2 -p near-kit --no-default-features
+      # WASI with the RPC layer: the built-in wasi:http transport
+      - run: cargo check --target wasm32-wasip2 -p near-kit --no-default-features --features rpc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,5 +89,8 @@ jobs:
       - run: cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js,rpc
       # WASI: the offline core (types, signing, tx building) without a transport
       - run: cargo check --target wasm32-wasip2 -p near-kit --no-default-features
-      # WASI with the RPC layer: the built-in wasi:http transport
+      # WASI with the RPC layer but no built-in transport (hosts without
+      # wasi:http; the caller injects one via NearBuilder::transport)
       - run: cargo check --target wasm32-wasip2 -p near-kit --no-default-features --features rpc
+      # WASI with the built-in wasi:http transport
+      - run: cargo check --target wasm32-wasip2 -p near-kit --no-default-features --features wasi-http

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,14 @@ uses — e.g. ed25519-dalek, k256 (secp256k1), sha2, sha3, ml-dsa (FIPS-204
 ML-DSA-65), bip39, hmac. The bar for a new crypto dependency is that it
 implements a standard primitive the protocol requires and is auditable.
 
+Also allowed: *platform bindings* for wasm targets, when they are the
+canonical thin binding to a host interface and are declared only in that
+target's `[target.'cfg(...)']` table — `js-sys`/`gloo-timers`/`getrandom` on
+JS-host wasm (`wasm32-unknown-unknown`), and `wasi` (the Bytecode Alliance's
+generated WASI 0.2 bindings) on `wasm32-wasip2` for the `wasi:http` transport.
+These play the role reqwest/tokio play natively; hand-rolling them would mean
+maintaining generated FFI by hand.
+
 **Not allowed**: near-primitives, near-crypto, near-jsonrpc-client (we hand-roll
 the NEAR types/borsh ourselves; this rule forbids the NEAR-specific crates, not
 crypto primitives).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1053,7 +1053,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1767,7 +1767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -1883,6 +1883,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3779,6 +3780,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4264,6 +4274,9 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/README.md
+++ b/README.md
@@ -198,15 +198,26 @@ Available known tokens: `tokens::USDC`, `tokens::USDT`, `tokens::W_NEAR`
 
 | Feature | Description |
 |---------|-------------|
-| `rpc` | The RPC layer: the `Near` client, queries, transactions, token helpers, and the HTTP client (on by default) |
+| `rpc` | The RPC layer: the `Near` client, queries, transactions, token helpers, and the HTTP transport — reqwest, or `wasi:http` on `wasm32-wasip2` (on by default) |
 | `sandbox` | Local testing with [near-sandbox](https://crates.io/crates/near-sandbox) |
 | `keyring` | System keyring integration for desktop apps |
 | `tracing` | [`tracing`](https://crates.io/crates/tracing) spans and events for RPC calls and transactions (on by default; drop it with `default-features = false`) |
 | `interactive-clap` | Enables `interactive-clap` derives on re-exported `NearToken` and `Gas` for CLI tools |
 
+### WASI (`wasm32-wasip2`)
+
+near-kit runs inside WASI Preview 2 components with full RPC support — on this target the `rpc` feature uses a built-in `wasi:http/outgoing-handler` transport instead of reqwest:
+
+```toml
+[dependencies]
+near-kit = { version = "0.13", default-features = false, features = ["rpc"] }
+```
+
+The host must provide the `wasi:http` interface (e.g. `wasmtime run -S http`, or any runtime targeting the `wasi:http/proxy` world). The transport is blocking — one request in flight at a time — which is the natural shape for a single-threaded component. On WASI hosts without `wasi:http`, plug your platform's transport in via `NearBuilder::transport`, or go fully offline (below).
+
 ### Offline / no-network usage
 
-With `default-features = false` the RPC layer drops out and near-kit becomes a pure offline toolkit: all the types, the signers, transaction construction and signing via `Transaction` (`new` → `sign` → `to_bytes`), and NEP-413 `verify_signature`. This is what you want on targets without an HTTP stack — the motivating example is `wasm32-wasip2`, where you can sign transactions and messages inside a component and hand them off for submission elsewhere. Note the fluent `TransactionBuilder` belongs to the RPC layer (it is created from a `Near` client), so it requires the `rpc` feature.
+With `default-features = false` the RPC layer drops out and near-kit becomes a pure offline toolkit: all the types, the signers, transaction construction and signing via `Transaction` (`new` → `sign` → `to_bytes`), and NEP-413 `verify_signature`. This is what you want on targets without any network stack: sign transactions and messages locally and hand them off for submission elsewhere. Note the fluent `TransactionBuilder` belongs to the RPC layer (it is created from a `Near` client), so it requires the `rpc` feature.
 
 ### A note on `near-token` / `near-gas`
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ Available known tokens: `tokens::USDC`, `tokens::USDT`, `tokens::W_NEAR`
 
 | Feature | Description |
 |---------|-------------|
-| `rpc` | The RPC layer: the `Near` client, queries, transactions, token helpers, and the HTTP transport — reqwest, or `wasi:http` on `wasm32-wasip2` (on by default) |
+| `rpc` | The RPC layer: the `Near` client, queries, transactions, token helpers, and the HTTP transport — reqwest, except on WASI (on by default) |
+| `wasi-http` | Built-in `wasi:http` transport for `wasm32-wasip2`; implies `rpc`, no-op elsewhere (on by default) |
 | `sandbox` | Local testing with [near-sandbox](https://crates.io/crates/near-sandbox) |
 | `keyring` | System keyring integration for desktop apps |
 | `tracing` | [`tracing`](https://crates.io/crates/tracing) spans and events for RPC calls and transactions (on by default; drop it with `default-features = false`) |
@@ -206,14 +207,16 @@ Available known tokens: `tokens::USDC`, `tokens::USDT`, `tokens::W_NEAR`
 
 ### WASI (`wasm32-wasip2`)
 
-near-kit runs inside WASI Preview 2 components with full RPC support — on this target the `rpc` feature uses a built-in `wasi:http/outgoing-handler` transport instead of reqwest:
+near-kit runs inside WASI Preview 2 components with full RPC support — the `wasi-http` feature (implies `rpc`) provides a built-in `wasi:http/outgoing-handler` transport in place of reqwest:
 
 ```toml
 [dependencies]
-near-kit = { version = "0.13", default-features = false, features = ["rpc"] }
+near-kit = { version = "0.14", default-features = false, features = ["wasi-http"] }
 ```
 
-The host must provide the `wasi:http` interface (e.g. `wasmtime run -S http`, or any runtime targeting the `wasi:http/proxy` world). The transport is blocking — one request in flight at a time — which is the natural shape for a single-threaded component. On WASI hosts without `wasi:http`, plug your platform's transport in via `NearBuilder::transport`, or go fully offline (below).
+The host must provide the `wasi:http` interface (e.g. `wasmtime run -S http`, or any runtime targeting the `wasi:http/proxy` world). The transport is blocking — one request in flight at a time, the natural shape for a single-threaded component — and does not follow HTTP redirects, so point it at the final RPC URL.
+
+On WASI hosts without `wasi:http`, enable only `rpc` and plug your platform's transport in via `NearBuilder::transport` — `wasi-http` must stay off there, because merely compiling the built-in transport makes the component import `wasi:http`, which such hosts refuse to instantiate. Or go fully offline (below).
 
 ### Offline / no-network usage
 

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -22,8 +22,8 @@ near-global-contracts.workspace = true
 tokio = { version = "1", features = ["sync"] }
 futures.workspace = true
 
-# HTTP client (optional; gated by `rpc` — the offline build has no transport)
-reqwest = { workspace = true, optional = true }
+# HTTP client: target-specific — see the two `rpc`-gated target tables below
+# (reqwest everywhere except WASI; `wasi:http` bindings on WASI).
 
 # Serialization
 serde.workspace = true
@@ -65,10 +65,23 @@ testcontainers = { workspace = true, optional = true, features = ["watchdog"] }
 libc = { version = "0.2", optional = true }
 serde_with = { version = "3.20", features = ["hex", "base64"] }
 
-# All targets except JS-host wasm (this includes WASI, which has real OS
-# timers): tokio timer support for the RPC retry backoff.
-[target.'cfg(not(all(target_arch = "wasm32", target_os = "unknown")))'.dependencies]
+# Native targets: tokio timer support for the RPC retry backoff. Wasm targets
+# sleep differently — the JS host's timers on `wasm32-unknown-unknown` (below),
+# `std::thread::sleep` on single-threaded WASI guests (see client/rpc.rs).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["sync", "time"] }
+
+# HTTP transport, part 1 — every target except WASI (native + JS-host wasm,
+# which uses reqwest's fetch backend). Optional; pulled in by the `rpc` feature.
+[target.'cfg(not(all(target_arch = "wasm32", target_os = "wasi")))'.dependencies]
+reqwest = { workspace = true, optional = true }
+
+# HTTP transport, part 2 — WASI only: raw `wasi:http/outgoing-handler` bindings
+# for the built-in blocking transport. reqwest has no WASI support (its native
+# stack needs an aws-lc-sys C cross-compile and hyper's tokio `net`, neither of
+# which builds for wasm). Optional; pulled in by the `rpc` feature.
+[target.'cfg(all(target_arch = "wasm32", target_os = "wasi"))'.dependencies]
+wasi = { version = "0.14", optional = true }
 
 # JS-host wasm only (`wasm32-unknown-unknown`, i.e. browsers/Node/Deno — NOT
 # WASI): JS-backed timer and time APIs. `getrandom`/`getrandom_v04` are entropy
@@ -84,11 +97,12 @@ getrandom_v04 = { package = "getrandom", version = "0.4", default-features = fal
 [features]
 default = ["rpc", "keyring", "file-signer", "tracing"]
 # The JSON-RPC layer: the `Near` client, query/transaction builders, contract
-# and token helpers, and the HTTP transport underneath them. Disable (via
-# `default-features = false`) for offline use — types, signing, and transaction
-# building without a network stack (e.g. on wasm32-wasip2, where reqwest
-# doesn't build).
-rpc = ["dep:reqwest"]
+# and token helpers, and the HTTP transport underneath them. Pulls in the HTTP
+# client appropriate to the target: reqwest off-WASI, `wasi:http` on WASI
+# (`dep:` on a target-inactive optional dependency is a no-op, so only the
+# matching one compiles). Disable (via `default-features = false`) for offline
+# use — types, signing, and transaction building without a network stack.
+rpc = ["dep:reqwest", "dep:wasi"]
 sandbox = ["rpc", "dep:testcontainers", "dep:libc", "tokio/rt"]
 keyring = ["dep:keyring"]
 file-signer = ["dep:dirs"]

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -22,8 +22,9 @@ near-global-contracts.workspace = true
 tokio = { version = "1", features = ["sync"] }
 futures.workspace = true
 
-# HTTP client: target-specific — see the two `rpc`-gated target tables below
-# (reqwest everywhere except WASI; `wasi:http` bindings on WASI).
+# HTTP client: target-specific — see the two feature-gated target tables below
+# (reqwest everywhere except WASI, via `rpc`; `wasi:http` bindings on
+# wasm32-wasip2, via `wasi-http`).
 
 # Serialization
 serde.workspace = true
@@ -76,11 +77,13 @@ tokio = { version = "1", features = ["sync", "time"] }
 [target.'cfg(not(all(target_arch = "wasm32", target_os = "wasi")))'.dependencies]
 reqwest = { workspace = true, optional = true }
 
-# HTTP transport, part 2 — WASI only: raw `wasi:http/outgoing-handler` bindings
-# for the built-in blocking transport. reqwest has no WASI support (its native
-# stack needs an aws-lc-sys C cross-compile and hyper's tokio `net`, neither of
-# which builds for wasm). Optional; pulled in by the `rpc` feature.
-[target.'cfg(all(target_arch = "wasm32", target_os = "wasi"))'.dependencies]
+# HTTP transport, part 2 — wasm32-wasip2 only: raw `wasi:http/outgoing-handler`
+# bindings for the built-in blocking transport. reqwest has no WASI support (its
+# native stack needs an aws-lc-sys C cross-compile and hyper's tokio `net`,
+# neither of which builds for wasm). Optional; pulled in by the `wasi-http`
+# feature. Scoped to `target_env = "p2"`: earlier WASI targets (wasm32-wasip1)
+# predate the component model and have no `wasi:http` interface at all.
+[target.'cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))'.dependencies]
 wasi = { version = "0.14", optional = true }
 
 # JS-host wasm only (`wasm32-unknown-unknown`, i.e. browsers/Node/Deno — NOT
@@ -95,14 +98,21 @@ getrandom = { version = "0.2", default-features = false }
 getrandom_v04 = { package = "getrandom", version = "0.4", default-features = false }
 
 [features]
-default = ["rpc", "keyring", "file-signer", "tracing"]
+default = ["rpc", "wasi-http", "keyring", "file-signer", "tracing"]
 # The JSON-RPC layer: the `Near` client, query/transaction builders, contract
-# and token helpers, and the HTTP transport underneath them. Pulls in the HTTP
-# client appropriate to the target: reqwest off-WASI, `wasi:http` on WASI
-# (`dep:` on a target-inactive optional dependency is a no-op, so only the
-# matching one compiles). Disable (via `default-features = false`) for offline
-# use — types, signing, and transaction building without a network stack.
-rpc = ["dep:reqwest", "dep:wasi"]
+# and token helpers, and the HTTP transport underneath them. Pulls in reqwest
+# everywhere except WASI (`dep:` on a target-inactive optional dependency is a
+# no-op there). On WASI the built-in transport comes from `wasi-http` instead;
+# `rpc` alone means bring-your-own via `NearBuilder::transport`. Disable (via
+# `default-features = false`) for offline use — types, signing, and transaction
+# building without a network stack.
+rpc = ["dep:reqwest"]
+# The built-in `wasi:http` transport for `wasm32-wasip2` (implies `rpc`; a
+# no-op on every other target). Kept separate from `rpc` because merely
+# compiling the built-in transport makes the component import `wasi:http`,
+# which hosts without that interface refuse to instantiate — leave this off
+# and inject a custom transport to run on such hosts.
+wasi-http = ["rpc", "dep:wasi"]
 sandbox = ["rpc", "dep:testcontainers", "dep:libc", "tokio/rt"]
 keyring = ["dep:keyring"]
 file-signer = ["dep:dirs"]

--- a/crates/near-kit/src/client/mod.rs
+++ b/crates/near-kit/src/client/mod.rs
@@ -5,6 +5,8 @@
 //! - [`Near`] — The main client, the single entry point for all operations
 //! - [`NearBuilder`] — Fluent builder for configuring the client
 //! - [`RpcClient`] — Low-level JSON-RPC client with retry logic
+//! - [`RpcTransport`] — Pluggable HTTP layer under [`RpcClient`] (reqwest by
+//!   default; `wasi:http` on `wasm32-wasip2`)
 //!
 //! # Signers
 //!
@@ -49,6 +51,8 @@ mod rpc;
 mod signer;
 #[cfg(feature = "rpc")]
 mod transaction;
+#[cfg(feature = "rpc")]
+mod transport;
 
 #[cfg(feature = "keyring")]
 mod keyring_signer;
@@ -70,6 +74,14 @@ pub use transaction::{
     CallBuilder, DelegateOptions, DelegateResult, FunctionCall, SignedTransactionSend,
     TransactionBuilder, TransactionSend,
 };
+#[cfg(feature = "rpc")]
+pub use transport::{BoxFuture, RpcTransport, TransportResponse};
+// Only the built-in transport matching the build target exists; the other side
+// of the cfg pair would reference a dependency that isn't compiled in.
+#[cfg(all(feature = "rpc", not(all(target_arch = "wasm32", target_os = "wasi"))))]
+pub use transport::ReqwestTransport;
+#[cfg(all(feature = "rpc", target_arch = "wasm32", target_os = "wasi"))]
+pub use transport::WasiHttpTransport;
 
 #[cfg(feature = "keyring")]
 pub use keyring_signer::KeyringSigner;

--- a/crates/near-kit/src/client/mod.rs
+++ b/crates/near-kit/src/client/mod.rs
@@ -76,11 +76,18 @@ pub use transaction::{
 };
 #[cfg(feature = "rpc")]
 pub use transport::{BoxFuture, RpcTransport, TransportResponse};
-// Only the built-in transport matching the build target exists; the other side
-// of the cfg pair would reference a dependency that isn't compiled in.
+// Only the built-in transport matching the build configuration exists:
+// reqwest everywhere except WASI, the wasi:http transport on wasm32-wasip2
+// with the `wasi-http` feature — and neither on WASI without it (inject a
+// custom transport via `NearBuilder::transport` there).
 #[cfg(all(feature = "rpc", not(all(target_arch = "wasm32", target_os = "wasi"))))]
 pub use transport::ReqwestTransport;
-#[cfg(all(feature = "rpc", target_arch = "wasm32", target_os = "wasi"))]
+#[cfg(all(
+    feature = "wasi-http",
+    target_arch = "wasm32",
+    target_os = "wasi",
+    target_env = "p2"
+))]
 pub use transport::WasiHttpTransport;
 
 #[cfg(feature = "keyring")]

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -8,8 +8,14 @@ use crate::contract::ContractClient;
 use crate::error::Error;
 use crate::types::{
     AccountId, ChainId, Gas, IntoGlobalContractId, IntoNearToken, NearToken, PublicKey,
-    PublishMode, SecretKey, StateInit, TryIntoAccountId,
+    PublishMode, StateInit, TryIntoAccountId,
 };
+// Only used by `Near::sandbox`, which needs a built-in transport (see below).
+#[cfg(any(
+    not(all(target_arch = "wasm32", target_os = "wasi")),
+    all(feature = "wasi-http", target_env = "p2")
+))]
+use crate::types::SecretKey;
 
 use super::query::{
     AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, ContractCodeQuery,
@@ -18,7 +24,14 @@ use super::query::{
 use super::rpc::{MAINNET, RetryConfig, RpcClient, TESTNET};
 use super::signer::{InMemorySigner, Signer};
 use super::transaction::{CallBuilder, SignedTransactionSend, TransactionBuilder};
-use super::transport::{self, RpcTransport};
+use super::transport::RpcTransport;
+// The module itself is only referenced for the built-in transports, which
+// don't exist on WASI builds without the `wasi-http` feature.
+#[cfg(any(
+    not(all(target_arch = "wasm32", target_os = "wasi")),
+    all(feature = "wasi-http", target_env = "p2")
+))]
+use super::transport;
 
 /// Trait for sandbox network configuration.
 ///
@@ -259,6 +272,13 @@ impl Near {
     /// // Root account credentials are auto-configured - ready for transactions!
     /// near.transfer("alice.sandbox", "10 NEAR").await?;
     /// ```
+    /// Only exists where a built-in transport does (every configuration except
+    /// WASI without the `wasi-http` feature): it connects immediately, so it
+    /// needs a transport nobody injected.
+    #[cfg(any(
+        not(all(target_arch = "wasm32", target_os = "wasi")),
+        all(feature = "wasi-http", target_env = "p2")
+    ))]
     pub fn sandbox(network: &impl SandboxNetwork) -> Near {
         let secret_key: SecretKey = network
             .root_secret_key()
@@ -1196,7 +1216,10 @@ impl std::fmt::Debug for Near {
 /// ```
 pub struct NearBuilder {
     rpc_url: String,
-    transport: Arc<dyn RpcTransport>,
+    /// `None` until [`NearBuilder::build`] — resolved lazily so that injecting
+    /// a transport never constructs the built-in one (which doesn't even exist
+    /// on WASI without the `wasi-http` feature).
+    transport: Option<Arc<dyn RpcTransport>>,
     signer: Option<Arc<dyn Signer>>,
     retry_config: RetryConfig,
     chain_id: ChainId,
@@ -1208,7 +1231,7 @@ impl NearBuilder {
     fn new(rpc_url: impl Into<String>, chain_id: ChainId) -> Self {
         Self {
             rpc_url: rpc_url.into(),
-            transport: transport::default_transport(),
+            transport: None,
             signer: None,
             retry_config: RetryConfig::default(),
             chain_id,
@@ -1272,7 +1295,7 @@ impl NearBuilder {
     /// [`NearBuilder::transport`] for full transport replacement.
     #[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
     pub fn http_client(mut self, client: reqwest::Client) -> Self {
-        self.transport = Arc::new(transport::ReqwestTransport::with_client(client));
+        self.transport = Some(Arc::new(transport::ReqwestTransport::with_client(client)));
         self
     }
 
@@ -1280,11 +1303,13 @@ impl NearBuilder {
     ///
     /// This is the injection point for platforms whose HTTP stack near-kit
     /// doesn't know about — e.g. a runtime that proxies RPC traffic through a
-    /// host call instead of exposing raw HTTP. For merely *configuring* the
-    /// default reqwest transport (headers, proxies, TLS), prefer
+    /// host call instead of exposing raw HTTP. On WASI builds without the
+    /// `wasi-http` feature it is the *only* way to reach the network — there
+    /// is no built-in transport there. For merely *configuring* the default
+    /// reqwest transport (headers, proxies, TLS), prefer
     /// [`NearBuilder::http_client`].
     pub fn transport(mut self, transport: impl RpcTransport + 'static) -> Self {
-        self.transport = Arc::new(transport);
+        self.transport = Some(Arc::new(transport));
         self
     }
 
@@ -1302,11 +1327,34 @@ impl NearBuilder {
     }
 
     /// Build the client.
+    ///
+    /// # Panics
+    ///
+    /// On WASI without the `wasi-http` feature there is no built-in HTTP
+    /// transport, so one must have been injected with
+    /// [`NearBuilder::transport`]; panics otherwise. Every other configuration
+    /// has a built-in default and never panics.
     pub fn build(self) -> Near {
+        // A built-in default exists everywhere except WASI-without-`wasi-http`
+        // (see `transport::default_transport`).
+        #[cfg(any(
+            not(all(target_arch = "wasm32", target_os = "wasi")),
+            all(feature = "wasi-http", target_env = "p2")
+        ))]
+        let transport = self.transport.unwrap_or_else(transport::default_transport);
+        #[cfg(all(
+            target_arch = "wasm32",
+            target_os = "wasi",
+            not(all(feature = "wasi-http", target_env = "p2"))
+        ))]
+        let transport = self.transport.expect(
+            "no built-in HTTP transport on WASI without the `wasi-http` feature; \
+             supply one with `NearBuilder::transport`",
+        );
         Near {
             rpc: Arc::new(RpcClient::with_transport_and_retry_config(
                 self.rpc_url,
-                self.transport,
+                transport,
                 self.retry_config,
             )),
             signer: self.signer,

--- a/crates/near-kit/src/client/near.rs
+++ b/crates/near-kit/src/client/near.rs
@@ -18,6 +18,7 @@ use super::query::{
 use super::rpc::{MAINNET, RetryConfig, RpcClient, TESTNET};
 use super::signer::{InMemorySigner, Signer};
 use super::transaction::{CallBuilder, SignedTransactionSend, TransactionBuilder};
+use super::transport::{self, RpcTransport};
 
 /// Trait for sandbox network configuration.
 ///
@@ -1195,7 +1196,7 @@ impl std::fmt::Debug for Near {
 /// ```
 pub struct NearBuilder {
     rpc_url: String,
-    http_client: reqwest::Client,
+    transport: Arc<dyn RpcTransport>,
     signer: Option<Arc<dyn Signer>>,
     retry_config: RetryConfig,
     chain_id: ChainId,
@@ -1207,7 +1208,7 @@ impl NearBuilder {
     fn new(rpc_url: impl Into<String>, chain_id: ChainId) -> Self {
         Self {
             rpc_url: rpc_url.into(),
-            http_client: reqwest::Client::new(),
+            transport: transport::default_transport(),
             signer: None,
             retry_config: RetryConfig::default(),
             chain_id,
@@ -1266,8 +1267,24 @@ impl NearBuilder {
     /// This allows callers to configure transport concerns such as default
     /// headers, proxies, TLS, and timeouts without expanding near-kit's API for
     /// each individual HTTP setting.
+    ///
+    /// Not available on WASI, where reqwest doesn't build — see
+    /// [`NearBuilder::transport`] for full transport replacement.
+    #[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
     pub fn http_client(mut self, client: reqwest::Client) -> Self {
-        self.http_client = client;
+        self.transport = Arc::new(transport::ReqwestTransport::with_client(client));
+        self
+    }
+
+    /// Replace the HTTP transport entirely with a custom [`RpcTransport`].
+    ///
+    /// This is the injection point for platforms whose HTTP stack near-kit
+    /// doesn't know about — e.g. a runtime that proxies RPC traffic through a
+    /// host call instead of exposing raw HTTP. For merely *configuring* the
+    /// default reqwest transport (headers, proxies, TLS), prefer
+    /// [`NearBuilder::http_client`].
+    pub fn transport(mut self, transport: impl RpcTransport + 'static) -> Self {
+        self.transport = Arc::new(transport);
         self
     }
 
@@ -1287,9 +1304,9 @@ impl NearBuilder {
     /// Build the client.
     pub fn build(self) -> Near {
         Near {
-            rpc: Arc::new(RpcClient::with_http_client_and_retry_config(
+            rpc: Arc::new(RpcClient::with_transport_and_retry_config(
                 self.rpc_url,
-                self.http_client,
+                self.transport,
                 self.retry_config,
             )),
             signer: self.signer,

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -7,7 +7,14 @@ use std::time::Duration;
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
-use super::transport::{self, RpcTransport};
+use super::transport::RpcTransport;
+// The module itself is only referenced for `default_transport`, which doesn't
+// exist on WASI builds without the `wasi-http` feature (no built-in transport).
+#[cfg(any(
+    not(all(target_arch = "wasm32", target_os = "wasi")),
+    all(feature = "wasi-http", target_env = "p2")
+))]
+use super::transport;
 use crate::error::RpcError;
 use crate::trace;
 use crate::types::rpc::RawTransactionResponse;
@@ -156,6 +163,14 @@ pub struct RpcClient {
 
 impl RpcClient {
     /// Create a new RPC client with the given URL.
+    ///
+    /// Only exists where a built-in transport does (every target except WASI
+    /// without the `wasi-http` feature) — otherwise construct via
+    /// [`with_transport_and_retry_config`](Self::with_transport_and_retry_config).
+    #[cfg(any(
+        not(all(target_arch = "wasm32", target_os = "wasi")),
+        all(feature = "wasi-http", target_env = "p2")
+    ))]
     pub fn new(url: impl Into<String>) -> Self {
         Self::with_transport_and_retry_config(
             url,
@@ -165,6 +180,12 @@ impl RpcClient {
     }
 
     /// Create a new RPC client with custom retry configuration.
+    ///
+    /// Only exists where a built-in transport does — see [`RpcClient::new`].
+    #[cfg(any(
+        not(all(target_arch = "wasm32", target_os = "wasi")),
+        all(feature = "wasi-http", target_env = "p2")
+    ))]
     pub fn with_retry_config(url: impl Into<String>, retry_config: RetryConfig) -> Self {
         Self::with_transport_and_retry_config(url, transport::default_transport(), retry_config)
     }

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -1,11 +1,13 @@
 //! Low-level JSON-RPC client for NEAR.
 
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
+use super::transport::{self, RpcTransport};
 use crate::error::RpcError;
 use crate::trace;
 use crate::types::rpc::RawTransactionResponse;
@@ -19,13 +21,21 @@ use crate::types::{
 
 /// Platform-appropriate async sleep, used for retry backoff.
 ///
-/// Dispatches to `tokio::time::sleep` everywhere except `wasm32-unknown-unknown`,
-/// which has no OS timer APIs and uses the JS host's timers via `gloo-timers`
-/// instead. WASI targets take the tokio path.
+/// - Native (non-wasm): `tokio::time::sleep`.
+/// - WASI: `std::thread::sleep`. A WASI guest is single-threaded with no tokio
+///   runtime, so `tokio::time::sleep` would panic ("no reactor running") —
+///   and blocking the one thread is fine, since the whole guest is already
+///   blocked on this future (the wasi:http transport is blocking too).
+/// - `wasm32-unknown-unknown`: no OS timers — use the JS host's via `gloo-timers`.
 async fn async_sleep(duration: Duration) {
-    #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+    #[cfg(not(target_arch = "wasm32"))]
     {
         tokio::time::sleep(duration).await;
+    }
+
+    #[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
+    {
+        std::thread::sleep(duration);
     }
 
     #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
@@ -139,7 +149,7 @@ struct CallFunctionResponse {
 /// Low-level JSON-RPC client for NEAR.
 pub struct RpcClient {
     url: String,
-    client: reqwest::Client,
+    transport: Arc<dyn RpcTransport>,
     retry_config: RetryConfig,
     request_id: AtomicU64,
 }
@@ -147,22 +157,32 @@ pub struct RpcClient {
 impl RpcClient {
     /// Create a new RPC client with the given URL.
     pub fn new(url: impl Into<String>) -> Self {
-        Self::with_http_client_and_retry_config(url, reqwest::Client::new(), RetryConfig::default())
+        Self::with_transport_and_retry_config(
+            url,
+            transport::default_transport(),
+            RetryConfig::default(),
+        )
     }
 
     /// Create a new RPC client with custom retry configuration.
     pub fn with_retry_config(url: impl Into<String>, retry_config: RetryConfig) -> Self {
-        Self::with_http_client_and_retry_config(url, reqwest::Client::new(), retry_config)
+        Self::with_transport_and_retry_config(url, transport::default_transport(), retry_config)
     }
 
-    pub(crate) fn with_http_client_and_retry_config(
+    /// Create a new RPC client with a custom [`RpcTransport`] and retry
+    /// configuration.
+    ///
+    /// This is the low-level injection point for platforms whose HTTP stack
+    /// near-kit doesn't know about. Most callers should use
+    /// [`NearBuilder::transport`](super::NearBuilder::transport) instead.
+    pub fn with_transport_and_retry_config(
         url: impl Into<String>,
-        client: reqwest::Client,
+        transport: Arc<dyn RpcTransport>,
         retry_config: RetryConfig,
     ) -> Self {
         Self {
             url: url.into(),
-            client,
+            transport,
             retry_config,
             request_id: AtomicU64::new(0),
         }
@@ -233,20 +253,18 @@ impl RpcClient {
             tracing::trace!(payload = %json, "RPC request");
         }
 
-        let response = self
-            .client
-            .post(&self.url)
-            .header("Content-Type", "application/json")
-            .json(request)
-            .send()
-            .await?;
+        let request_body = serde_json::to_vec(request).map_err(RpcError::Json)?;
+        let response = self.transport.post_json(&self.url, request_body).await?;
 
-        let status = response.status();
-        let body = response.text().await?;
+        let status = response.status;
+        // Lossy decode matches what reqwest's `text()` did here before the
+        // transport seam: the RPC's JSON bodies are UTF-8, and anything mangled
+        // by a proxy fails in the JSON parse below with the payload visible.
+        let body = String::from_utf8_lossy(&response.body);
 
         trace::trace!(payload = %body, "RPC response");
 
-        if !status.is_success() {
+        if !(200..300).contains(&status) {
             // nearcore returns non-2xx (e.g. 422 UNKNOWN_BLOCK, 408 TIMEOUT_ERROR) with
             // a well-formed JSON-RPC error body — try to decode that first so callers
             // get typed variants instead of an opaque Network error. Falls back to the
@@ -256,15 +274,13 @@ impl RpcClient {
             {
                 let parsed_err = self.parse_rpc_error(&error);
                 return Err(preserve_http_retry_classification(
-                    parsed_err,
-                    status.as_u16(),
-                    &body,
+                    parsed_err, status, &body,
                 ));
             }
-            let retryable = is_retryable_status(status.as_u16());
+            let retryable = is_retryable_status(status);
             return Err(RpcError::network(
                 format!("HTTP {}: {}", status, body),
-                Some(status.as_u16()),
+                Some(status),
                 retryable,
             ));
         }
@@ -1014,7 +1030,7 @@ impl Clone for RpcClient {
     fn clone(&self) -> Self {
         Self {
             url: self.url.clone(),
-            client: self.client.clone(),
+            transport: self.transport.clone(),
             retry_config: self.retry_config.clone(),
             request_id: AtomicU64::new(0),
         }

--- a/crates/near-kit/src/client/transport.rs
+++ b/crates/near-kit/src/client/transport.rs
@@ -7,12 +7,16 @@
 //! - **Every target except WASI** (native + `wasm32-unknown-unknown`):
 //!   [`ReqwestTransport`]. reqwest's fetch backend covers browsers/JS hosts;
 //!   its native stack covers everything else.
-//! - **`wasm32-wasip2`**: `WasiHttpTransport` (only nameable when compiling
-//!   for WASI), which speaks `wasi:http/outgoing-handler` through the `wasi`
-//!   crate's raw bindings.
+//! - **`wasm32-wasip2`** with the default-on `wasi-http` feature:
+//!   `WasiHttpTransport` (only nameable there), which speaks
+//!   `wasi:http/outgoing-handler` through the `wasi` crate's raw bindings.
 //!   reqwest has no WASI support (its native stack drags in an `aws-lc-sys` C
 //!   cross-compile and hyper's tokio `net`, neither of which builds for wasm),
 //!   so a wasip2 component needs a `wasi:http`-native client instead.
+//! - **WASI without `wasi-http`**: no built-in transport. The feature split
+//!   matters because compiling the built-in transport at all makes the
+//!   component import `wasi:http`, which hosts lacking that interface refuse
+//!   to instantiate — with only `rpc` enabled, those imports never appear.
 //!
 //! Custom implementations plug in via
 //! [`NearBuilder::transport`](super::NearBuilder::transport) (or
@@ -25,6 +29,22 @@ use std::sync::Arc;
 use crate::error::RpcError;
 pub use crate::platform::BoxFuture;
 use crate::platform::{MaybeSend, MaybeSync};
+
+// The built-in WASI transport speaks the `wasi:http` component-model
+// interface, which only exists on WASI Preview 2. On earlier WASI targets,
+// fail loudly at build time instead of emitting an artifact whose `wasi:http`
+// imports no preview1 host can satisfy.
+#[cfg(all(
+    feature = "wasi-http",
+    target_arch = "wasm32",
+    target_os = "wasi",
+    not(target_env = "p2")
+))]
+compile_error!(
+    "near-kit's `wasi-http` feature requires wasm32-wasip2 (the wasi:http interface does not \
+     exist on earlier WASI targets); disable it and supply a custom transport via \
+     `NearBuilder::transport` instead"
+);
 
 /// A raw HTTP response handed back from an [`RpcTransport`].
 ///
@@ -105,6 +125,17 @@ impl<T: RpcTransport + ?Sized> RpcTransport for Arc<T> {
 }
 
 /// The transport used when the caller doesn't supply one.
+///
+/// Only compiled when a built-in transport exists for the configuration:
+/// reqwest everywhere except WASI, the `wasi:http` transport on wasm32-wasip2
+/// with the `wasi-http` feature. A WASI build without `wasi-http` has no
+/// default — the caller injects one (`NearBuilder::transport`), and because
+/// this function doesn't exist there, nothing can drag `wasi:http` imports
+/// into such a component.
+#[cfg(any(
+    not(all(target_arch = "wasm32", target_os = "wasi")),
+    all(feature = "wasi-http", target_env = "p2")
+))]
 pub(crate) fn default_transport() -> Arc<dyn RpcTransport> {
     #[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
     {
@@ -179,24 +210,37 @@ impl RpcTransport for ReqwestTransport {
 }
 
 // ============================================================================
-// WASI (wasm32-wasip2): wasi:http/outgoing-handler
+// WASI (wasm32-wasip2, `wasi-http` feature): wasi:http/outgoing-handler
 // ============================================================================
 
-/// The default [`RpcTransport`] on `wasm32-wasip2`, backed by
-/// `wasi:http/outgoing-handler`.
+/// The default [`RpcTransport`] on `wasm32-wasip2` (behind the default-on
+/// `wasi-http` feature), backed by `wasi:http/outgoing-handler`.
 ///
 /// The host must provide the `wasi:http` interface — e.g. `wasmtime run -S
-/// http`, or any runtime targeting the `wasi:http/proxy` world.
+/// http`, or any runtime targeting the `wasi:http/proxy` world. For WASI
+/// hosts *without* `wasi:http`, disable the `wasi-http` feature (keeping
+/// `rpc`) and inject the platform's transport via
+/// [`NearBuilder::transport`](super::NearBuilder::transport) instead.
 ///
 /// The exchange is *blocking*: the guest parks on a wasi pollable until the
 /// response arrives, so exactly one request is in flight at a time. That is
 /// the natural shape for a single-threaded component; concurrent RPC calls
 /// from the same guest serialize rather than interleave.
-#[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
+#[cfg(all(
+    feature = "wasi-http",
+    target_arch = "wasm32",
+    target_os = "wasi",
+    target_env = "p2"
+))]
 #[derive(Clone, Debug, Default)]
 pub struct WasiHttpTransport;
 
-#[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
+#[cfg(all(
+    feature = "wasi-http",
+    target_arch = "wasm32",
+    target_os = "wasi",
+    target_env = "p2"
+))]
 impl WasiHttpTransport {
     /// Create a new wasi:http transport.
     pub fn new() -> Self {
@@ -204,7 +248,12 @@ impl WasiHttpTransport {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
+#[cfg(all(
+    feature = "wasi-http",
+    target_arch = "wasm32",
+    target_os = "wasi",
+    target_env = "p2"
+))]
 impl RpcTransport for WasiHttpTransport {
     fn post_json(
         &self,
@@ -215,12 +264,18 @@ impl RpcTransport for WasiHttpTransport {
     }
 }
 
-#[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
+#[cfg(all(
+    feature = "wasi-http",
+    target_arch = "wasm32",
+    target_os = "wasi",
+    target_env = "p2"
+))]
 mod wasi_http {
     use std::future::Future;
     use std::pin::Pin;
     use std::task::{Context, Poll};
 
+    use base64::{Engine as _, engine::general_purpose::STANDARD};
     use wasi::http::outgoing_handler;
     use wasi::http::types::{
         ErrorCode, Fields, IncomingBody, Method, OutgoingBody, OutgoingRequest, Scheme,
@@ -271,17 +326,25 @@ mod wasi_http {
 
     /// The synchronous `wasi:http/outgoing-handler` exchange.
     fn exchange(url: &str, body: &[u8]) -> Result<TransportResponse, RpcError> {
-        let (scheme, authority, path_with_query) = split_url(url)?;
+        let UrlParts {
+            scheme,
+            authority,
+            path_with_query,
+            authorization,
+        } = split_url(url)?;
 
-        // Rejected headers mean a malformed request — not retryable.
-        let headers = Fields::from_list(&[
+        let mut header_list = vec![
             ("content-type".to_string(), b"application/json".to_vec()),
             (
                 "content-length".to_string(),
                 body.len().to_string().into_bytes(),
             ),
-        ])
-        .map_err(|e| {
+        ];
+        if let Some(value) = authorization {
+            header_list.push(("authorization".to_string(), value));
+        }
+        // Rejected headers mean a malformed request — not retryable.
+        let headers = Fields::from_list(&header_list).map_err(|e| {
             RpcError::network(
                 format!("wasi:http rejected request headers: {e:?}"),
                 None,
@@ -406,20 +469,43 @@ mod wasi_http {
         Ok(TransportResponse { status, body: buf })
     }
 
-    /// Split a URL into the `wasi:http` request parts: scheme, authority, and
-    /// path-with-query. (No `url`-crate dependency; RPC endpoint URLs are
-    /// simple enough for direct splitting.)
-    fn split_url(url: &str) -> Result<(Scheme, String, String), RpcError> {
+    /// The `wasi:http` request parts extracted from an RPC endpoint URL.
+    struct UrlParts {
+        scheme: Scheme,
+        /// Host (and optional port), with any URL userinfo stripped.
+        authority: String,
+        path_with_query: String,
+        /// `Authorization` header value synthesized from URL userinfo
+        /// (`https://user:pass@host/`), as reqwest does on other targets.
+        authorization: Option<Vec<u8>>,
+    }
+
+    /// Split a URL into the `wasi:http` request parts. (No `url`-crate
+    /// dependency; RPC endpoint URLs are simple enough for direct splitting.)
+    fn split_url(url: &str) -> Result<UrlParts, RpcError> {
         let (scheme_raw, rest) = url
             .split_once("://")
             .ok_or_else(|| invalid_url(url, "missing scheme"))?;
-        let scheme = match scheme_raw {
-            "http" => Scheme::Http,
-            "https" => Scheme::Https,
-            other => Scheme::Other(other.to_string()),
+        // Scheme names are case-insensitive (the `url` crate lowercases them
+        // on other targets). Anything but http/https is deterministically
+        // wrong for an RPC endpoint — reject it here, non-retryably, instead
+        // of letting the host fail the dispatch with a retryable-looking
+        // protocol error.
+        let scheme = if scheme_raw.eq_ignore_ascii_case("http") {
+            Scheme::Http
+        } else if scheme_raw.eq_ignore_ascii_case("https") {
+            Scheme::Https
+        } else {
+            return Err(invalid_url(url, "scheme must be http or https"));
         };
         let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
         let (authority, tail) = rest.split_at(authority_end);
+        // URL userinfo is not part of the wire-format authority: like reqwest,
+        // turn `user:pass@host` into an `Authorization: Basic` header.
+        let (authorization, authority) = match authority.rsplit_once('@') {
+            Some((userinfo, host)) => (basic_auth(userinfo), host),
+            None => (None, authority),
+        };
         if authority.is_empty() {
             return Err(invalid_url(url, "missing host"));
         }
@@ -432,7 +518,62 @@ mod wasi_http {
         } else {
             tail.to_string()
         };
-        Ok((scheme, authority.to_string(), path_with_query))
+        Ok(UrlParts {
+            scheme,
+            authority: authority.to_string(),
+            path_with_query,
+            authorization,
+        })
+    }
+
+    /// `Authorization: Basic` value for a URL userinfo segment (`user` or
+    /// `user:pass`). Both halves are percent-decoded before base64-encoding,
+    /// mirroring reqwest's conversion on other targets.
+    fn basic_auth(userinfo: &str) -> Option<Vec<u8>> {
+        if userinfo.is_empty() {
+            return None;
+        }
+        let (user, pass) = match userinfo.split_once(':') {
+            Some((user, pass)) => (user, Some(pass)),
+            None => (userinfo, None),
+        };
+        let mut credentials = percent_decode(user);
+        credentials.push(b':');
+        if let Some(pass) = pass {
+            credentials.extend(percent_decode(pass));
+        }
+        Some(format!("Basic {}", STANDARD.encode(credentials)).into_bytes())
+    }
+
+    /// Minimal percent-decoding for URL userinfo (`%40` → `@`, ...). Invalid
+    /// escapes pass through verbatim, matching lenient URL-parser behavior.
+    fn percent_decode(s: &str) -> Vec<u8> {
+        fn hex_val(b: u8) -> Option<u8> {
+            match b {
+                b'0'..=b'9' => Some(b - b'0'),
+                b'a'..=b'f' => Some(b - b'a' + 10),
+                b'A'..=b'F' => Some(b - b'A' + 10),
+                _ => None,
+            }
+        }
+        let bytes = s.as_bytes();
+        let mut out = Vec::with_capacity(bytes.len());
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == b'%'
+                && let (Some(hi), Some(lo)) = (
+                    bytes.get(i + 1).copied().and_then(hex_val),
+                    bytes.get(i + 2).copied().and_then(hex_val),
+                )
+            {
+                out.push((hi << 4) | lo);
+                i += 3;
+            } else {
+                out.push(bytes[i]);
+                i += 1;
+            }
+        }
+        out
     }
 
     /// A malformed URL is deterministic — never retryable.

--- a/crates/near-kit/src/client/transport.rs
+++ b/crates/near-kit/src/client/transport.rs
@@ -1,0 +1,472 @@
+//! Pluggable HTTP transport for the JSON-RPC client.
+//!
+//! [`RpcClient`](super::rpc::RpcClient) never talks to an HTTP library
+//! directly — it drives an [`RpcTransport`] trait object. The built-in
+//! implementation is chosen by target:
+//!
+//! - **Every target except WASI** (native + `wasm32-unknown-unknown`):
+//!   [`ReqwestTransport`]. reqwest's fetch backend covers browsers/JS hosts;
+//!   its native stack covers everything else.
+//! - **`wasm32-wasip2`**: `WasiHttpTransport` (only nameable when compiling
+//!   for WASI), which speaks `wasi:http/outgoing-handler` through the `wasi`
+//!   crate's raw bindings.
+//!   reqwest has no WASI support (its native stack drags in an `aws-lc-sys` C
+//!   cross-compile and hyper's tokio `net`, neither of which builds for wasm),
+//!   so a wasip2 component needs a `wasi:http`-native client instead.
+//!
+//! Custom implementations plug in via
+//! [`NearBuilder::transport`](super::NearBuilder::transport) (or
+//! [`RpcClient::with_transport_and_retry_config`](super::RpcClient::with_transport_and_retry_config)) —
+//! for example a host-call transport on a platform whose runtime proxies RPC
+//! traffic instead of exposing raw HTTP.
+
+use std::sync::Arc;
+
+use crate::error::RpcError;
+pub use crate::platform::BoxFuture;
+use crate::platform::{MaybeSend, MaybeSync};
+
+/// A raw HTTP response handed back from an [`RpcTransport`].
+///
+/// The body is raw bytes, not a `String`: HTTP bodies are bytes on the wire,
+/// and keeping the trait encoding-agnostic means transports never have to
+/// know that NEAR's JSON-RPC happens to be UTF-8 text. The RPC layer owns the
+/// (lossy) UTF-8 decode, exactly as it did when reqwest's `text()` did it.
+#[derive(Debug)]
+pub struct TransportResponse {
+    /// The HTTP status code (e.g. `200`).
+    pub status: u16,
+    /// The complete response body.
+    pub body: Vec<u8>,
+}
+
+/// The HTTP layer under [`RpcClient`](super::rpc::RpcClient).
+///
+/// One method: POST a JSON body, return the status and body — even for non-2xx
+/// statuses. The RPC layer interprets the response (including nearcore's
+/// convention of well-formed JSON-RPC error bodies on 4xx/5xx), so a transport
+/// should only return `Err` when no HTTP response was obtained at all.
+///
+/// # Errors
+///
+/// [`RpcError::Network`] is the portable error variant: set `retryable: true`
+/// for plausibly-transient failures (DNS, connect, timeout, connection reset)
+/// and `false` for deterministic ones (malformed URL, invalid request), and the
+/// client's retry/backoff loop will honor it. The built-in
+/// [`ReqwestTransport`] instead returns [`RpcError::Http`] so reqwest's own
+/// retryability classification keeps applying unchanged.
+///
+/// # Implementing
+///
+/// The trait is object-safe, so the future comes back boxed ([`BoxFuture`]);
+/// wrap an async block in `Box::pin`. The future may borrow `self` but not
+/// `url` or `body` — copy what you need up front. On native targets
+/// implementations (and their futures) must be `Send + Sync`; on
+/// `wasm32-unknown-unknown` those bounds disappear so browser APIs can be used
+/// directly.
+///
+/// ```rust,ignore
+/// struct MyTransport;
+///
+/// impl RpcTransport for MyTransport {
+///     fn post_json(
+///         &self,
+///         url: &str,
+///         body: Vec<u8>,
+///     ) -> BoxFuture<'_, Result<TransportResponse, RpcError>> {
+///         let url = url.to_string();
+///         Box::pin(async move { /* ... */ })
+///     }
+/// }
+/// ```
+pub trait RpcTransport: MaybeSend + MaybeSync {
+    /// POST `body` to `url` with `Content-Type: application/json`.
+    fn post_json(
+        &self,
+        url: &str,
+        body: Vec<u8>,
+    ) -> BoxFuture<'_, Result<TransportResponse, RpcError>>;
+}
+
+/// Implement `RpcTransport` for `Arc<T>` where `T: RpcTransport`.
+///
+/// This covers `Arc<dyn RpcTransport>` (since `dyn RpcTransport:
+/// RpcTransport`) as well as concrete types, so an already-shared transport
+/// can be passed to [`NearBuilder::transport`](super::NearBuilder::transport)
+/// without unwrapping it.
+impl<T: RpcTransport + ?Sized> RpcTransport for Arc<T> {
+    fn post_json(
+        &self,
+        url: &str,
+        body: Vec<u8>,
+    ) -> BoxFuture<'_, Result<TransportResponse, RpcError>> {
+        (**self).post_json(url, body)
+    }
+}
+
+/// The transport used when the caller doesn't supply one.
+pub(crate) fn default_transport() -> Arc<dyn RpcTransport> {
+    #[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
+    {
+        Arc::new(ReqwestTransport::new())
+    }
+    #[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
+    {
+        Arc::new(WasiHttpTransport::new())
+    }
+}
+
+// ============================================================================
+// Off-WASI: reqwest (native + wasm32-unknown-unknown)
+// ============================================================================
+
+/// The default [`RpcTransport`] on every target except WASI, backed by
+/// [`reqwest::Client`].
+///
+/// Wrap a preconfigured client (default headers, proxies, TLS, timeouts, ...)
+/// with [`ReqwestTransport::with_client`] — or use the
+/// [`NearBuilder::http_client`](super::NearBuilder::http_client) shorthand.
+#[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
+#[derive(Clone, Default)]
+pub struct ReqwestTransport {
+    client: reqwest::Client,
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
+impl ReqwestTransport {
+    /// Create a transport with a default `reqwest::Client`.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Wrap a preconfigured `reqwest::Client`.
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+// Manual impl: `reqwest::Client`'s Debug prints its full config, including
+// default headers, which may hold API keys.
+#[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
+impl std::fmt::Debug for ReqwestTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReqwestTransport").finish_non_exhaustive()
+    }
+}
+
+#[cfg(not(all(target_arch = "wasm32", target_os = "wasi")))]
+impl RpcTransport for ReqwestTransport {
+    fn post_json(
+        &self,
+        url: &str,
+        body: Vec<u8>,
+    ) -> BoxFuture<'_, Result<TransportResponse, RpcError>> {
+        let request = self
+            .client
+            .post(url)
+            .header("Content-Type", "application/json")
+            .body(body);
+        Box::pin(async move {
+            // Failures pass through as `RpcError::Http`, keeping reqwest's
+            // retryability classification (`is_timeout`/`is_connect`) exactly
+            // as it was before the transport seam existed.
+            let response = request.send().await?;
+            let status = response.status().as_u16();
+            let body = response.bytes().await?.to_vec();
+            Ok(TransportResponse { status, body })
+        })
+    }
+}
+
+// ============================================================================
+// WASI (wasm32-wasip2): wasi:http/outgoing-handler
+// ============================================================================
+
+/// The default [`RpcTransport`] on `wasm32-wasip2`, backed by
+/// `wasi:http/outgoing-handler`.
+///
+/// The host must provide the `wasi:http` interface — e.g. `wasmtime run -S
+/// http`, or any runtime targeting the `wasi:http/proxy` world.
+///
+/// The exchange is *blocking*: the guest parks on a wasi pollable until the
+/// response arrives, so exactly one request is in flight at a time. That is
+/// the natural shape for a single-threaded component; concurrent RPC calls
+/// from the same guest serialize rather than interleave.
+#[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
+#[derive(Clone, Debug, Default)]
+pub struct WasiHttpTransport;
+
+#[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
+impl WasiHttpTransport {
+    /// Create a new wasi:http transport.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
+impl RpcTransport for WasiHttpTransport {
+    fn post_json(
+        &self,
+        url: &str,
+        body: Vec<u8>,
+    ) -> BoxFuture<'_, Result<TransportResponse, RpcError>> {
+        Box::pin(wasi_http::Exchange::new(url, body))
+    }
+}
+
+#[cfg(all(target_arch = "wasm32", target_os = "wasi"))]
+mod wasi_http {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use wasi::http::outgoing_handler;
+    use wasi::http::types::{
+        ErrorCode, Fields, IncomingBody, Method, OutgoingBody, OutgoingRequest, Scheme,
+    };
+    use wasi::io::streams::StreamError;
+
+    use super::TransportResponse;
+    use crate::error::RpcError;
+
+    /// `wasi:io` streams cap a single `blocking-write-and-flush` at 4096 bytes.
+    const WRITE_CHUNK: usize = 4096;
+    /// Bytes to request per `blocking-read` while draining the response body.
+    const READ_CHUNK: u64 = 16 * 1024;
+
+    /// A future that runs the whole blocking `wasi:http` exchange inside a
+    /// single `poll` and returns `Ready`.
+    ///
+    /// Send-safety: `BoxFuture` requires `Send` on this target (only
+    /// `wasm32-unknown-unknown` relaxes it), but every `wasi` resource handle
+    /// (`OutgoingRequest`, streams, pollables) is `!Send`. Doing the exchange —
+    /// dispatch, pollable block, body drain — synchronously inside one `poll`
+    /// means those handles live and die in a single stack frame and are never
+    /// stored in the future. `Exchange` itself holds only a `String` and a
+    /// `Vec<u8>`, so it is `Send` by construction, with no `unsafe`.
+    pub(super) struct Exchange {
+        request: Option<(String, Vec<u8>)>,
+    }
+
+    impl Exchange {
+        pub(super) fn new(url: &str, body: Vec<u8>) -> Self {
+            Self {
+                request: Some((url.to_string(), body)),
+            }
+        }
+    }
+
+    impl Future for Exchange {
+        type Output = Result<TransportResponse, RpcError>;
+
+        fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
+            let (url, body) = self
+                .request
+                .take()
+                .expect("Exchange future polled after completion");
+            Poll::Ready(exchange(&url, &body))
+        }
+    }
+
+    /// The synchronous `wasi:http/outgoing-handler` exchange.
+    fn exchange(url: &str, body: &[u8]) -> Result<TransportResponse, RpcError> {
+        let (scheme, authority, path_with_query) = split_url(url)?;
+
+        // Rejected headers mean a malformed request — not retryable.
+        let headers = Fields::from_list(&[
+            ("content-type".to_string(), b"application/json".to_vec()),
+            (
+                "content-length".to_string(),
+                body.len().to_string().into_bytes(),
+            ),
+        ])
+        .map_err(|e| {
+            RpcError::network(
+                format!("wasi:http rejected request headers: {e:?}"),
+                None,
+                false,
+            )
+        })?;
+
+        let request = OutgoingRequest::new(headers);
+        request
+            .set_method(&Method::Post)
+            .map_err(|()| RpcError::network("wasi:http rejected method POST", None, false))?;
+        request
+            .set_scheme(Some(&scheme))
+            .map_err(|()| invalid_url(url, "unsupported scheme"))?;
+        request
+            .set_authority(Some(&authority))
+            .map_err(|()| invalid_url(url, "invalid authority"))?;
+        request
+            .set_path_with_query(Some(&path_with_query))
+            .map_err(|()| invalid_url(url, "invalid path"))?;
+
+        // Take the body handle *before* `handle` consumes the request resource.
+        let out_body = request
+            .body()
+            .map_err(|()| RpcError::network("wasi:http request body already taken", None, false))?;
+
+        let future_response = outgoing_handler::handle(request, None).map_err(|code| {
+            RpcError::network(
+                format!("wasi:http dispatch failed: {code:?}"),
+                None,
+                is_retryable_error_code(&code),
+            )
+        })?;
+
+        // Write the request body in the 4 KiB chunks `wasi:io` allows. The
+        // child stream must be dropped before finishing the body (dropping a
+        // still-open child traps in some hosts, so the scope is explicit).
+        {
+            let stream = out_body.write().map_err(|()| {
+                RpcError::network("wasi:http request body stream unavailable", None, false)
+            })?;
+            for chunk in body.chunks(WRITE_CHUNK) {
+                stream.blocking_write_and_flush(chunk).map_err(|e| {
+                    RpcError::network(
+                        format!("wasi:http request body write failed: {}", stream_err(e)),
+                        None,
+                        true,
+                    )
+                })?;
+            }
+        }
+        OutgoingBody::finish(out_body, None).map_err(|code| {
+            RpcError::network(
+                format!("wasi:http finishing request body failed: {code:?}"),
+                None,
+                is_retryable_error_code(&code),
+            )
+        })?;
+
+        // Block the (single-threaded) guest until the response is available.
+        let pollable = future_response.subscribe();
+        pollable.block();
+        drop(pollable);
+
+        let response = match future_response.get() {
+            Some(Ok(Ok(response))) => response,
+            // The host-reported failure (DNS, connect, TLS, ...) — the
+            // wasi:http analogue of a reqwest connect error.
+            Some(Ok(Err(code))) => {
+                return Err(RpcError::network(
+                    format!("wasi:http request failed: {code:?}"),
+                    None,
+                    is_retryable_error_code(&code),
+                ));
+            }
+            Some(Err(())) => {
+                return Err(RpcError::network(
+                    "wasi:http response consumed twice",
+                    None,
+                    false,
+                ));
+            }
+            None => {
+                return Err(RpcError::network(
+                    "wasi:http response not ready after blocking",
+                    None,
+                    true,
+                ));
+            }
+        };
+
+        // Non-2xx is not an error here: return the status and body and let
+        // the RPC layer interpret them (nearcore sends JSON-RPC error bodies
+        // with 4xx/5xx statuses).
+        let status = response.status();
+
+        let incoming_body = response.consume().map_err(|()| {
+            RpcError::network("wasi:http response body already consumed", None, false)
+        })?;
+        let mut buf = Vec::new();
+        {
+            let stream = incoming_body.stream().map_err(|()| {
+                RpcError::network("wasi:http response body stream unavailable", None, false)
+            })?;
+            loop {
+                match stream.blocking_read(READ_CHUNK) {
+                    Ok(chunk) => buf.extend_from_slice(&chunk),
+                    Err(StreamError::Closed) => break,
+                    Err(e @ StreamError::LastOperationFailed(_)) => {
+                        return Err(RpcError::network(
+                            format!("wasi:http response body read failed: {}", stream_err(e)),
+                            None,
+                            true,
+                        ));
+                    }
+                }
+            }
+        }
+        // Finish the incoming body (drops the trailers future we never read).
+        let _ = IncomingBody::finish(incoming_body);
+
+        Ok(TransportResponse { status, body: buf })
+    }
+
+    /// Split a URL into the `wasi:http` request parts: scheme, authority, and
+    /// path-with-query. (No `url`-crate dependency; RPC endpoint URLs are
+    /// simple enough for direct splitting.)
+    fn split_url(url: &str) -> Result<(Scheme, String, String), RpcError> {
+        let (scheme_raw, rest) = url
+            .split_once("://")
+            .ok_or_else(|| invalid_url(url, "missing scheme"))?;
+        let scheme = match scheme_raw {
+            "http" => Scheme::Http,
+            "https" => Scheme::Https,
+            other => Scheme::Other(other.to_string()),
+        };
+        let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+        let (authority, tail) = rest.split_at(authority_end);
+        if authority.is_empty() {
+            return Err(invalid_url(url, "missing host"));
+        }
+        // Fragments are client-side only; never send them.
+        let tail = tail.split('#').next().unwrap_or_default();
+        let path_with_query = if tail.is_empty() {
+            "/".to_string()
+        } else if tail.starts_with('?') {
+            format!("/{tail}")
+        } else {
+            tail.to_string()
+        };
+        Ok((scheme, authority.to_string(), path_with_query))
+    }
+
+    /// A malformed URL is deterministic — never retryable.
+    fn invalid_url(url: &str, reason: &str) -> RpcError {
+        RpcError::network(format!("invalid RPC URL `{url}`: {reason}"), None, false)
+    }
+
+    fn stream_err(e: StreamError) -> String {
+        match e {
+            StreamError::Closed => "stream closed".to_string(),
+            StreamError::LastOperationFailed(err) => err.to_debug_string(),
+        }
+    }
+
+    /// Retryability of a `wasi:http` [`ErrorCode`], mirroring the reqwest
+    /// classification (`is_timeout`/`is_connect`): failures to *reach or keep
+    /// talking to* the server (DNS, connect, TLS, timeouts, protocol hiccups)
+    /// are transient and worth retrying; codes that say the *request itself*
+    /// is unacceptable are deterministic and are not.
+    fn is_retryable_error_code(code: &ErrorCode) -> bool {
+        !matches!(
+            code,
+            ErrorCode::HttpRequestDenied
+                | ErrorCode::HttpRequestLengthRequired
+                | ErrorCode::HttpRequestBodySize(_)
+                | ErrorCode::HttpRequestMethodInvalid
+                | ErrorCode::HttpRequestUriInvalid
+                | ErrorCode::HttpRequestUriTooLong
+                | ErrorCode::HttpRequestHeaderSectionSize(_)
+                | ErrorCode::HttpRequestHeaderSize(_)
+                | ErrorCode::HttpRequestTrailerSectionSize(_)
+                | ErrorCode::HttpRequestTrailerSize(_)
+                | ErrorCode::LoopDetected
+                | ErrorCode::ConfigurationError
+        )
+    }
+}

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -175,9 +175,10 @@ pub enum KeyStoreError {
 #[non_exhaustive]
 pub enum RpcError {
     // ─── Network/Transport ───
-    // reqwest only compiles with the `rpc` feature, so this variant (and its
-    // `is_retryable` arm below) exists only there.
-    #[cfg(feature = "rpc")]
+    // reqwest only compiles with the `rpc` feature and never on WASI (the
+    // wasi:http transport reports failures as `Network` instead), so this
+    // variant (and its `is_retryable` arm below) exists only there.
+    #[cfg(all(feature = "rpc", not(all(target_arch = "wasm32", target_os = "wasi"))))]
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
 
@@ -308,7 +309,7 @@ impl RpcError {
     /// Check if this error is retryable.
     pub fn is_retryable(&self) -> bool {
         match self {
-            #[cfg(feature = "rpc")]
+            #[cfg(all(feature = "rpc", not(all(target_arch = "wasm32", target_os = "wasi"))))]
             RpcError::Http(e) => {
                 // `is_connect()` doesn't exist on reqwest's JS fetch backend
                 // (`wasm32-unknown-unknown` — no hyper connector); `is_request()`

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -402,6 +402,29 @@
 //! below) works. (WASI targets like `wasm32-wasip1` don't need any of this:
 //! `getrandom` supports them natively, so leave `js` off there too.)
 //!
+//! ### WASI (`wasm32-wasip2`)
+//!
+//! near-kit also runs inside WASI Preview 2 components, with full RPC support:
+//! on this target the `rpc` feature swaps reqwest for a built-in
+//! `WasiHttpTransport` speaking `wasi:http/outgoing-handler`.
+//!
+//! ```toml
+//! [dependencies]
+//! near-kit = { version = "0.13", default-features = false, features = ["rpc"] }
+//! ```
+//!
+//! The host must provide the `wasi:http` interface — `wasmtime run -S http`, or
+//! any runtime targeting the `wasi:http/proxy` world. Two semantic differences
+//! from native:
+//!
+//! - The transport is *blocking*: the guest parks until each response arrives,
+//!   so one request is in flight at a time and concurrent RPC calls serialize.
+//! - Retry backoff uses `std::thread::sleep` (no async runtime in the guest).
+//!
+//! On WASI hosts without `wasi:http`, either stay offline (drop the `rpc`
+//! feature — see below) or plug in whatever the platform does provide via
+//! [`NearBuilder::transport`].
+//!
 //! ### Custom entropy backends
 //!
 //! Non-JS `wasm32-unknown-unknown` embedders must provide entropy for both `getrandom`
@@ -434,8 +457,8 @@
 //! (`new` → `sign` → `to_bytes`), and NEP-413 [`nep413::verify_signature`].
 //! The fluent [`TransactionBuilder`] is part of the RPC layer — it is created
 //! from a [`Near`] client — so it requires `rpc`.
-//! The motivating target is `wasm32-wasip2`, where the HTTP client doesn't
-//! build — sign transactions and messages in the component, send them elsewhere:
+//! This is what you want on targets with no network stack at all — sign
+//! transactions and messages locally, send them elsewhere:
 //!
 //! ```toml
 //! [dependencies]
@@ -446,7 +469,7 @@
 //!
 //! | Feature | Default | Description |
 //! |---------|---------|-------------|
-//! | `rpc` | Yes | The RPC layer: [`Near`], queries, transactions, tokens, and the HTTP client. Disable for offline signing/verification (e.g. on `wasm32-wasip2`) |
+//! | `rpc` | Yes | The RPC layer: [`Near`], queries, transactions, tokens, and the HTTP transport (reqwest; `wasi:http` on `wasm32-wasip2`). Disable for offline signing/verification |
 //! | `keyring` | Yes | System keyring signer (macOS Keychain, Windows Credential Manager, etc.) |
 //! | `file-signer` | Yes | [`FileSigner`] for loading keys from `~/.near-credentials` |
 //! | `tracing` | Yes | [`tracing`](https://docs.rs/tracing) spans and events for RPC calls and transactions |
@@ -502,11 +525,17 @@ pub use contract::{Contract, ContractClient};
 // Re-export client types
 #[cfg(feature = "rpc")]
 pub use client::{
-    AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, CallBuilder,
+    AccessKeysQuery, AccountExistsQuery, AccountQuery, BalanceQuery, BoxFuture, CallBuilder,
     ContractCodeQuery, DelegateOptions, DelegateResult, FunctionCall, GlobalContractQuery, Near,
-    NearBuilder, RetryConfig, RpcClient, SandboxNetwork, SignedTransactionSend, TransactionBuilder,
-    TransactionSend, TransactionStatusQuery, ViewCall, ViewCallBorsh,
+    NearBuilder, RetryConfig, RpcClient, RpcTransport, SandboxNetwork, SignedTransactionSend,
+    TransactionBuilder, TransactionSend, TransactionStatusQuery, TransportResponse, ViewCall,
+    ViewCallBorsh,
 };
+// Only the built-in transport matching the build target exists (see client/mod.rs).
+#[cfg(all(feature = "rpc", not(all(target_arch = "wasm32", target_os = "wasi"))))]
+pub use client::ReqwestTransport;
+#[cfg(all(feature = "rpc", target_arch = "wasm32", target_os = "wasi"))]
+pub use client::WasiHttpTransport;
 // The signers do local cryptography only — they stay available offline.
 pub use client::{EnvSigner, InMemorySigner, RotatingSigner, Signer, SigningKey};
 

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -405,25 +405,32 @@
 //! ### WASI (`wasm32-wasip2`)
 //!
 //! near-kit also runs inside WASI Preview 2 components, with full RPC support:
-//! on this target the `rpc` feature swaps reqwest for a built-in
-//! `WasiHttpTransport` speaking `wasi:http/outgoing-handler`.
+//! the `wasi-http` feature (on by default; implies `rpc`) provides a built-in
+//! `WasiHttpTransport` speaking `wasi:http/outgoing-handler` in place of
+//! reqwest, which doesn't build for WASI.
 //!
 //! ```toml
 //! [dependencies]
-//! near-kit = { version = "0.13", default-features = false, features = ["rpc"] }
+//! near-kit = { version = "0.14", default-features = false, features = ["wasi-http"] }
 //! ```
 //!
 //! The host must provide the `wasi:http` interface — `wasmtime run -S http`, or
-//! any runtime targeting the `wasi:http/proxy` world. Two semantic differences
-//! from native:
+//! any runtime targeting the `wasi:http/proxy` world. Three semantic
+//! differences from native:
 //!
 //! - The transport is *blocking*: the guest parks until each response arrives,
 //!   so one request is in flight at a time and concurrent RPC calls serialize.
 //! - Retry backoff uses `std::thread::sleep` (no async runtime in the guest).
+//! - HTTP redirects are not followed (reqwest follows up to 10 by default) —
+//!   point the client at the final RPC URL.
 //!
-//! On WASI hosts without `wasi:http`, either stay offline (drop the `rpc`
-//! feature — see below) or plug in whatever the platform does provide via
-//! [`NearBuilder::transport`].
+//! On WASI hosts *without* `wasi:http`, enable only `rpc` and plug in whatever
+//! the platform does provide via [`NearBuilder::transport`]. The `wasi-http`
+//! feature must stay off there: merely compiling the built-in transport makes
+//! the component import `wasi:http`, which such hosts refuse to instantiate.
+//! With `rpc` alone those imports never appear — but there is then no built-in
+//! transport, so [`NearBuilder::build`] panics unless one was injected. (Or
+//! stay fully offline by dropping `rpc` too — see below.)
 //!
 //! ### Custom entropy backends
 //!
@@ -469,7 +476,8 @@
 //!
 //! | Feature | Default | Description |
 //! |---------|---------|-------------|
-//! | `rpc` | Yes | The RPC layer: [`Near`], queries, transactions, tokens, and the HTTP transport (reqwest; `wasi:http` on `wasm32-wasip2`). Disable for offline signing/verification |
+//! | `rpc` | Yes | The RPC layer: [`Near`], queries, transactions, tokens, and the HTTP transport (reqwest, except on WASI). Disable for offline signing/verification |
+//! | `wasi-http` | Yes | Built-in `wasi:http` transport for `wasm32-wasip2` (implies `rpc`; no-op elsewhere). Disable on WASI hosts without `wasi:http` and inject a transport via [`NearBuilder::transport`] |
 //! | `keyring` | Yes | System keyring signer (macOS Keychain, Windows Credential Manager, etc.) |
 //! | `file-signer` | Yes | [`FileSigner`] for loading keys from `~/.near-credentials` |
 //! | `tracing` | Yes | [`tracing`](https://docs.rs/tracing) spans and events for RPC calls and transactions |
@@ -531,10 +539,16 @@ pub use client::{
     TransactionBuilder, TransactionSend, TransactionStatusQuery, TransportResponse, ViewCall,
     ViewCallBorsh,
 };
-// Only the built-in transport matching the build target exists (see client/mod.rs).
+// Only the built-in transport matching the build configuration exists (see
+// client/mod.rs); WASI without `wasi-http` has none.
 #[cfg(all(feature = "rpc", not(all(target_arch = "wasm32", target_os = "wasi"))))]
 pub use client::ReqwestTransport;
-#[cfg(all(feature = "rpc", target_arch = "wasm32", target_os = "wasi"))]
+#[cfg(all(
+    feature = "wasi-http",
+    target_arch = "wasm32",
+    target_os = "wasi",
+    target_env = "p2"
+))]
 pub use client::WasiHttpTransport;
 // The signers do local cryptography only — they stay available offline.
 pub use client::{EnvSigner, InMemorySigner, RotatingSigner, Signer, SigningKey};

--- a/crates/near-kit/src/platform.rs
+++ b/crates/near-kit/src/platform.rs
@@ -4,37 +4,43 @@
 //! On `wasm32-unknown-unknown` (browsers and other JS hosts), there are no threads,
 //! so these bounds are unnecessary (and often impossible to satisfy with browser
 //! APIs). WASI targets (`wasm32-wasip1`/`p2`) keep the regular bounds.
+//!
+//! The items here are `pub` (not `pub(crate)`) because they appear in the
+//! public [`RpcTransport`](crate::client::RpcTransport) interface — `BoxFuture`
+//! is re-exported from there; `MaybeSend`/`MaybeSync` stay unnameable outside
+//! the crate (their blanket impls apply to every eligible type, so implementors
+//! never spell them out).
 
 use std::future::Future;
 use std::pin::Pin;
 
 /// A boxed future that is `Send` everywhere except `wasm32-unknown-unknown`.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub(crate) type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 /// Trait alias: `Send` everywhere except `wasm32-unknown-unknown`, where it's
 /// unconditional.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-pub(crate) trait MaybeSend: Send {}
+pub trait MaybeSend: Send {}
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 impl<T: Send> MaybeSend for T {}
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub(crate) trait MaybeSend {}
+pub trait MaybeSend {}
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl<T> MaybeSend for T {}
 
 /// Trait alias: `Sync` everywhere except `wasm32-unknown-unknown`, where it's
 /// unconditional.
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
-pub(crate) trait MaybeSync: Sync {}
+pub trait MaybeSync: Sync {}
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 impl<T: Sync> MaybeSync for T {}
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
-pub(crate) trait MaybeSync {}
+pub trait MaybeSync {}
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 impl<T> MaybeSync for T {}


### PR DESCRIPTION
## Summary

Makes near-kit's RPC client work on `wasm32-wasip2` by introducing a pluggable transport layer. Follow-up to #258 (part 2 of 2).

Motivation: near/intents' `defuse-wallet-sdk` needs near-kit inside WASI Preview 2 components (OutLayer-style TEE wallets), where reqwest cannot compile — its native stack needs an `aws-lc-sys` C cross-compile and hyper's tokio `net` feature, neither of which builds for wasm, and upstream WASI support is stalled on in-guest TLS (seanmonstar/reqwest#2979, seanmonstar/reqwest#2453). `wasi:http/outgoing-handler` sidesteps all of that: the host does TLS, the guest carries zero crypto for transport. Related: #151.

## Design

- **`RpcTransport` trait** (`client/transport.rs`): object-safe, `post_json(url, body) -> BoxFuture<Result<TransportResponse, RpcError>>` using the crate's platform `Send` bounds. `RpcClient` now holds `Arc<dyn RpcTransport>`; retry/backoff logic is unchanged.
- **`ReqwestTransport`** (every target except WASI): wraps `reqwest::Client`, maps errors to `RpcError::Http` exactly as before — native retry semantics are preserved byte-for-byte, and `NearBuilder::http_client` (#249) keeps working as a convenience wrapper (its unit test passes unmodified).
- **`WasiHttpTransport`** (`wasm32-wasip2`, new default-on **`wasi-http`** feature, implies `rpc`): raw `wasi = "0.14"` bindings, the entire blocking exchange inside a single `Future::poll` so no `!Send` wasi resource is ever held across a suspension — no `unsafe`, no platform.rs changes. Schemes matched case-insensitively; non-http(s) schemes rejected as non-retryable; URL userinfo becomes an `Authorization: Basic` header (as reqwest does elsewhere).
- **Why `wasi-http` is a separate feature**: merely compiling the built-in transport makes the component import `wasi:http`, which hosts without that interface refuse to instantiate. With only `rpc` enabled there is no such import — `NearBuilder::transport` injection is the only network path, and `build()` panics with a clear message if none was supplied. Scoped to `target_env = "p2"` (wasm32-wasip1 has no `wasi:http`), with a `compile_error!` guard.
- **`NearBuilder::transport(...)`**: public injection point for custom transports (e.g. a runtime that proxies RPC through host calls instead of raw HTTP).
- Retry backoff on WASI uses `std::thread::sleep` (no async runtime in a single-threaded guest; the tokio arm would panic).
- Semantic differences from native, documented: blocking transport (one request in flight), thread-sleep backoff, no redirect following.

## Test plan

- `cargo check` matrix, all clean (0 warnings): native default / `--no-default-features --all-targets` / `rpc` only / wasip2 offline / wasip2 `rpc`-only (no wasi:http import) / wasip2 `wasi-http` / browser `js,rpc`.
- `cargo test -p near-kit --lib`: 506 passed. Doctests pass under default and `--no-default-features`.
- `cargo fmt`, workspace clippy with `-Dwarnings` (all features, all targets), and `cargo +1.88 check --workspace --all-targets` (MSRV): clean.
- CI gains two wasip2 lanes: `--features rpc` (bring-your-own transport) and `--features wasi-http` (built-in).
- **Live E2E**: a `wasm32-wasip2` component built against this branch, run under `wasmtime run -S http`, real testnet queries through the unchanged `Near` facade:

```
built Near facade, rpc_url = https://test.rpc.fastnear.com
OK status: chain_id=testnet protocol_version=85 latest_block=260764750
OK account(testnet): amount=1131549.37 NEAR locked=0 NEAR storage_usage=1185135
OK balance(testnet): total=1131549.37 NEAR available=1131537.52 NEAR locked=0 NEAR
OK block(final): height=260764751 hash=6ZCpekESLDCLFchVGFjxL14YMR2qBVw8qjRrvtrnq6XX
ALL RPC SMOKE TESTS PASSED on wasm32-wasip2 via wasi:http
```
