### PR TITLE
fix!: distinguish view function RPC errors

### DIFF
--- a/crates/near-kit/CHANGELOG.md
+++ b/crates/near-kit/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - distinguish missing accounts, undeployed contracts, missing methods, and
   contract panics returned by view function calls
 
+### Removed
+
+- [**breaking**] remove the unused `RpcError::FunctionCall` variant and
+  `RpcError::function_call` constructor
+
 ## [0.14.0](https://github.com/r-near/near-kit-rs/compare/near-kit-v0.13.0...near-kit-v0.14.0) - 2026-07-24
 
 ### Added

--- a/crates/near-kit/CHANGELOG.md
+++ b/crates/near-kit/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- distinguish missing accounts, undeployed contracts, missing methods, and
+  contract panics returned by view function calls
+
 ## [0.14.0](https://github.com/r-near/near-kit-rs/compare/near-kit-v0.13.0...near-kit-v0.14.0) - 2026-07-24
 
 ### Added

--- a/crates/near-kit/CHANGELOG.md
+++ b/crates/near-kit/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [**breaking**] preserve block height and hash metadata on applicable view RPC
+  error variants when returned by the node
+
 ### Fixed
 
 - distinguish missing accounts, undeployed contracts, missing methods, and

--- a/crates/near-kit/src/client/query.rs
+++ b/crates/near-kit/src/client/query.rs
@@ -225,7 +225,7 @@ impl IntoFuture for AccountExistsQuery {
                 .await
             {
                 Ok(_) => Ok(true),
-                Err(crate::error::RpcError::AccountNotFound(_)) => Ok(false),
+                Err(crate::error::RpcError::AccountNotFound { .. }) => Ok(false),
                 Err(e) => Err(e.into()),
             }
         })
@@ -662,8 +662,8 @@ impl ContractCodeQuery {
     pub async fn exists(self) -> Result<bool, Error> {
         match self.rpc.view_code(&self.account_id, self.block_ref).await {
             Ok(_) => Ok(true),
-            Err(crate::error::RpcError::ContractNotDeployed(_))
-            | Err(crate::error::RpcError::AccountNotFound(_)) => Ok(false),
+            Err(crate::error::RpcError::ContractNotDeployed { .. })
+            | Err(crate::error::RpcError::AccountNotFound { .. }) => Ok(false),
             Err(e) => Err(e.into()),
         }
     }
@@ -762,7 +762,7 @@ impl GlobalContractQuery {
             // by identifier, not account), but a nonexistent publisher has
             // published nothing — treat it the same as not-found.
             Err(crate::error::RpcError::GlobalContractNotFound(_))
-            | Err(crate::error::RpcError::AccountNotFound(_)) => Ok(false),
+            | Err(crate::error::RpcError::AccountNotFound { .. }) => Ok(false),
             Err(e) => Err(e.into()),
         }
     }

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -2369,6 +2369,93 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_rpc_error_contract_panic_real_testnet_payload() {
+        // Verbatim testnet `EXPERIMENTAL_call_function` response for a near-sdk
+        // contract that panicked while deserializing its arguments.
+        let client = RpcClient::new("https://example.com");
+        let panic_msg = "panicked at 'Failed to deserialize input from JSON.: Error(\"missing field `keys`\", line: 1, column: 2)', contract/src/api.rs:54:1";
+        let error = JsonRpcError {
+            code: -32000,
+            message: "Server error".to_string(),
+            data: Some(serde_json::json!(format!(
+                "Function call returned an error: ExecutionError({:?})",
+                format!("Smart contract panicked: {panic_msg}")
+            ))),
+            cause: Some(ErrorCause {
+                name: "CONTRACT_EXECUTION_ERROR".to_string(),
+                info: Some(serde_json::json!({
+                    "vm_error": {
+                        "ExecutionError": format!("Smart contract panicked: {panic_msg}"),
+                    },
+                    "block_height": 263803636u64,
+                    "block_hash": "B7UiEhkg1AeXvUoJUEaf8cqEc8Py7XhZ66vt7jJJUHw5",
+                })),
+            }),
+            name: Some("HANDLER_ERROR".to_string()),
+        };
+
+        match client.parse_rpc_error(&error) {
+            RpcError::ContractPanic {
+                message,
+                block_height,
+                block_hash,
+            } => {
+                assert_eq!(message, panic_msg);
+                assert_eq!(block_height, Some(263_803_636));
+                assert_eq!(
+                    block_hash,
+                    Some(
+                        "B7UiEhkg1AeXvUoJUEaf8cqEc8Py7XhZ66vt7jJJUHw5"
+                            .parse()
+                            .unwrap()
+                    )
+                );
+            }
+            other => panic!("Expected ContractPanic error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_extract_contract_panic_message_preserves_source_casing() {
+        // The text after the prefix belongs to the contract author, so it is
+        // passed through byte for byte rather than re-cased.
+        assert_eq!(
+            extract_contract_panic_message("Smart contract panicked: Insufficient balance"),
+            Some("Insufficient balance".to_string())
+        );
+        assert_eq!(
+            extract_contract_panic_message("Smart contract panicked: ERR_NOT_ENOUGH_DEPOSIT"),
+            Some("ERR_NOT_ENOUGH_DEPOSIT".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_contract_panic_message_ignores_non_panic_errors() {
+        assert_eq!(
+            extract_contract_panic_message("memory access violation"),
+            None
+        );
+        assert_eq!(extract_contract_panic_message("Smart contract"), None);
+        assert_eq!(
+            extract_contract_panic_message("Smart contract panicked unexpectedly"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_contract_panic_message_keeps_prefix_without_a_message() {
+        // Stripping would leave nothing to show, so the raw string is kept.
+        assert_eq!(
+            extract_contract_panic_message("Smart contract panicked"),
+            Some("Smart contract panicked".to_string())
+        );
+        assert_eq!(
+            extract_contract_panic_message("Smart contract panicked:   "),
+            Some("Smart contract panicked:   ".to_string())
+        );
+    }
+
+    #[test]
     fn test_parse_rpc_error_non_panic_execution_error_stays_generic() {
         let client = RpcClient::new("https://example.com");
         let error = JsonRpcError {

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -20,10 +20,11 @@ use crate::trace;
 use crate::types::rpc::RawTransactionResponse;
 use crate::types::{
     AccessKeyListView, AccessKeyView, AccountId, AccountView, BlockEffects, BlockReference,
-    BlockView, ContractCodeView, CryptoHash, EpochValidatorInfo, GasKeyNoncesView, GasPrice,
-    GlobalContractId, GlobalContractIdentifierView, MaintenanceWindow, PublicKey,
-    ReceiptToTxResponse, SignedTransaction, StateItem, StatusResponse, TxExecutionStatus,
-    ViewFunctionResult, ViewStateResult,
+    BlockView, CompilationError, ContractCodeView, CryptoHash, EpochValidatorInfo,
+    FunctionCallError, GasKeyNoncesView, GasPrice, GlobalContractId, GlobalContractIdentifierView,
+    HostError, MaintenanceWindow, MethodResolveError, PublicKey, ReceiptToTxResponse,
+    SignedTransaction, StateItem, StatusResponse, TxExecutionStatus, ViewFunctionResult,
+    ViewStateResult,
 };
 
 /// Platform-appropriate async sleep, used for retry backoff.
@@ -139,6 +140,80 @@ struct ErrorCause {
     name: String,
     #[serde(default)]
     info: Option<serde_json::Value>,
+}
+
+/// Extract nearcore's structured `FunctionCallError` from a handler error.
+///
+/// Current nodes use `info.vm_error`; the initial structured endpoint shape
+/// used `info.error`. Accept both so providers on either nearcore generation
+/// get the same typed classification.
+fn parse_function_call_error(info: Option<&serde_json::Value>) -> Option<FunctionCallError> {
+    let info = info?;
+
+    ["vm_error", "error"].into_iter().find_map(|key| {
+        let value = info.get(key)?;
+        // The legacy `query` endpoint also has a `vm_error` string. It is not
+        // structured and should not mask a structured `error` sibling.
+        if !value.is_object() {
+            return None;
+        }
+        let value = value.get("FunctionCallError").unwrap_or(value);
+        match serde_json::from_value(value.clone()).ok()? {
+            FunctionCallError::Unknown(_) => None,
+            error => Some(error),
+        }
+    })
+}
+
+/// Map the function-call cases callers need to branch on independently.
+fn classify_function_call_error(
+    error: &FunctionCallError,
+    contract_id: &AccountId,
+    method_name: Option<&str>,
+) -> Option<RpcError> {
+    match error {
+        FunctionCallError::CompilationError(CompilationError::CodeDoesNotExist { account_id }) => {
+            Some(RpcError::ContractNotDeployed(account_id.clone()))
+        }
+        FunctionCallError::MethodResolveError(MethodResolveError::MethodNotFound) => {
+            Some(RpcError::MethodNotFound {
+                contract_id: contract_id.clone(),
+                method_name: method_name.unwrap_or("unknown").to_string(),
+            })
+        }
+        FunctionCallError::HostError(HostError::GuestPanic { panic_msg }) => {
+            Some(RpcError::ContractPanic {
+                message: panic_msg.clone(),
+            })
+        }
+        FunctionCallError::ExecutionError(message) => extract_contract_panic_message(message)
+            .map(|message| RpcError::ContractPanic { message }),
+        _ => None,
+    }
+}
+
+/// nearcore collapses current execution failures to strings, but retains a
+/// stable prefix for explicit guest panics.
+fn extract_contract_panic_message(message: &str) -> Option<String> {
+    const PREFIX: &str = "Smart contract panicked";
+
+    let candidate_prefix = message.get(..PREFIX.len())?;
+    if !candidate_prefix.eq_ignore_ascii_case(PREFIX) {
+        return None;
+    }
+
+    match &message[PREFIX.len()..] {
+        "" => Some(message.to_string()),
+        rest if rest.starts_with(':') => {
+            let panic_message = rest[1..].trim_start();
+            Some(if panic_message.is_empty() {
+                message.to_string()
+            } else {
+                panic_message.to_string()
+            })
+        }
+        _ => None,
+    }
 }
 
 /// Response from EXPERIMENTAL_call_function.
@@ -449,47 +524,42 @@ impl RpcClient {
                     }
                 }
                 "CONTRACT_EXECUTION_ERROR" => {
-                    // Check for CodeDoesNotExist inside vm_error
-                    // (EXPERIMENTAL_call_function wraps this as CONTRACT_EXECUTION_ERROR)
-                    if let Some(vm_error) = info.and_then(|i| i.get("vm_error"))
-                        && let Some(compilation_err) = vm_error.get("CompilationError")
-                        && let Some(code_not_exist) = compilation_err.get("CodeDoesNotExist")
-                        && let Some(account_id) = code_not_exist
-                            .get("account_id")
-                            .and_then(|a| a.as_str())
-                            .and_then(|a| a.parse().ok())
-                    {
-                        return RpcError::ContractNotDeployed(account_id);
-                    }
-
                     // Legacy `query` includes contract_id/method_name;
                     // EXPERIMENTAL_call_function does not (the caller
                     // already knows them). Fall back to "unknown".
                     let contract_id = info
                         .and_then(|i| i.get("contract_id"))
                         .and_then(|c| c.as_str())
-                        .unwrap_or("unknown");
+                        .unwrap_or("unknown")
+                        .parse()
+                        .unwrap_or_else(|_| "unknown".parse().unwrap());
                     let method_name = info
                         .and_then(|i| i.get("method_name"))
                         .and_then(|m| m.as_str())
                         .map(String::from);
+                    let function_call_error = parse_function_call_error(info);
+                    if let Some(specific_error) = function_call_error.as_ref().and_then(|error| {
+                        classify_function_call_error(error, &contract_id, method_name.as_deref())
+                    }) {
+                        return specific_error;
+                    }
+
                     let message = data
                         .as_ref()
                         .and_then(|d| d.as_str())
                         .map(|s| s.to_string())
+                        .or_else(|| function_call_error.as_ref().map(ToString::to_string))
                         .or_else(|| {
                             // EXPERIMENTAL endpoint: use vm_error as fallback
                             // when data isn't a string
                             info.and_then(|i| i.get("vm_error")).map(|v| v.to_string())
                         })
                         .unwrap_or_else(|| error.message.clone());
-                    if let Ok(contract_id) = contract_id.parse() {
-                        return RpcError::ContractExecution {
-                            contract_id,
-                            method_name,
-                            message,
-                        };
-                    }
+                    return RpcError::ContractExecution {
+                        contract_id,
+                        method_name,
+                        message,
+                    };
                 }
                 "UNAVAILABLE_SHARD" => {
                     return RpcError::ShardUnavailable(error.message.clone());
@@ -656,6 +726,10 @@ impl RpcClient {
                     contract_id: account_id.clone(),
                     method_name: Some(method_name.to_string()),
                     message,
+                },
+                RpcError::MethodNotFound { .. } => RpcError::MethodNotFound {
+                    contract_id: account_id.clone(),
+                    method_name: method_name.to_string(),
                 },
                 other => other,
             })?;
@@ -1137,11 +1211,55 @@ fn preserve_http_retry_classification(err: RpcError, status: u16, body: &str) ->
 mod tests {
     use std::io::{Read, Write};
     use std::net::TcpListener;
-    use std::sync::mpsc;
+    use std::sync::{Arc, mpsc};
 
     use reqwest::header::{HeaderMap, HeaderValue};
 
     use super::*;
+    use crate::client::{BoxFuture, TransportResponse};
+
+    struct StaticResponseTransport {
+        body: Vec<u8>,
+    }
+
+    impl RpcTransport for StaticResponseTransport {
+        fn post_json(
+            &self,
+            _url: &str,
+            _body: Vec<u8>,
+        ) -> BoxFuture<'_, Result<TransportResponse, RpcError>> {
+            let body = self.body.clone();
+            Box::pin(async move { Ok(TransportResponse { status: 200, body }) })
+        }
+    }
+
+    fn rpc_with_handler_error(cause_name: &str, info: serde_json::Value) -> RpcClient {
+        let body = serde_json::to_vec(&serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 0,
+            "error": {
+                "name": "HANDLER_ERROR",
+                "cause": {
+                    "name": cause_name,
+                    "info": info,
+                },
+                "code": -32000,
+                "message": "Server error",
+                "data": "view function failed",
+            },
+        }))
+        .unwrap();
+
+        RpcClient::with_transport_and_retry_config(
+            "https://example.com",
+            Arc::new(StaticResponseTransport { body }),
+            RetryConfig {
+                max_retries: 0,
+                ..RetryConfig::default()
+            },
+        )
+    }
+
     // ========================================================================
     // RetryConfig tests
     // ========================================================================
@@ -1209,6 +1327,93 @@ mod tests {
         let debug = format!("{:?}", client);
         assert!(debug.contains("RpcClient"));
         assert!(debug.contains("rpc.testnet.near.org"));
+    }
+
+    #[tokio::test]
+    async fn test_view_function_distinguishes_contract_errors() {
+        let missing_account: AccountId = "missing.near".parse().unwrap();
+        let error = rpc_with_handler_error(
+            "UNKNOWN_ACCOUNT",
+            serde_json::json!({ "requested_account_id": missing_account }),
+        )
+        .view_function(
+            &missing_account,
+            "nep413_get_message",
+            &[],
+            BlockReference::final_(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            RpcError::AccountNotFound(account_id) if account_id == missing_account
+        ));
+
+        let account_without_code: AccountId = "no-code.near".parse().unwrap();
+        let error = rpc_with_handler_error(
+            "CONTRACT_EXECUTION_ERROR",
+            serde_json::json!({
+                "vm_error": {
+                    "CompilationError": {
+                        "CodeDoesNotExist": {
+                            "account_id": account_without_code,
+                        },
+                    },
+                },
+            }),
+        )
+        .view_function(
+            &account_without_code,
+            "nep413_get_message",
+            &[],
+            BlockReference::final_(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            RpcError::ContractNotDeployed(account_id) if account_id == account_without_code
+        ));
+
+        let contract_id: AccountId = "contract.near".parse().unwrap();
+        let missing_method = "nep413_get_message";
+        let error = rpc_with_handler_error(
+            "CONTRACT_EXECUTION_ERROR",
+            serde_json::json!({
+                "vm_error": {
+                    "MethodResolveError": "MethodNotFound",
+                },
+            }),
+        )
+        .view_function(&contract_id, missing_method, &[], BlockReference::final_())
+        .await
+        .unwrap_err();
+        match error {
+            RpcError::MethodNotFound {
+                contract_id: actual_contract_id,
+                method_name,
+            } => {
+                assert_eq!(actual_contract_id, contract_id);
+                assert_eq!(method_name, missing_method);
+            }
+            other => panic!("expected MethodNotFound, got {other:?}"),
+        }
+
+        let error = rpc_with_handler_error(
+            "CONTRACT_EXECUTION_ERROR",
+            serde_json::json!({
+                "vm_error": {
+                    "ExecutionError": "Smart contract panicked: invalid payload",
+                },
+            }),
+        )
+        .view_function(&contract_id, "verify_nep413", &[], BlockReference::final_())
+        .await
+        .unwrap_err();
+        match error {
+            RpcError::ContractPanic { message } => assert_eq!(message, "invalid payload"),
+            other => panic!("expected ContractPanic, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -1945,7 +2150,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_rpc_error_contract_execution_experimental() {
+    fn test_parse_rpc_error_method_not_found_current_shape() {
         // EXPERIMENTAL_call_function omits contract_id/method_name from info,
         // but includes vm_error and a data string
         let client = RpcClient::new("https://example.com");
@@ -1967,16 +2172,117 @@ mod tests {
         };
         let result = client.parse_rpc_error(&error);
         match result {
-            RpcError::ContractExecution {
+            RpcError::MethodNotFound {
                 contract_id,
-                message,
-                ..
+                method_name,
             } => {
-                // contract_id falls back to "unknown" — caller enriches it
+                // The high-level view_function caller enriches both fields.
                 assert_eq!(contract_id.as_str(), "unknown");
-                assert!(message.contains("MethodResolveError"));
+                assert_eq!(method_name, "unknown");
             }
-            _ => panic!("Expected ContractExecution error, got {:?}", result),
+            _ => panic!("Expected MethodNotFound error, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_parse_rpc_error_method_not_found_legacy_error_field() {
+        let client = RpcClient::new("https://example.com");
+        let error = JsonRpcError {
+            code: -32000,
+            message: "Server error".to_string(),
+            data: None,
+            cause: Some(ErrorCause {
+                name: "CONTRACT_EXECUTION_ERROR".to_string(),
+                info: Some(serde_json::json!({
+                    // The endpoint's initial structured shape called this
+                    // field `error`; current nearcore calls it `vm_error`.
+                    "error": { "MethodResolveError": "MethodNotFound" },
+                })),
+            }),
+            name: Some("HANDLER_ERROR".to_string()),
+        };
+
+        assert!(matches!(
+            client.parse_rpc_error(&error),
+            RpcError::MethodNotFound { .. }
+        ));
+    }
+
+    #[test]
+    fn test_parse_rpc_error_contract_panic_current_shape() {
+        let client = RpcClient::new("https://example.com");
+        let error = JsonRpcError {
+            code: -32000,
+            message: "Server error".to_string(),
+            data: None,
+            cause: Some(ErrorCause {
+                name: "CONTRACT_EXECUTION_ERROR".to_string(),
+                info: Some(serde_json::json!({
+                    "vm_error": {
+                        "ExecutionError": "Smart contract panicked: invalid signature"
+                    },
+                })),
+            }),
+            name: Some("HANDLER_ERROR".to_string()),
+        };
+
+        match client.parse_rpc_error(&error) {
+            RpcError::ContractPanic { message } => assert_eq!(message, "invalid signature"),
+            other => panic!("Expected ContractPanic error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_rpc_error_non_panic_execution_error_stays_generic() {
+        let client = RpcClient::new("https://example.com");
+        let error = JsonRpcError {
+            code: -32000,
+            message: "Server error".to_string(),
+            data: None,
+            cause: Some(ErrorCause {
+                name: "CONTRACT_EXECUTION_ERROR".to_string(),
+                info: Some(serde_json::json!({
+                    "vm_error": {
+                        "ExecutionError": "memory access violation"
+                    },
+                })),
+            }),
+            name: Some("HANDLER_ERROR".to_string()),
+        };
+
+        match client.parse_rpc_error(&error) {
+            RpcError::ContractExecution { message, .. } => {
+                assert!(message.contains("memory access violation"));
+            }
+            other => panic!("Expected ContractExecution error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_rpc_error_contract_panic_legacy_guest_panic_shape() {
+        let client = RpcClient::new("https://example.com");
+        let error = JsonRpcError {
+            code: -32000,
+            message: "Server error".to_string(),
+            data: None,
+            cause: Some(ErrorCause {
+                name: "CONTRACT_EXECUTION_ERROR".to_string(),
+                info: Some(serde_json::json!({
+                    "error": {
+                        "HostError": {
+                            "GuestPanic": {
+                                "panic_msg": "legacy panic"
+                            }
+                        }
+                    },
+                })),
+            }),
+            name: Some("HANDLER_ERROR".to_string()),
+        };
+
+        match client.parse_rpc_error(&error) {
+            RpcError::ContractPanic { message } => assert_eq!(message, "legacy panic"),
+            other => panic!("Expected ContractPanic error, got {other:?}"),
         }
     }
 

--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -142,6 +142,20 @@ struct ErrorCause {
     info: Option<serde_json::Value>,
 }
 
+/// Extract the block context included in view RPC error payloads.
+fn parse_error_block_context(
+    info: Option<&serde_json::Value>,
+) -> (Option<u64>, Option<CryptoHash>) {
+    let block_height = info
+        .and_then(|value| value.get("block_height"))
+        .and_then(serde_json::Value::as_u64);
+    let block_hash = info
+        .and_then(|value| value.get("block_hash"))
+        .and_then(serde_json::Value::as_str)
+        .and_then(|value| value.parse().ok());
+    (block_height, block_hash)
+}
+
 /// Extract nearcore's structured `FunctionCallError` from a handler error.
 ///
 /// Current nodes use `info.vm_error`; the initial structured endpoint shape
@@ -170,24 +184,39 @@ fn classify_function_call_error(
     error: &FunctionCallError,
     contract_id: &AccountId,
     method_name: Option<&str>,
+    block_height: Option<u64>,
+    block_hash: Option<CryptoHash>,
 ) -> Option<RpcError> {
     match error {
         FunctionCallError::CompilationError(CompilationError::CodeDoesNotExist { account_id }) => {
-            Some(RpcError::ContractNotDeployed(account_id.clone()))
+            Some(RpcError::ContractNotDeployed {
+                account_id: account_id.clone(),
+                block_height,
+                block_hash,
+            })
         }
         FunctionCallError::MethodResolveError(MethodResolveError::MethodNotFound) => {
             Some(RpcError::MethodNotFound {
                 contract_id: contract_id.clone(),
                 method_name: method_name.unwrap_or("unknown").to_string(),
+                block_height,
+                block_hash,
             })
         }
         FunctionCallError::HostError(HostError::GuestPanic { panic_msg }) => {
             Some(RpcError::ContractPanic {
                 message: panic_msg.clone(),
+                block_height,
+                block_hash,
             })
         }
-        FunctionCallError::ExecutionError(message) => extract_contract_panic_message(message)
-            .map(|message| RpcError::ContractPanic { message }),
+        FunctionCallError::ExecutionError(message) => {
+            extract_contract_panic_message(message).map(|message| RpcError::ContractPanic {
+                message,
+                block_height,
+                block_hash,
+            })
+        }
         _ => None,
     }
 }
@@ -420,6 +449,7 @@ impl RpcClient {
             let cause_name = cause.name.as_str();
             let info = cause.info.as_ref();
             let data = &error.data;
+            let (block_height, block_hash) = parse_error_block_context(info);
 
             match cause_name {
                 "UNKNOWN_ACCOUNT" => {
@@ -428,7 +458,11 @@ impl RpcClient {
                         .and_then(|a| a.as_str())
                         && let Ok(account_id) = account_id.parse()
                     {
-                        return RpcError::AccountNotFound(account_id);
+                        return RpcError::AccountNotFound {
+                            account_id,
+                            block_height,
+                            block_hash,
+                        };
                     }
                 }
                 "INVALID_ACCOUNT" => {
@@ -496,7 +530,11 @@ impl RpcClient {
                         .and_then(|a| a.as_str())
                         .unwrap_or("unknown");
                     if let Ok(account_id) = account_id.parse() {
-                        return RpcError::ContractNotDeployed(account_id);
+                        return RpcError::ContractNotDeployed {
+                            account_id,
+                            block_height,
+                            block_hash,
+                        };
                     }
                 }
                 "NO_GLOBAL_CONTRACT_CODE" => {
@@ -539,7 +577,13 @@ impl RpcClient {
                         .map(String::from);
                     let function_call_error = parse_function_call_error(info);
                     if let Some(specific_error) = function_call_error.as_ref().and_then(|error| {
-                        classify_function_call_error(error, &contract_id, method_name.as_deref())
+                        classify_function_call_error(
+                            error,
+                            &contract_id,
+                            method_name.as_deref(),
+                            block_height,
+                            block_hash,
+                        )
                     }) {
                         return specific_error;
                     }
@@ -559,6 +603,8 @@ impl RpcClient {
                         contract_id,
                         method_name,
                         message,
+                        block_height,
+                        block_hash,
                     };
                 }
                 "UNAVAILABLE_SHARD" => {
@@ -608,7 +654,11 @@ impl RpcClient {
                 && let Some(account_str) = start.split_whitespace().next()
                 && let Ok(account_id) = account_str.parse()
             {
-                return RpcError::AccountNotFound(account_id);
+                return RpcError::AccountNotFound {
+                    account_id,
+                    block_height: None,
+                    block_hash: None,
+                };
             }
         }
 
@@ -722,14 +772,27 @@ impl RpcClient {
             .call("EXPERIMENTAL_call_function", params)
             .await
             .map_err(|e| match e {
-                RpcError::ContractExecution { message, .. } => RpcError::ContractExecution {
+                RpcError::ContractExecution {
+                    message,
+                    block_height,
+                    block_hash,
+                    ..
+                } => RpcError::ContractExecution {
                     contract_id: account_id.clone(),
                     method_name: Some(method_name.to_string()),
                     message,
+                    block_height,
+                    block_hash,
                 },
-                RpcError::MethodNotFound { .. } => RpcError::MethodNotFound {
+                RpcError::MethodNotFound {
+                    block_height,
+                    block_hash,
+                    ..
+                } => RpcError::MethodNotFound {
                     contract_id: account_id.clone(),
                     method_name: method_name.to_string(),
+                    block_height,
+                    block_hash,
                 },
                 other => other,
             })?;
@@ -1331,10 +1394,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_view_function_distinguishes_contract_errors() {
+        let block_height = 243_803_767;
+        let block_hash: CryptoHash = "H33oNAtVZDJjhpncQb5LY6NxYzQLMMVLptq99mwmLmnj"
+            .parse()
+            .unwrap();
         let missing_account: AccountId = "missing.near".parse().unwrap();
         let error = rpc_with_handler_error(
             "UNKNOWN_ACCOUNT",
-            serde_json::json!({ "requested_account_id": missing_account }),
+            serde_json::json!({
+                "requested_account_id": missing_account,
+                "block_height": block_height,
+                "block_hash": block_hash,
+            }),
         )
         .view_function(
             &missing_account,
@@ -1346,7 +1417,13 @@ mod tests {
         .unwrap_err();
         assert!(matches!(
             error,
-            RpcError::AccountNotFound(account_id) if account_id == missing_account
+            RpcError::AccountNotFound {
+                account_id,
+                block_height: Some(actual_block_height),
+                block_hash: Some(actual_block_hash),
+            } if account_id == missing_account
+                && actual_block_height == block_height
+                && actual_block_hash == block_hash
         ));
 
         let account_without_code: AccountId = "no-code.near".parse().unwrap();
@@ -1360,6 +1437,8 @@ mod tests {
                         },
                     },
                 },
+                "block_height": block_height,
+                "block_hash": block_hash,
             }),
         )
         .view_function(
@@ -1372,7 +1451,13 @@ mod tests {
         .unwrap_err();
         assert!(matches!(
             error,
-            RpcError::ContractNotDeployed(account_id) if account_id == account_without_code
+            RpcError::ContractNotDeployed {
+                account_id,
+                block_height: Some(actual_block_height),
+                block_hash: Some(actual_block_hash),
+            } if account_id == account_without_code
+                && actual_block_height == block_height
+                && actual_block_hash == block_hash
         ));
 
         let contract_id: AccountId = "contract.near".parse().unwrap();
@@ -1383,6 +1468,8 @@ mod tests {
                 "vm_error": {
                     "MethodResolveError": "MethodNotFound",
                 },
+                "block_height": block_height,
+                "block_hash": block_hash,
             }),
         )
         .view_function(&contract_id, missing_method, &[], BlockReference::final_())
@@ -1392,9 +1479,13 @@ mod tests {
             RpcError::MethodNotFound {
                 contract_id: actual_contract_id,
                 method_name,
+                block_height: Some(actual_block_height),
+                block_hash: Some(actual_block_hash),
             } => {
                 assert_eq!(actual_contract_id, contract_id);
                 assert_eq!(method_name, missing_method);
+                assert_eq!(actual_block_height, block_height);
+                assert_eq!(actual_block_hash, block_hash);
             }
             other => panic!("expected MethodNotFound, got {other:?}"),
         }
@@ -1405,13 +1496,23 @@ mod tests {
                 "vm_error": {
                     "ExecutionError": "Smart contract panicked: invalid payload",
                 },
+                "block_height": block_height,
+                "block_hash": block_hash,
             }),
         )
         .view_function(&contract_id, "verify_nep413", &[], BlockReference::final_())
         .await
         .unwrap_err();
         match error {
-            RpcError::ContractPanic { message } => assert_eq!(message, "invalid payload"),
+            RpcError::ContractPanic {
+                message,
+                block_height: Some(actual_block_height),
+                block_hash: Some(actual_block_hash),
+            } => {
+                assert_eq!(message, "invalid payload");
+                assert_eq!(actual_block_height, block_height);
+                assert_eq!(actual_block_hash, block_hash);
+            }
             other => panic!("expected ContractPanic, got {other:?}"),
         }
     }
@@ -1622,13 +1723,22 @@ mod tests {
             cause: Some(ErrorCause {
                 name: "UNKNOWN_ACCOUNT".to_string(),
                 info: Some(serde_json::json!({
-                    "requested_account_id": "nonexistent.near"
+                    "requested_account_id": "nonexistent.near",
+                    "block_height": 243803761,
+                    "block_hash": "11111111111111111111111111111111"
                 })),
             }),
             name: None,
         };
         let result = client.parse_rpc_error(&error);
-        assert!(matches!(result, RpcError::AccountNotFound(_)));
+        assert!(matches!(
+            result,
+            RpcError::AccountNotFound {
+                block_height: Some(243_803_761),
+                block_hash: Some(CryptoHash::ZERO),
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -1857,13 +1967,22 @@ mod tests {
             cause: Some(ErrorCause {
                 name: "NO_CONTRACT_CODE".to_string(),
                 info: Some(serde_json::json!({
-                    "contract_account_id": "no-contract.near"
+                    "contract_account_id": "no-contract.near",
+                    "block_height": 243803762,
+                    "block_hash": "11111111111111111111111111111111"
                 })),
             }),
             name: None,
         };
         let result = client.parse_rpc_error(&error);
-        assert!(matches!(result, RpcError::ContractNotDeployed(_)));
+        assert!(matches!(
+            result,
+            RpcError::ContractNotDeployed {
+                block_height: Some(243_803_762),
+                block_hash: Some(CryptoHash::ZERO),
+                ..
+            }
+        ));
     }
 
     fn no_global_contract_code_error(identifier: serde_json::Value) -> JsonRpcError {
@@ -2165,7 +2284,7 @@ mod tests {
                 info: Some(serde_json::json!({
                     "vm_error": { "MethodResolveError": "MethodNotFound" },
                     "block_height": 243803767,
-                    "block_hash": "Et7So7jtsorkYLdVMMgV8gxA3Cfaztp75Ti6TPv2A"
+                    "block_hash": "H33oNAtVZDJjhpncQb5LY6NxYzQLMMVLptq99mwmLmnj"
                 })),
             }),
             name: Some("HANDLER_ERROR".to_string()),
@@ -2175,10 +2294,21 @@ mod tests {
             RpcError::MethodNotFound {
                 contract_id,
                 method_name,
+                block_height,
+                block_hash,
             } => {
                 // The high-level view_function caller enriches both fields.
                 assert_eq!(contract_id.as_str(), "unknown");
                 assert_eq!(method_name, "unknown");
+                assert_eq!(block_height, Some(243_803_767));
+                assert_eq!(
+                    block_hash,
+                    Some(
+                        "H33oNAtVZDJjhpncQb5LY6NxYzQLMMVLptq99mwmLmnj"
+                            .parse()
+                            .unwrap()
+                    )
+                );
             }
             _ => panic!("Expected MethodNotFound error, got {:?}", result),
         }
@@ -2221,13 +2351,19 @@ mod tests {
                     "vm_error": {
                         "ExecutionError": "Smart contract panicked: invalid signature"
                     },
+                    "block_height": 243803768,
+                    "block_hash": "11111111111111111111111111111111"
                 })),
             }),
             name: Some("HANDLER_ERROR".to_string()),
         };
 
         match client.parse_rpc_error(&error) {
-            RpcError::ContractPanic { message } => assert_eq!(message, "invalid signature"),
+            RpcError::ContractPanic {
+                message,
+                block_height: Some(243_803_768),
+                block_hash: Some(CryptoHash::ZERO),
+            } => assert_eq!(message, "invalid signature"),
             other => panic!("Expected ContractPanic error, got {other:?}"),
         }
     }
@@ -2245,13 +2381,20 @@ mod tests {
                     "vm_error": {
                         "ExecutionError": "memory access violation"
                     },
+                    "block_height": 243803769,
+                    "block_hash": "11111111111111111111111111111111"
                 })),
             }),
             name: Some("HANDLER_ERROR".to_string()),
         };
 
         match client.parse_rpc_error(&error) {
-            RpcError::ContractExecution { message, .. } => {
+            RpcError::ContractExecution {
+                message,
+                block_height: Some(243_803_769),
+                block_hash: Some(CryptoHash::ZERO),
+                ..
+            } => {
                 assert!(message.contains("memory access violation"));
             }
             other => panic!("Expected ContractExecution error, got {other:?}"),
@@ -2281,7 +2424,7 @@ mod tests {
         };
 
         match client.parse_rpc_error(&error) {
-            RpcError::ContractPanic { message } => assert_eq!(message, "legacy panic"),
+            RpcError::ContractPanic { message, .. } => assert_eq!(message, "legacy panic"),
             other => panic!("Expected ContractPanic error, got {other:?}"),
         }
     }
@@ -2314,8 +2457,21 @@ mod tests {
         };
         let result = client.parse_rpc_error(&error);
         match result {
-            RpcError::ContractNotDeployed(account_id) => {
+            RpcError::ContractNotDeployed {
+                account_id,
+                block_height,
+                block_hash,
+            } => {
                 assert_eq!(account_id.as_str(), "nonexistent.testnet");
+                assert_eq!(block_height, Some(243_803_764));
+                assert_eq!(
+                    block_hash,
+                    Some(
+                        "H33oNAtVZDJjhpncQb5LY6NxYzQLMMVLptq99mwmLmnj"
+                            .parse()
+                            .unwrap()
+                    )
+                );
             }
             _ => panic!("Expected ContractNotDeployed error, got {:?}", result),
         }
@@ -2334,7 +2490,7 @@ mod tests {
             name: None,
         };
         let result = client.parse_rpc_error(&error);
-        assert!(matches!(result, RpcError::AccountNotFound(_)));
+        assert!(matches!(result, RpcError::AccountNotFound { .. }));
     }
 
     #[test]

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -236,7 +236,7 @@ pub enum RpcError {
     /// as [`ContractNotDeployed`](Self::ContractNotDeployed),
     /// [`MethodNotFound`](Self::MethodNotFound), and
     /// [`ContractPanic`](Self::ContractPanic), respectively.
-    #[error("Contract execution failed on {contract_id}: {message}")]
+    #[error("contract execution failed on {contract_id}: {message}")]
     ContractExecution {
         contract_id: AccountId,
         method_name: Option<String>,
@@ -244,7 +244,7 @@ pub enum RpcError {
     },
 
     /// The requested method is not exported by the deployed contract.
-    #[error("Contract method not found: {contract_id}.{method_name}")]
+    #[error("contract method not found: `{contract_id}::{method_name}`")]
     MethodNotFound {
         contract_id: AccountId,
         method_name: String,
@@ -254,22 +254,8 @@ pub enum RpcError {
     ///
     /// Transaction function-call panics are reported in the transaction
     /// outcome instead; see [`crate::types::FunctionCallError`].
-    #[error("Contract panic: {message}")]
+    #[error("contract panic: {message}")]
     ContractPanic { message: String },
-
-    /// A manually constructed function-call error with optional panic and log
-    /// details.
-    ///
-    /// Built-in view calls use the more specific contract error variants
-    /// above. This variant is retained for callers of
-    /// [`RpcError::function_call`].
-    #[error("Function call error on {contract_id}.{method_name}: {}", panic.as_deref().unwrap_or("unknown error"))]
-    FunctionCall {
-        contract_id: AccountId,
-        method_name: String,
-        panic: Option<String>,
-        logs: Vec<String>,
-    },
 
     // ─── Block/Chunk Errors ───
     #[error(
@@ -413,21 +399,6 @@ impl RpcError {
         }
 
         None
-    }
-
-    /// Create a function call error.
-    pub fn function_call(
-        contract_id: AccountId,
-        method_name: impl Into<String>,
-        panic: Option<String>,
-        logs: Vec<String>,
-    ) -> Self {
-        RpcError::FunctionCall {
-            contract_id,
-            method_name: method_name.into(),
-            panic,
-            logs,
-        }
     }
 }
 
@@ -907,31 +878,6 @@ mod tests {
     }
 
     #[test]
-    fn test_rpc_error_function_call_constructor() {
-        let account_id: AccountId = "contract.near".parse().unwrap();
-        let err = RpcError::function_call(
-            account_id.clone(),
-            "my_method",
-            Some("assertion failed".to_string()),
-            vec!["log1".to_string(), "log2".to_string()],
-        );
-        match err {
-            RpcError::FunctionCall {
-                contract_id,
-                method_name,
-                panic,
-                logs,
-            } => {
-                assert_eq!(contract_id, account_id);
-                assert_eq!(method_name, "my_method");
-                assert_eq!(panic, Some("assertion failed".to_string()));
-                assert_eq!(logs, vec!["log1", "log2"]);
-            }
-            _ => panic!("Expected FunctionCall error"),
-        }
-    }
-
-    #[test]
     fn test_rpc_error_is_account_not_found() {
         let account_id: AccountId = "alice.near".parse().unwrap();
         assert!(RpcError::AccountNotFound(account_id).is_account_not_found());
@@ -971,7 +917,7 @@ mod tests {
         };
         assert_eq!(
             err.to_string(),
-            "Contract method not found: contract.near.missing"
+            "contract method not found: `contract.near::missing`"
         );
     }
 
@@ -985,34 +931,16 @@ mod tests {
         };
         assert_eq!(
             err.to_string(),
-            "Contract execution failed on contract.near: execution failed"
+            "contract execution failed on contract.near: execution failed"
         );
     }
 
     #[test]
-    fn test_rpc_error_function_call_display() {
-        let account_id: AccountId = "contract.near".parse().unwrap();
-        let err = RpcError::FunctionCall {
-            contract_id: account_id.clone(),
-            method_name: "my_method".to_string(),
-            panic: Some("assertion failed".to_string()),
-            logs: vec![],
+    fn test_rpc_error_contract_panic_display() {
+        let panic = RpcError::ContractPanic {
+            message: "assertion failed".to_string(),
         };
-        assert_eq!(
-            err.to_string(),
-            "Function call error on contract.near.my_method: assertion failed"
-        );
-
-        let err_no_panic = RpcError::FunctionCall {
-            contract_id: account_id,
-            method_name: "other_method".to_string(),
-            panic: None,
-            logs: vec![],
-        };
-        assert_eq!(
-            err_no_panic.to_string(),
-            "Function call error on contract.near.other_method: unknown error"
-        );
+        assert_eq!(panic.to_string(), "contract panic: assertion failed");
     }
 
     #[test]

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -1040,6 +1040,44 @@ mod tests {
     }
 
     #[test]
+    fn test_view_call_error_display_preserves_message_casing() {
+        let contract_id: AccountId = "contract.near".parse().unwrap();
+
+        // Messages that come from the node are embedded exactly as they
+        // arrived — nothing re-cases the first letter.
+        assert_eq!(
+            RpcError::ContractPanic {
+                message: "ERR_NOT_ENOUGH_DEPOSIT".to_string(),
+                block_height: None,
+                block_hash: None,
+            }
+            .to_string(),
+            "contract panic: ERR_NOT_ENOUGH_DEPOSIT"
+        );
+        assert_eq!(
+            RpcError::ContractExecution {
+                contract_id: contract_id.clone(),
+                method_name: Some("ft_balance_of".to_string()),
+                message: "Memory access violation".to_string(),
+                block_height: None,
+                block_hash: None,
+            }
+            .to_string(),
+            "contract execution failed on contract.near: Memory access violation"
+        );
+        assert_eq!(
+            RpcError::MethodNotFound {
+                contract_id,
+                method_name: "Nep413GetMessage".to_string(),
+                block_height: None,
+                block_hash: None,
+            }
+            .to_string(),
+            "contract method not found: `contract.near::Nep413GetMessage`"
+        );
+    }
+
+    #[test]
     fn test_rpc_error_invalid_tx_display() {
         use crate::types::InvalidTxError;
         let err = RpcError::InvalidTx(InvalidTxError::InvalidNonce {

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -55,7 +55,8 @@
 use thiserror::Error;
 
 use crate::types::{
-    AccountId, DelegateDecodeError, GlobalContractIdentifierView, InvalidTxError, PublicKey,
+    AccountId, CryptoHash, DelegateDecodeError, GlobalContractIdentifierView, InvalidTxError,
+    PublicKey,
 };
 
 /// Error parsing an account ID.
@@ -207,8 +208,12 @@ pub enum RpcError {
     },
 
     // ─── Account Errors ───
-    #[error("Account not found: {0}")]
-    AccountNotFound(AccountId),
+    #[error("Account not found: {account_id}")]
+    AccountNotFound {
+        account_id: AccountId,
+        block_height: Option<u64>,
+        block_hash: Option<CryptoHash>,
+    },
 
     #[error("Invalid account ID: {0}")]
     InvalidAccount(String),
@@ -220,8 +225,12 @@ pub enum RpcError {
     },
 
     // ─── Contract Errors ───
-    #[error("Contract not deployed on account: {0}")]
-    ContractNotDeployed(AccountId),
+    #[error("Contract not deployed on account: {account_id}")]
+    ContractNotDeployed {
+        account_id: AccountId,
+        block_height: Option<u64>,
+        block_hash: Option<CryptoHash>,
+    },
 
     #[error("Contract state too large for account: {0}")]
     ContractStateTooLarge(AccountId),
@@ -241,6 +250,8 @@ pub enum RpcError {
         contract_id: AccountId,
         method_name: Option<String>,
         message: String,
+        block_height: Option<u64>,
+        block_hash: Option<CryptoHash>,
     },
 
     /// The requested method is not exported by the deployed contract.
@@ -248,6 +259,8 @@ pub enum RpcError {
     MethodNotFound {
         contract_id: AccountId,
         method_name: String,
+        block_height: Option<u64>,
+        block_hash: Option<CryptoHash>,
     },
 
     /// A view method explicitly panicked during contract execution.
@@ -255,7 +268,11 @@ pub enum RpcError {
     /// Transaction function-call panics are reported in the transaction
     /// outcome instead; see [`crate::types::FunctionCallError`].
     #[error("contract panic: {message}")]
-    ContractPanic { message: String },
+    ContractPanic {
+        message: String,
+        block_height: Option<u64>,
+        block_hash: Option<CryptoHash>,
+    },
 
     // ─── Block/Chunk Errors ───
     #[error(
@@ -410,12 +427,12 @@ impl RpcError {
 impl RpcError {
     /// Returns true if this error indicates the account was not found.
     pub fn is_account_not_found(&self) -> bool {
-        matches!(self, RpcError::AccountNotFound(_))
+        matches!(self, RpcError::AccountNotFound { .. })
     }
 
     /// Returns true if this error indicates a contract is not deployed.
     pub fn is_contract_not_deployed(&self) -> bool {
-        matches!(self, RpcError::ContractNotDeployed(_))
+        matches!(self, RpcError::ContractNotDeployed { .. })
     }
 
     /// Returns true if this error indicates the requested contract method was
@@ -432,6 +449,30 @@ impl RpcError {
     /// Returns true if this error indicates a global contract was not found.
     pub fn is_global_contract_not_found(&self) -> bool {
         matches!(self, RpcError::GlobalContractNotFound(_))
+    }
+
+    /// Returns the block height attached to a view RPC error, if available.
+    pub fn block_height(&self) -> Option<u64> {
+        match self {
+            RpcError::AccountNotFound { block_height, .. }
+            | RpcError::ContractNotDeployed { block_height, .. }
+            | RpcError::ContractExecution { block_height, .. }
+            | RpcError::MethodNotFound { block_height, .. }
+            | RpcError::ContractPanic { block_height, .. } => *block_height,
+            _ => None,
+        }
+    }
+
+    /// Returns the block hash attached to a view RPC error, if available.
+    pub fn block_hash(&self) -> Option<CryptoHash> {
+        match self {
+            RpcError::AccountNotFound { block_hash, .. }
+            | RpcError::ContractNotDeployed { block_hash, .. }
+            | RpcError::ContractExecution { block_hash, .. }
+            | RpcError::MethodNotFound { block_hash, .. }
+            | RpcError::ContractPanic { block_hash, .. } => *block_hash,
+            _ => None,
+        }
     }
 }
 
@@ -698,7 +739,12 @@ mod tests {
             "Invalid response: missing result"
         );
         assert_eq!(
-            RpcError::AccountNotFound(account_id.clone()).to_string(),
+            RpcError::AccountNotFound {
+                account_id: account_id.clone(),
+                block_height: None,
+                block_hash: None,
+            }
+            .to_string(),
             "Account not found: alice.near"
         );
         assert_eq!(
@@ -706,7 +752,12 @@ mod tests {
             "Invalid account ID: bad-account"
         );
         assert_eq!(
-            RpcError::ContractNotDeployed(account_id.clone()).to_string(),
+            RpcError::ContractNotDeployed {
+                account_id: account_id.clone(),
+                block_height: None,
+                block_hash: None,
+            }
+            .to_string(),
             "Contract not deployed on account: alice.near"
         );
         assert_eq!(
@@ -800,8 +851,22 @@ mod tests {
 
         // Non-retryable errors
         let account_id: AccountId = "alice.near".parse().unwrap();
-        assert!(!RpcError::AccountNotFound(account_id.clone()).is_retryable());
-        assert!(!RpcError::ContractNotDeployed(account_id.clone()).is_retryable());
+        assert!(
+            !RpcError::AccountNotFound {
+                account_id: account_id.clone(),
+                block_height: None,
+                block_hash: None,
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RpcError::ContractNotDeployed {
+                account_id: account_id.clone(),
+                block_height: None,
+                block_hash: None,
+            }
+            .is_retryable()
+        );
         assert!(!RpcError::InvalidAccount("bad".to_string()).is_retryable());
         assert!(!RpcError::UnknownBlock("12345".to_string()).is_retryable());
         assert!(!RpcError::ParseError("bad json".to_string()).is_retryable());
@@ -880,32 +945,57 @@ mod tests {
     #[test]
     fn test_rpc_error_is_account_not_found() {
         let account_id: AccountId = "alice.near".parse().unwrap();
-        assert!(RpcError::AccountNotFound(account_id).is_account_not_found());
+        assert!(
+            RpcError::AccountNotFound {
+                account_id,
+                block_height: None,
+                block_hash: None,
+            }
+            .is_account_not_found()
+        );
         assert!(!RpcError::Timeout(3).is_account_not_found());
     }
 
     #[test]
     fn test_rpc_error_is_contract_not_deployed() {
         let account_id: AccountId = "alice.near".parse().unwrap();
-        assert!(RpcError::ContractNotDeployed(account_id).is_contract_not_deployed());
+        assert!(
+            RpcError::ContractNotDeployed {
+                account_id,
+                block_height: None,
+                block_hash: None,
+            }
+            .is_contract_not_deployed()
+        );
         assert!(!RpcError::Timeout(3).is_contract_not_deployed());
     }
 
     #[test]
     fn test_rpc_error_view_call_classification_helpers() {
         let account_id: AccountId = "contract.near".parse().unwrap();
+        let block_hash = CryptoHash::hash(b"block");
         let method_not_found = RpcError::MethodNotFound {
             contract_id: account_id,
             method_name: "missing".to_string(),
+            block_height: Some(42),
+            block_hash: Some(block_hash),
         };
         assert!(method_not_found.is_method_not_found());
         assert!(!method_not_found.is_contract_panic());
+        assert_eq!(method_not_found.block_height(), Some(42));
+        assert_eq!(method_not_found.block_hash(), Some(block_hash));
 
         let panic = RpcError::ContractPanic {
             message: "boom".to_string(),
+            block_height: None,
+            block_hash: None,
         };
         assert!(panic.is_contract_panic());
         assert!(!panic.is_method_not_found());
+        assert_eq!(panic.block_height(), None);
+        assert_eq!(panic.block_hash(), None);
+        assert_eq!(RpcError::Timeout(3).block_height(), None);
+        assert_eq!(RpcError::Timeout(3).block_hash(), None);
     }
 
     #[test]
@@ -914,6 +1004,8 @@ mod tests {
         let err = RpcError::MethodNotFound {
             contract_id: account_id,
             method_name: "missing".to_string(),
+            block_height: None,
+            block_hash: None,
         };
         assert_eq!(
             err.to_string(),
@@ -928,6 +1020,8 @@ mod tests {
             contract_id: account_id,
             method_name: Some("my_method".to_string()),
             message: "execution failed".to_string(),
+            block_height: None,
+            block_hash: None,
         };
         assert_eq!(
             err.to_string(),
@@ -939,6 +1033,8 @@ mod tests {
     fn test_rpc_error_contract_panic_display() {
         let panic = RpcError::ContractPanic {
             message: "assertion failed".to_string(),
+            block_height: None,
+            block_hash: None,
         };
         assert_eq!(panic.to_string(), "contract panic: assertion failed");
     }

--- a/crates/near-kit/src/error.rs
+++ b/crates/near-kit/src/error.rs
@@ -229,6 +229,13 @@ pub enum RpcError {
     #[error("Global contract not found: {0}")]
     GlobalContractNotFound(GlobalContractIdentifierView),
 
+    /// A view function failed for a reason that does not have a more specific
+    /// [`RpcError`] variant.
+    ///
+    /// Missing contract code, missing methods, and contract panics are exposed
+    /// as [`ContractNotDeployed`](Self::ContractNotDeployed),
+    /// [`MethodNotFound`](Self::MethodNotFound), and
+    /// [`ContractPanic`](Self::ContractPanic), respectively.
     #[error("Contract execution failed on {contract_id}: {message}")]
     ContractExecution {
         contract_id: AccountId,
@@ -236,9 +243,26 @@ pub enum RpcError {
         message: String,
     },
 
+    /// The requested method is not exported by the deployed contract.
+    #[error("Contract method not found: {contract_id}.{method_name}")]
+    MethodNotFound {
+        contract_id: AccountId,
+        method_name: String,
+    },
+
+    /// A view method explicitly panicked during contract execution.
+    ///
+    /// Transaction function-call panics are reported in the transaction
+    /// outcome instead; see [`crate::types::FunctionCallError`].
     #[error("Contract panic: {message}")]
     ContractPanic { message: String },
 
+    /// A manually constructed function-call error with optional panic and log
+    /// details.
+    ///
+    /// Built-in view calls use the more specific contract error variants
+    /// above. This variant is retained for callers of
+    /// [`RpcError::function_call`].
     #[error("Function call error on {contract_id}.{method_name}: {}", panic.as_deref().unwrap_or("unknown error"))]
     FunctionCall {
         contract_id: AccountId,
@@ -421,6 +445,17 @@ impl RpcError {
     /// Returns true if this error indicates a contract is not deployed.
     pub fn is_contract_not_deployed(&self) -> bool {
         matches!(self, RpcError::ContractNotDeployed(_))
+    }
+
+    /// Returns true if this error indicates the requested contract method was
+    /// not found.
+    pub fn is_method_not_found(&self) -> bool {
+        matches!(self, RpcError::MethodNotFound { .. })
+    }
+
+    /// Returns true if this error indicates a view method panicked.
+    pub fn is_contract_panic(&self) -> bool {
+        matches!(self, RpcError::ContractPanic { .. })
     }
 
     /// Returns true if this error indicates a global contract was not found.
@@ -908,6 +943,36 @@ mod tests {
         let account_id: AccountId = "alice.near".parse().unwrap();
         assert!(RpcError::ContractNotDeployed(account_id).is_contract_not_deployed());
         assert!(!RpcError::Timeout(3).is_contract_not_deployed());
+    }
+
+    #[test]
+    fn test_rpc_error_view_call_classification_helpers() {
+        let account_id: AccountId = "contract.near".parse().unwrap();
+        let method_not_found = RpcError::MethodNotFound {
+            contract_id: account_id,
+            method_name: "missing".to_string(),
+        };
+        assert!(method_not_found.is_method_not_found());
+        assert!(!method_not_found.is_contract_panic());
+
+        let panic = RpcError::ContractPanic {
+            message: "boom".to_string(),
+        };
+        assert!(panic.is_contract_panic());
+        assert!(!panic.is_method_not_found());
+    }
+
+    #[test]
+    fn test_rpc_error_method_not_found_display() {
+        let account_id: AccountId = "contract.near".parse().unwrap();
+        let err = RpcError::MethodNotFound {
+            contract_id: account_id,
+            method_name: "missing".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "Contract method not found: contract.near.missing"
+        );
     }
 
     #[test]

--- a/crates/near-kit/tests/integration/error_handling_integration.rs
+++ b/crates/near-kit/tests/integration/error_handling_integration.rs
@@ -41,7 +41,7 @@ async fn test_error_balance_nonexistent_account() {
     match err {
         Error::Rpc(ref rpc_err) => {
             assert!(
-                matches!(rpc_err.as_ref(), RpcError::AccountNotFound(_)),
+                matches!(rpc_err.as_ref(), RpcError::AccountNotFound { .. }),
                 "Expected AccountNotFound, got: {:?}",
                 rpc_err
             );
@@ -63,7 +63,7 @@ async fn test_error_account_info_nonexistent() {
 
     match err {
         Error::Rpc(ref e) => match e.as_ref() {
-            RpcError::AccountNotFound(account_id) => {
+            RpcError::AccountNotFound { account_id, .. } => {
                 assert_eq!(account_id.as_str(), "nonexistent-account-xyz.sandbox");
             }
             other => panic!("Expected AccountNotFound, got: {:?}", other),
@@ -202,6 +202,7 @@ async fn test_error_view_nonexistent_method() {
             RpcError::MethodNotFound {
                 contract_id: actual_contract_id,
                 method_name,
+                ..
             } => {
                 assert_eq!(actual_contract_id, &contract_id);
                 assert_eq!(method_name, "this_method_does_not_exist");

--- a/crates/near-kit/tests/integration/error_handling_integration.rs
+++ b/crates/near-kit/tests/integration/error_handling_integration.rs
@@ -197,17 +197,17 @@ async fn test_error_view_nonexistent_method() {
     );
     let err = result.unwrap_err();
 
-    // The query endpoint returns view-call errors in different formats depending
-    // on the RPC version (structured ContractExecution vs inline result.error).
-    // Just verify we get an Rpc error with MethodNotFound somewhere in it.
     match err {
-        Error::Rpc(ref e) => {
-            let msg = format!("{e:?}");
-            assert!(
-                msg.contains("MethodNotFound") || msg.contains("MethodResolveError"),
-                "Expected method not found error, got: {msg}"
-            );
-        }
+        Error::Rpc(e) => match e.as_ref() {
+            RpcError::MethodNotFound {
+                contract_id: actual_contract_id,
+                method_name,
+            } => {
+                assert_eq!(actual_contract_id, &contract_id);
+                assert_eq!(method_name, "this_method_does_not_exist");
+            }
+            other => panic!("Expected MethodNotFound, got: {other:?}"),
+        },
         other => panic!("Expected Rpc error, got: {:?}", other),
     }
 }

--- a/crates/near-kit/tests/integration/token_error_integration.rs
+++ b/crates/near-kit/tests/integration/token_error_integration.rs
@@ -51,7 +51,7 @@ async fn test_ft_metadata_on_non_contract_account() {
     // Should be ContractNotDeployed or similar error
     println!("FT metadata on non-contract: {:?}", err);
     match err {
-        Error::Rpc(ref e) if matches!(e.as_ref(), RpcError::ContractNotDeployed(_)) => {
+        Error::Rpc(ref e) if matches!(e.as_ref(), RpcError::ContractNotDeployed { .. }) => {
             // Expected
         }
         Error::Rpc(_) => {
@@ -195,6 +195,7 @@ async fn test_ft_on_wrong_contract_type() {
             RpcError::MethodNotFound {
                 contract_id: actual_contract_id,
                 method_name,
+                ..
             } => {
                 assert_eq!(actual_contract_id, &contract_id);
                 assert_eq!(method_name, "ft_metadata");

--- a/crates/near-kit/tests/integration/token_error_integration.rs
+++ b/crates/near-kit/tests/integration/token_error_integration.rs
@@ -190,12 +190,18 @@ async fn test_ft_on_wrong_contract_type() {
     let err = result.unwrap_err();
     println!("FT metadata on guestbook: {:?}", err);
 
-    // Could be ContractExecution or other RPC error
     match err {
-        Error::Rpc(ref e) if matches!(e.as_ref(), RpcError::ContractExecution { .. }) => { /* Expected */
-        }
-        Error::Rpc(_) => { /* Other RPC errors are acceptable too */ }
-        _ => panic!("Expected RPC error, got: {:?}", err),
+        Error::Rpc(e) => match e.as_ref() {
+            RpcError::MethodNotFound {
+                contract_id: actual_contract_id,
+                method_name,
+            } => {
+                assert_eq!(actual_contract_id, &contract_id);
+                assert_eq!(method_name, "ft_metadata");
+            }
+            other => panic!("Expected MethodNotFound, got: {other:?}"),
+        },
+        other => panic!("Expected RPC error, got: {other:?}"),
     }
 }
 

--- a/crates/near-kit/tests/integration/typed_contract_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_error_integration.rs
@@ -71,9 +71,9 @@ async fn test_typed_contract_view_on_nonexistent_account() {
 
     // Should be AccountNotFound or ContractNotDeployed
     match err {
-        Error::Rpc(ref e) if matches!(e.as_ref(), RpcError::AccountNotFound(_)) => { /* Expected */
+        Error::Rpc(ref e) if matches!(e.as_ref(), RpcError::AccountNotFound { .. }) => { /* Expected */
         }
-        Error::Rpc(ref e) if matches!(e.as_ref(), RpcError::ContractNotDeployed(_)) => { /* Also acceptable */
+        Error::Rpc(ref e) if matches!(e.as_ref(), RpcError::ContractNotDeployed { .. }) => { /* Also acceptable */
         }
         _ => panic!(
             "Expected AccountNotFound or ContractNotDeployed, got: {:?}",
@@ -109,7 +109,7 @@ async fn test_typed_contract_view_on_account_without_contract() {
     println!("View on account without contract: {:?}", err);
 
     match err {
-        Error::Rpc(ref e) if matches!(e.as_ref(), RpcError::ContractNotDeployed(_)) => { /* Expected */
+        Error::Rpc(ref e) if matches!(e.as_ref(), RpcError::ContractNotDeployed { .. }) => { /* Expected */
         }
         Error::Rpc(_) => { /* Other RPC errors acceptable */ }
         _ => panic!("Expected RPC error, got: {:?}", err),
@@ -190,6 +190,7 @@ async fn test_typed_contract_view_on_wrong_contract_type() {
             RpcError::MethodNotFound {
                 contract_id: actual_contract_id,
                 method_name,
+                ..
             } => {
                 assert_eq!(actual_contract_id, &contract_id);
                 assert_eq!(method_name, "total_messages");

--- a/crates/near-kit/tests/integration/typed_contract_error_integration.rs
+++ b/crates/near-kit/tests/integration/typed_contract_error_integration.rs
@@ -185,12 +185,18 @@ async fn test_typed_contract_view_on_wrong_contract_type() {
     let err = result.unwrap_err();
     println!("Guestbook call on FT contract: {:?}", err);
 
-    // Should be a contract execution error (method not found)
     match err {
-        Error::Rpc(ref e) if matches!(e.as_ref(), RpcError::ContractExecution { .. }) => { /* Expected */
-        }
-        Error::Rpc(_) => { /* Other RPC errors acceptable */ }
-        _ => panic!("Expected RPC error, got: {:?}", err),
+        Error::Rpc(e) => match e.as_ref() {
+            RpcError::MethodNotFound {
+                contract_id: actual_contract_id,
+                method_name,
+            } => {
+                assert_eq!(actual_contract_id, &contract_id);
+                assert_eq!(method_name, "total_messages");
+            }
+            other => panic!("Expected MethodNotFound, got: {other:?}"),
+        },
+        other => panic!("Expected RPC error, got: {other:?}"),
     }
 }
 


### PR DESCRIPTION
Closes #270

## Summary

- add `RpcError::MethodNotFound` for missing contract methods
- surface view-method panics as the existing `RpcError::ContractPanic`
- keep non-panic VM failures under `RpcError::ContractExecution`
- preserve `block_height` and `block_hash` on applicable view RPC errors
- expose `RpcError::block_height()` and `RpcError::block_hash()` accessors
- parse both current `info.vm_error` and legacy `info.error` RPC payloads
- use lowercase error messages and format methods as `contract::method`
- remove the unused `RpcError::FunctionCall` variant and `RpcError::function_call` constructor
- tighten the integration assertions for unknown accounts, accounts without code, missing methods, and contract panics

## Why

[NEP-641](https://github.com/near/NEPs/pull/641) falls back to NEP-413 only when `w_resolve_auth` is unavailable. A missing method (or no contract code) therefore needs to be distinguishable from a method that exists but panics; treating both as one generic execution error makes a safe fallback decision impossible.

The RPC also returns the block hash and height for these failures. Preserving that context lets resolvers associate failure and fallback decisions with the exact queried state.

The removed `FunctionCall` API had no client construction path and overlapped with the typed errors above. Transaction function-call failures remain available as `types::FunctionCallError` in transaction outcomes.

## Compatibility

This is a breaking pre-1.0 API change and should ship in `0.15.0`. `AccountNotFound` and `ContractNotDeployed` are now struct variants, while the view-call error variants include optional `block_height` and `block_hash` fields. The fields remain optional so legacy or string-only RPC errors can retain their typed classification without fabricated block context.

Downstream code that manually constructed or matched these variants must migrate to the new fields. Unknown or newly introduced VM error shapes continue to fall back to `RpcError::ContractExecution`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy -p near-kit --all-targets --no-default-features --features sandbox -- -D warnings`
- `cargo check -p near-kit --all-targets --no-default-features`
- `cargo test -p near-kit --no-default-features --doc`
- `cargo +1.88 check --workspace --all-targets`
- browser WASM and WASI feature checks
- `cargo package -p near-kit --allow-dirty`
