### PR TITLE
chore(deps): unify rand_core on 0.10 by bumping k256 and rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.2.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base64"
@@ -405,7 +405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "rand_core 0.10.1",
 ]
 
@@ -463,12 +463,6 @@ checksum = "e763eef8846b13b380f37dfecda401770b0ca4e56e95170237bd7c25c7db3582"
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -500,13 +494,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -519,12 +510,16 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
- "generic-array",
- "rand_core 0.6.4",
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
  "subtle",
  "zeroize",
 ]
@@ -557,6 +552,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -566,10 +562,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.11.2",
  "fiat-crypto",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -644,21 +641,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid 0.9.6",
- "zeroize",
-]
-
-[[package]]
-name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "const-oid 0.10.2",
+ "const-oid",
  "zeroize",
 ]
 
@@ -679,9 +666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid 0.9.6",
  "crypto-common 0.1.6",
- "subtle",
 ]
 
 [[package]]
@@ -691,7 +676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.1",
  "ctutils",
 ]
@@ -762,16 +747,17 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.16.9"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
 dependencies = [
- "der 0.7.10",
- "digest 0.10.7",
+ "der",
+ "digest 0.11.2",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
- "spki 0.7.3",
+ "signature",
+ "spki",
+ "zeroize",
 ]
 
 [[package]]
@@ -780,7 +766,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
- "signature 3.0.0",
+ "signature",
 ]
 
 [[package]]
@@ -791,7 +777,9 @@ checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "sha2 0.11.0",
+ "rand_core 0.10.1",
+ "sha2",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -804,18 +792,19 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.8"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "crypto-common 0.2.1",
+ "digest 0.11.2",
  "ff",
- "generic-array",
  "group",
- "pkcs8 0.10.2",
- "rand_core 0.6.4",
+ "hybrid-array",
+ "pkcs8",
+ "rand_core 0.10.1",
  "sec1",
  "subtle",
  "zeroize",
@@ -875,11 +864,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1044,7 +1033,6 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1110,12 +1098,12 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -1188,15 +1176,6 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hmac"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
@@ -1260,12 +1239,14 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.8"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8655f91cd07f2b9d0c24137bd650fe69617773435ee5ec83022377777ce65ef1"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "ctutils",
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -1634,16 +1615,17 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
- "cfg-if",
+ "cpubits",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
- "sha2 0.10.9",
- "signature 2.2.0",
+ "primeorder",
+ "sha2",
+ "signature",
+ "wnaf",
 ]
 
 [[package]]
@@ -1653,7 +1635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -1780,14 +1762,14 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "add6b9d92e496f16f4526d68ff29da1483aba4b119baeab8bed3b9e3544a6f3d"
 dependencies = [
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.1",
  "ctutils",
  "hybrid-array",
  "module-lattice",
- "pkcs8 0.11.0",
+ "pkcs8",
  "shake",
- "signature 3.0.0",
+ "signature",
 ]
 
 [[package]]
@@ -1857,11 +1839,10 @@ dependencies = [
  "dirs",
  "ed25519-dalek",
  "futures",
- "getrandom 0.2.17",
  "getrandom 0.4.2",
  "gloo-timers",
  "hex",
- "hmac 0.13.0",
+ "hmac",
  "js-sys",
  "k256",
  "keyring",
@@ -1872,12 +1853,12 @@ dependencies = [
  "near-global-contracts",
  "near-kit-macros",
  "near-token",
- "rand 0.8.5",
+ "rand 0.10.1",
  "reqwest",
  "serde",
  "serde_json",
  "serde_with",
- "sha2 0.11.0",
+ "sha2",
  "sha3 0.12.0",
  "tempfile",
  "testcontainers",
@@ -1910,7 +1891,7 @@ checksum = "73a159e55901b3a2fab682896ef8e037a3862d4677e762644be922696de28339"
 dependencies = [
  "near-sys",
  "ripemd",
- "sha2 0.11.0",
+ "sha2",
  "sha3 0.11.0",
 ]
 
@@ -2150,22 +2131,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der 0.7.10",
- "spki 0.7.3",
-]
-
-[[package]]
-name = "pkcs8"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
- "der 0.8.0",
- "spki 0.8.0",
+ "der",
+ "spki",
 ]
 
 [[package]]
@@ -2218,6 +2189,33 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint",
+ "crypto-common 0.2.1",
+ "ff",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve",
+ "once_cell",
+ "primefield",
+ "serdect",
+ "wnaf",
 ]
 
 [[package]]
@@ -2373,22 +2371,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.5",
 ]
 
@@ -2405,31 +2392,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2558,12 +2526,12 @@ dependencies = [
 
 [[package]]
 name = "rfc6979"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
 dependencies = [
- "hmac 0.12.1",
- "subtle",
+ "crypto-bigint",
+ "hmac",
 ]
 
 [[package]]
@@ -2750,14 +2718,14 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
 dependencies = [
  "base16ct",
- "der 0.7.10",
- "generic-array",
- "pkcs8 0.10.2",
+ "ctutils",
+ "der",
+ "hybrid-array",
  "subtle",
  "zeroize",
 ]
@@ -2912,14 +2880,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
+name = "serdect"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "base16ct",
+ "serde",
 ]
 
 [[package]]
@@ -2929,7 +2896,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures",
  "digest 0.11.2",
 ]
 
@@ -3002,16 +2969,6 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
@@ -3044,22 +3001,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der 0.7.10",
-]
-
-[[package]]
-name = "spki"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
- "der 0.8.0",
+ "der",
 ]
 
 [[package]]
@@ -3667,9 +3614,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -4378,6 +4325,17 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff",
+ "group",
+ "hybrid-array",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,18 +35,19 @@ borsh = { version = "1", features = ["derive"] }
 base64 = "0.23"
 
 # Cryptography
-# No `rand_core` feature: `SigningKey::generate` is generic over `rand_core`
-# 0.10's `CryptoRng`, but `k256` 0.13 pins the graph to `rand_core` 0.6 (via
-# `elliptic-curve` 0.13), so `rand` stays on 0.8 and key generation draws its
-# own seed bytes from `OsRng` — see `SecretKey::generate_ed25519`.
-ed25519-dalek = "3"
+# These versions are chosen together so the crypto graph agrees on one
+# `rand_core` (0.10) and therefore one `getrandom` (0.4): `k256` 0.14 brings
+# `elliptic-curve` 0.14 / `ecdsa` 0.17 / `signature` 3, which is what
+# `ed25519-dalek` 3 and `ml-dsa` 0.1 already sit on. Bumping any of these back
+# splits `rand_core` again — see `SecretKey::generate_ed25519`.
+ed25519-dalek = { version = "3", features = ["rand_core"] }
 sha2 = "0.11"
 sha3 = "0.12"
 ml-dsa = "0.1"
-rand = "0.8"
+rand = "0.10"
 bip39 = "2"
 hmac = "0.13"
-k256 = { version = "0.13", features = ["ecdsa"] }
+k256 = { version = "0.14", features = ["ecdsa"] }
 
 # Encoding
 bs58 = "0.5"

--- a/crates/near-kit/Cargo.toml
+++ b/crates/near-kit/Cargo.toml
@@ -87,15 +87,15 @@ reqwest = { workspace = true, optional = true }
 wasi = { version = "0.14", optional = true }
 
 # JS-host wasm only (`wasm32-unknown-unknown`, i.e. browsers/Node/Deno — NOT
-# WASI): JS-backed timer and time APIs. `getrandom`/`getrandom_v04` are entropy
-# backends for the transitive `rand`/`ml-dsa` dependency graphs; their
-# `js`/`wasm_js` features are opt-in via the crate's `js` feature (see below) so
-# non-JS wasm embedders can choose their own backend instead.
+# WASI): JS-backed timer and time APIs. `getrandom` is the entropy backend for
+# the whole crypto dependency graph (`rand`/`k256`/`ed25519-dalek`/`ml-dsa` all
+# reach it through `rand_core` 0.10); its `wasm_js` feature is opt-in via the
+# crate's `js` feature (see below) so non-JS wasm embedders can choose their own
+# backend instead.
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 gloo-timers = { version = "0.4", features = ["futures"] }
 js-sys = "0.3"
-getrandom = { version = "0.2", default-features = false }
-getrandom_v04 = { package = "getrandom", version = "0.4", default-features = false }
+getrandom = { version = "0.4", default-features = false }
 
 [features]
 default = ["rpc", "wasi-http", "keyring", "file-signer", "tracing"]
@@ -120,12 +120,11 @@ file-signer = ["dep:dirs"]
 # operations. Disable (via `default-features = false`) to drop the dependency.
 tracing = ["dep:tracing"]
 # JS-host entropy backend for `wasm32-unknown-unknown`. Enables `getrandom`'s
-# `js` feature (used transitively by `rand`/`k256`) and `getrandom` 0.4's
-# `wasm_js` feature (used transitively by `ml-dsa`/`sha2`/`hmac`/`ed25519-dalek`
-# via `digest`). Leave this off on non-JS wasm embedders
-# (register your own `getrandom` backend) and on WASI targets (which `getrandom`
-# supports natively).
-js = ["getrandom/js", "getrandom_v04/wasm_js"]
+# `wasm_js` feature, which every crypto dependency reaches through `rand_core`
+# 0.10 (`rand`, `k256`, `ed25519-dalek`, `ml-dsa`). Leave this off on non-JS
+# wasm embedders (register your own `getrandom` backend) and on WASI targets
+# (which `getrandom` supports natively).
+js = ["getrandom/wasm_js"]
 # Enables `interactive-clap` derives on re-exported `NearToken` and `Gas` types.
 # Useful for CLI tools using `interactive-clap` for argument parsing.
 interactive-clap = ["near-token/interactive-clap", "near-gas/interactive-clap"]

--- a/crates/near-kit/src/lib.rs
+++ b/crates/near-kit/src/lib.rs
@@ -434,25 +434,36 @@
 //!
 //! ### Custom entropy backends
 //!
-//! Non-JS `wasm32-unknown-unknown` embedders must provide entropy for both `getrandom`
-//! major versions in near-kit's dependency graph: 0.2 (via `rand`/`k256`) and 0.4 (via
-//! `ml-dsa`/`sha2`/`sha3`/`hmac`/`ed25519-dalek`).
+//! Non-JS `wasm32-unknown-unknown` embedders must register one entropy backend, for
+//! getrandom 0.4 — the only major version reachable on that target, which `rand`,
+//! `k256`, `ed25519-dalek`, and `ml-dsa` all share through `rand_core` 0.10. (A
+//! native `cargo tree` also shows getrandom 0.2/0.3 behind the `rpc` and `sandbox`
+//! features, via `ring`/`rustls` and `testcontainers`; neither builds for
+//! `wasm32-unknown-unknown`, so neither needs a backend here.)
 //!
 //! ```toml
 //! [dependencies]
 //! near-kit = { version = "0.14", default-features = false }
-//! getrandom = { version = "0.2", features = ["custom"] }
 //! ```
 //!
-//! For getrandom 0.2, the `custom` feature suppresses its wasm compile error; register
-//! your entropy function with its `register_custom_getrandom!` macro. For getrandom 0.4,
-//! build with `RUSTFLAGS='--cfg getrandom_backend="custom"'` and export an `extern
-//! "Rust"` fn named `__getrandom_v03_custom` returning `Result<(), getrandom::Error>` —
-//! note the `v03`: getrandom 0.4 kept the 0.3 symbol name, so `_v04_` won't link. See
-//! the [`getrandom` docs](https://docs.rs/getrandom) for the exact signature. If your
-//! application never generates keys or nonces, `--cfg getrandom_backend="unsupported"`
-//! also works for 0.4: it compiles everywhere and errors at runtime if entropy is ever
-//! requested.
+//! Build with `RUSTFLAGS='--cfg getrandom_backend="custom"'` and export an `extern
+//! "Rust"` fn named `__getrandom_v03_custom` returning `Result<(), getrandom::Error>`
+//! — note the `v03`: getrandom 0.4 kept the 0.3 symbol name, so `_v04_` won't link.
+//! See the [`getrandom` docs](https://docs.rs/getrandom) for the exact signature. If
+//! your application never generates keys or nonces,
+//! `--cfg getrandom_backend="unsupported"` also works: it compiles everywhere and
+//! errors at runtime if entropy is ever requested.
+//!
+//! <div class="warning">
+//!
+//! **Changed since 0.14:** near-kit used to pull in *two* getrandom majors (0.2 and
+//! 0.4) and needed a backend for each — the 0.2 one registered with
+//! `register_custom_getrandom!` behind its `custom` feature. Unifying the crypto
+//! graph on `rand_core` 0.10 dropped getrandom 0.2 entirely, so that half of the
+//! setup (and the direct `getrandom = "0.2"` dependency it required) should now be
+//! removed.
+//!
+//! </div>
 //!
 //! ## Offline / no-network usage
 //!
@@ -482,7 +493,7 @@
 //! | `file-signer` | Yes | [`FileSigner`] for loading keys from `~/.near-credentials` |
 //! | `tracing` | Yes | [`tracing`](https://docs.rs/tracing) spans and events for RPC calls and transactions |
 //! | `sandbox` | No | Integration with `near-sandbox` for local testing (implies `rpc`) |
-//! | `js` | No | JS-host entropy backend (`getrandom`'s `js`/`wasm_js`) for `wasm32-unknown-unknown` |
+//! | `js` | No | JS-host entropy backend (`getrandom`'s `wasm_js`) for `wasm32-unknown-unknown` |
 //!
 //! ## Error Handling
 //!

--- a/crates/near-kit/src/types/csprng.rs
+++ b/crates/near-kit/src/types/csprng.rs
@@ -1,0 +1,38 @@
+//! The OS CSPRNG, adapted to `rand_core` 0.10's infallible traits.
+//!
+//! `rand` 0.10 renamed `OsRng` to [`SysRng`] and, more importantly, made it
+//! *fallible*: it implements only [`TryRng`]/[`TryCryptoRng`], not the
+//! infallible [`Rng`]/[`CryptoRng`] that `SigningKey::generate` and
+//! `SecretKey::random` require. Every near-kit caller is an infallible
+//! `pub fn` returning a key, a seed phrase, or a nonce — not a `Result` — so
+//! there is nowhere to report an entropy failure without breaking the public
+//! API.
+//!
+//! [`UnwrapErr`] is therefore a deliberate choice, not an oversight: a failing
+//! OS entropy source panics here, which is exactly what `rand` 0.8's `OsRng`
+//! and `ed25519_dalek::SigningKey::generate` did before this bump. The failure
+//! is never swallowed and never falls back to a weaker source.
+//!
+//! [`Rng`]: rand::Rng
+//! [`CryptoRng`]: rand::CryptoRng
+//! [`TryRng`]: rand::TryRng
+//! [`TryCryptoRng`]: rand::TryCryptoRng
+
+use rand::Rng as _;
+use rand::rand_core::UnwrapErr;
+use rand::rngs::SysRng;
+
+/// The operating system's CSPRNG as an infallible [`CryptoRng`], for the
+/// keygen APIs that are generic over it. Panics if the OS source fails.
+///
+/// [`CryptoRng`]: rand::CryptoRng
+pub(crate) fn os_csprng() -> UnwrapErr<SysRng> {
+    UnwrapErr(SysRng)
+}
+
+/// Fill `dst` with bytes from the operating system's CSPRNG.
+///
+/// Panics if the OS source fails; see the module docs.
+pub(crate) fn fill_random(dst: &mut [u8]) {
+    os_csprng().fill_bytes(dst);
+}

--- a/crates/near-kit/src/types/key.rs
+++ b/crates/near-kit/src/types/key.rs
@@ -6,16 +6,17 @@ use std::str::FromStr;
 use bip39::Mnemonic;
 use borsh::{BorshDeserialize, BorshSerialize};
 use ed25519_dalek::{Signer as _, SigningKey, VerifyingKey};
-use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use k256::elliptic_curve::Generate as _;
+use k256::elliptic_curve::sec1::{FromSec1Point, ToSec1Point};
 // `Signer` is already in scope from `ed25519_dalek` above: dalek 3 and `ml-dsa`
 // both sit on `signature` 3, so it is literally the same trait and importing it
 // from both paths warns.
 use ml_dsa::signature::Verifier as _;
 use ml_dsa::{B32, EncodedSignature, EncodedVerifyingKey, ExpandedSigningKeyBytes, MlDsa65};
-use rand::rngs::OsRng;
 use serde_with::{DeserializeFromStr, SerializeDisplay};
 use sha2::Digest;
 
+use super::csprng::{fill_random, os_csprng};
 use super::hd::{derive_ed25519_slip10, derive_ml_dsa65_slip10, parse_hd_path};
 use crate::error::{ParseKeyError, SignerError};
 
@@ -145,9 +146,9 @@ impl PublicKey {
         let mut uncompressed = [0u8; 65];
         uncompressed[0] = 0x04;
         uncompressed[1..].copy_from_slice(&bytes);
-        let encoded = k256::EncodedPoint::from_bytes(uncompressed.as_ref())
+        let encoded = k256::Sec1Point::from_bytes(uncompressed.as_ref())
             .expect("invalid secp256k1 SEC1 encoding");
-        let point = k256::AffinePoint::from_encoded_point(&encoded);
+        let point = k256::AffinePoint::from_sec1_point(&encoded);
         assert!(bool::from(point.is_some()), "invalid secp256k1 curve point");
 
         Self::Secp256k1(bytes)
@@ -162,13 +163,13 @@ impl PublicKey {
     ///
     /// Panics if the bytes do not represent a valid point on the secp256k1 curve.
     pub fn secp256k1_from_compressed(bytes: [u8; 33]) -> Self {
-        let encoded = k256::EncodedPoint::from_bytes(bytes.as_ref())
-            .expect("invalid secp256k1 SEC1 encoding");
-        let point = k256::AffinePoint::from_encoded_point(&encoded);
+        let encoded =
+            k256::Sec1Point::from_bytes(bytes.as_ref()).expect("invalid secp256k1 SEC1 encoding");
+        let point = k256::AffinePoint::from_sec1_point(&encoded);
         let point: k256::AffinePoint = Option::from(point).expect("invalid secp256k1 curve point");
 
         // Re-encode as uncompressed (65 bytes with 0x04 prefix)
-        let uncompressed = point.to_encoded_point(false);
+        let uncompressed = point.to_sec1_point(false);
         let uncompressed_bytes: &[u8] = uncompressed.as_bytes();
         assert_eq!(uncompressed_bytes.len(), 65);
         assert_eq!(uncompressed_bytes[0], 0x04);
@@ -189,9 +190,9 @@ impl PublicKey {
     ///
     /// Panics if the bytes do not represent a valid point on the secp256k1 curve.
     pub fn secp256k1_from_uncompressed(bytes: [u8; 65]) -> Self {
-        let encoded = k256::EncodedPoint::from_bytes(bytes.as_ref())
-            .expect("invalid secp256k1 SEC1 encoding");
-        let point = k256::AffinePoint::from_encoded_point(&encoded);
+        let encoded =
+            k256::Sec1Point::from_bytes(bytes.as_ref()).expect("invalid secp256k1 SEC1 encoding");
+        let point = k256::AffinePoint::from_sec1_point(&encoded);
         assert!(bool::from(point.is_some()), "invalid secp256k1 curve point");
 
         // Store without the 0x04 prefix (64 bytes)
@@ -335,9 +336,9 @@ impl FromStr for PublicKey {
                 let mut uncompressed = [0u8; 65];
                 uncompressed[0] = 0x04;
                 uncompressed[1..].copy_from_slice(&data);
-                let encoded = k256::EncodedPoint::from_bytes(uncompressed)
+                let encoded = k256::Sec1Point::from_bytes(uncompressed)
                     .map_err(|_| ParseKeyError::InvalidCurvePoint)?;
-                let point = k256::AffinePoint::from_encoded_point(&encoded);
+                let point = k256::AffinePoint::from_sec1_point(&encoded);
                 if point.is_none().into() {
                     return Err(ParseKeyError::InvalidCurvePoint);
                 }
@@ -444,13 +445,13 @@ impl BorshDeserialize for PublicKey {
                 let mut uncompressed = [0u8; 65];
                 uncompressed[0] = 0x04;
                 uncompressed[1..].copy_from_slice(&bytes);
-                let encoded = k256::EncodedPoint::from_bytes(uncompressed).map_err(|_| {
+                let encoded = k256::Sec1Point::from_bytes(uncompressed).map_err(|_| {
                     std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
                         "invalid secp256k1 encoding",
                     )
                 })?;
-                let point = k256::AffinePoint::from_encoded_point(&encoded);
+                let point = k256::AffinePoint::from_sec1_point(&encoded);
                 if point.is_none().into() {
                     return Err(std::io::Error::new(
                         std::io::ErrorKind::InvalidData,
@@ -511,17 +512,7 @@ pub enum SecretKey {
 impl SecretKey {
     /// Generate a new random Ed25519 key pair.
     pub fn generate_ed25519() -> Self {
-        use rand::RngCore;
-        // NOTE: not `SigningKey::generate` — that is generic over
-        // `rand_core` 0.10's `CryptoRng`, which `rand` 0.8's `OsRng` (on
-        // `rand_core` 0.6) does not implement, and `rand` cannot be bumped past
-        // 0.8 while `k256` 0.13 still wants `rand_core` 0.6 below. Every
-        // 32-byte string is a valid Ed25519 seed, and `generate` does exactly
-        // this internally (fill 32 bytes, `SigningKey::from_bytes`), so drawing
-        // the seed straight from the OS CSPRNG is equivalent.
-        let mut seed = [0u8; 32];
-        OsRng.fill_bytes(&mut seed);
-        Self::Ed25519(seed)
+        Self::Ed25519(SigningKey::generate(&mut os_csprng()).to_bytes())
     }
 
     /// Create an Ed25519 secret key from raw 32 bytes.
@@ -531,7 +522,7 @@ impl SecretKey {
 
     /// Generate a new random Secp256k1 key pair.
     pub fn generate_secp256k1() -> Self {
-        let secret_key = k256::SecretKey::random(&mut OsRng);
+        let secret_key = k256::SecretKey::generate_from_rng(&mut os_csprng());
         let mut bytes = [0u8; 32];
         bytes.copy_from_slice(&secret_key.to_bytes());
         Self::Secp256k1(bytes)
@@ -548,9 +539,8 @@ impl SecretKey {
 
     /// Generate a new random ML-DSA-65 key pair (FIPS 204).
     pub fn generate_ml_dsa65() -> Self {
-        use rand::RngCore;
         let mut seed = Box::new([0u8; ML_DSA_65_SEED_LENGTH]);
-        OsRng.fill_bytes(seed.as_mut_slice());
+        fill_random(seed.as_mut_slice());
         Self::MlDsa65(MlDsa65SecretKey::Seed(seed))
     }
 
@@ -638,7 +628,7 @@ impl SecretKey {
                     k256::SecretKey::from_bytes(bytes.into()).expect("invalid secp256k1 key");
                 let public_key = secret_key.public_key();
                 // Get uncompressed encoding (65 bytes with 0x04 prefix)
-                let uncompressed = public_key.to_encoded_point(false);
+                let uncompressed = public_key.to_sec1_point(false);
                 let uncompressed_bytes: &[u8] = uncompressed.as_bytes();
                 assert_eq!(uncompressed_bytes.len(), 65);
                 // Store without the 0x04 prefix (64 bytes)
@@ -670,9 +660,7 @@ impl SecretKey {
 
                 // NEAR protocol: hash message with SHA-256 before signing
                 let hash = sha2::Sha256::digest(message);
-                let (signature, recovery_id) = signing_key
-                    .sign_prehash_recoverable(&hash)
-                    .expect("secp256k1 signing failed");
+                let (signature, recovery_id) = signing_key.sign_prehash_recoverable(&hash);
 
                 // NEAR format: [r (32) | s (32) | v (1)]
                 let mut sig_bytes = [0u8; 65];
@@ -1107,8 +1095,7 @@ impl Signature {
                     return false;
                 }
 
-                let Ok(signature) = k256::ecdsa::Signature::from_bytes((&sig_bytes[..64]).into())
-                else {
+                let Ok(signature) = k256::ecdsa::Signature::from_slice(&sig_bytes[..64]) else {
                     return false;
                 };
 
@@ -1290,8 +1277,6 @@ fn mnemonic_to_seed(
 /// assert_eq!(phrase.split_whitespace().count(), 12);
 /// ```
 pub fn generate_seed_phrase(word_count: usize) -> Result<String, SignerError> {
-    use rand::RngCore;
-
     // Word count to entropy bytes: 12->16, 15->20, 18->24, 21->28, 24->32
     let entropy_bytes = match word_count {
         12 => 16,
@@ -1308,7 +1293,7 @@ pub fn generate_seed_phrase(word_count: usize) -> Result<String, SignerError> {
     };
 
     let mut entropy = vec![0u8; entropy_bytes];
-    OsRng.fill_bytes(&mut entropy);
+    fill_random(&mut entropy);
 
     let mnemonic = Mnemonic::from_entropy(&entropy).map_err(|e| {
         SignerError::KeyDerivationFailed(format!("Failed to generate mnemonic: {}", e))
@@ -1926,9 +1911,9 @@ mod tests {
         uncompressed[0] = 0x04;
         uncompressed[1..].copy_from_slice(pk_bytes);
         let encoded =
-            k256::EncodedPoint::from_bytes(uncompressed.as_ref()).expect("valid encoded point");
-        let point = k256::AffinePoint::from_encoded_point(&encoded).expect("valid point on curve");
-        let compressed = point.to_encoded_point(true);
+            k256::Sec1Point::from_bytes(uncompressed.as_ref()).expect("valid encoded point");
+        let point = k256::AffinePoint::from_sec1_point(&encoded).expect("valid point on curve");
+        let compressed = point.to_sec1_point(true);
         let compressed_bytes: [u8; 33] = compressed
             .as_bytes()
             .try_into()

--- a/crates/near-kit/src/types/mod.rs
+++ b/crates/near-kit/src/types/mod.rs
@@ -47,6 +47,7 @@
 mod account;
 mod action;
 mod block_reference;
+mod csprng;
 mod error;
 mod hash;
 mod hd;

--- a/crates/near-kit/src/types/nep413.rs
+++ b/crates/near-kit/src/types/nep413.rs
@@ -354,7 +354,7 @@ pub fn generate_nonce() -> [u8; 32] {
     nonce[..8].copy_from_slice(&timestamp.to_be_bytes());
 
     // Remaining 24 bytes: random data
-    rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut nonce[8..]);
+    super::csprng::fill_random(&mut nonce[8..]);
 
     nonce
 }


### PR DESCRIPTION
## Why

#241 bumped `ed25519-dalek` 2→3. Dalek 3 sits on `rand_core` 0.10, but the workspace pinned `rand = "0.8"` (`rand_core` 0.6), so `SigningKey::generate` was unusable and `generate_ed25519` had to hand-fill a seed as a stopgap.

The thing pinning `rand` was **`k256` 0.13**, which reaches `rand_core` 0.6 via `ecdsa` 0.16 → `elliptic-curve` 0.13 → `crypto-bigint` 0.5 / `ff` / `group`. Bumping the two together untangles it.

## Dep tree

k256 0.14 brings `elliptic-curve` 0.14 / `ecdsa` 0.17 / `signature` 3 — which `ed25519-dalek` 3 and `ml-dsa` 0.1 already use — so the crypto graph collapses to one version of each:

| | before | after |
|---|---|---|
| `rand_core` (crypto path) | 0.6.4 + 0.10.1 | **0.10.1** |
| `getrandom` (wasm32-unknown-unknown) | 0.2 + 0.4 | **0.4** |

`rand_core` 0.6 is gone from the graph entirely. Natively `cargo tree` still shows getrandom 0.2/0.3 behind the `rpc` and `sandbox` features (via `ring`/`rustls` and `testcontainers`), but neither builds for `wasm32-unknown-unknown`, so neither is part of the entropy story. Verified: for `--target wasm32-unknown-unknown --no-default-features [--features js]` the tree resolves to exactly one `getrandom` (0.4.2) and one `rand_core` (0.10.1).

## The delicate part: fallible OsRng

In `rand_core` 0.9+ the OS source was renamed **and** made fallible — it's now `rngs::SysRng` and implements only `TryRng`/`TryCryptoRng`, not the infallible `Rng`/`CryptoRng` that `SigningKey::generate` and k256's `generate_from_rng` require. `OsRng.fill_bytes(..)` simply doesn't exist anymore.

All six call sites now go through a new `types::csprng` module wrapping it in `rand_core::UnwrapErr`, which **panics** on entropy failure (`panic!("rand_core::UnwrapErr: failed to unwrap: {err}")`) and preserves the `TryCryptoRng` marker so the generic keygen bounds still accept it. That is the same behaviour as rand 0.8's `OsRng` and dalek's `generate` had: the failure is never swallowed and never falls back to a weaker source, and these `pub fn`s stay infallible rather than having their signatures broken.

Call sites: ed25519 keygen, secp256k1 keygen, ML-DSA-65 seed, BIP-39 entropy, NEP-413 nonce.

## k256 0.14 API renames

`EncodedPoint`→`Sec1Point`, `From/ToEncodedPoint`→`From/ToSec1Point`, `to_encoded_point`→`to_sec1_point`, `SecretKey::random`→`generate_from_rng` (via `elliptic_curve::Generate`), `Signature::from_bytes`→`from_slice`, and `sign_prehash_recoverable` no longer returns a `Result`.

## Breaking for wasm embedders

near-kit's **public API is unchanged**, but setup instructions for non-JS `wasm32-unknown-unknown` embedders do change: they previously had to register a backend for *both* getrandom majors (0.2 via `register_custom_getrandom!` behind its `custom` feature, plus 0.4 via `__getrandom_v03_custom`). Now only the 0.4 backend is needed, and the direct `getrandom = "0.2"` dependency should be removed. There's a migration callout in the crate docs.

Also collapses the `getrandom_v04` package-alias hack: `js = ["getrandom/js", "getrandom_v04/wasm_js"]` → `js = ["getrandom/wasm_js"]`.

## Verification

Run locally, all passing:

- `cargo build --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy -p near-kit --all-targets --no-default-features --features sandbox -- -D warnings`
- `cargo check -p near-kit --all-targets --no-default-features`
- `cargo fmt --all --check`
- `cargo test --workspace` — 516 passed, 0 failed (116 crypto-specific: ed25519/secp256k1/ML-DSA/seed-phrase/NEP-413), plus 140 doctests
- `cargo +1.88 check --workspace --all-targets` (MSRV — all new deps need 1.85, under the repo's 1.88)
- `cargo check --target wasm32-unknown-unknown -p near-kit --no-default-features --features js,rpc`
- `cargo check --target wasm32-wasip2 -p near-kit --no-default-features` (also `--features rpc`, `--features wasi-http`)

Sandbox integration tests requiring a live `near-sandbox` container were not run locally; CI covers what it covers.