### PR TITLE
feat: derive Copy for BlockReference

### DIFF
--- a/crates/near-kit/src/client/rpc.rs
+++ b/crates/near-kit/src/client/rpc.rs
@@ -799,13 +799,7 @@ impl RpcClient {
         let mut after_key: Option<Vec<u8>> = None;
         loop {
             let page = self
-                .view_state(
-                    account_id,
-                    prefix,
-                    after_key.as_deref(),
-                    limit,
-                    fixed_block.clone(),
-                )
+                .view_state(account_id, prefix, after_key.as_deref(), limit, fixed_block)
                 .await?;
             all.extend(page.values);
             match page.last_key {

--- a/crates/near-kit/src/types/block_reference.rs
+++ b/crates/near-kit/src/types/block_reference.rs
@@ -17,7 +17,7 @@ pub enum SyncCheckpoint {
 /// Reference to a specific block for RPC queries.
 ///
 /// Every NEAR RPC query operates on state at a specific block.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BlockReference {
     /// Query at latest block with specified finality.
     Finality(Finality),
@@ -387,10 +387,10 @@ mod tests {
     }
 
     #[test]
-    fn test_block_reference_clone_and_eq() {
+    fn test_block_reference_copy_and_eq() {
         let original = BlockReference::Height(12345);
-        let cloned = original.clone();
-        assert_eq!(original, cloned);
+        let copied = original;
+        assert_eq!(original, copied);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- derive `Copy` for `BlockReference`
- use copy semantics instead of cloning the fixed block during paginated state reads
- update the unit test to exercise the new `Copy` implementation

## Motivation

Every `BlockReference` variant already contains only `Copy` values, so the enum can safely be copied without explicit cloning. This makes it easier to reuse a block reference while preserving the existing behavior.

## Test plan

- `cargo fmt --all -- --check`
- `cargo test -p near-kit test_block_reference`
- `cargo clippy -p near-kit --all-targets --all-features -- -D warnings`
